### PR TITLE
unix LogImpl: ensure pFile is NULL if no filename was given

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -106,6 +106,7 @@ Version 1.3
  - Fixed Issue 462 - Fix Builds on FreeBSD - From Stromnet (Justin)
  - Added Vision Z-Wave USB Stick device thanks to GizMoCuz (Alex)
  - Fixed issue 469 - Added Fibaro Smoke Detector FGSD-002 thanks to tmartine (Alex)
+ - Fix LogImpl crash if no filename was configured (pull req 488) (Stromnet)
 
 Version 1.2 
  - Released on 15/10/14

--- a/cpp/src/platform/unix/LogImpl.cpp
+++ b/cpp/src/platform/unix/LogImpl.cpp
@@ -52,7 +52,8 @@ m_bConsoleOutput( _bConsoleOutput ),		// true to provide a copy of output to con
 m_bAppendLog( _bAppendLog ),				// true to append (and not overwrite) any existing log
 m_saveLevel( _saveLevel ),					// level of messages to log to file
 m_queueLevel( _queueLevel ),				// level of messages to log to queue
-m_dumpTrigger( _dumpTrigger )				// dump queued messages when this level is seen
+m_dumpTrigger( _dumpTrigger ),				// dump queued messages when this level is seen
+pFile( NULL )
 {
 	if (!m_filename.empty()) {
 		if ( !m_bAppendLog )


### PR DESCRIPTION
Otherwise we use an uninited pFile in Write, potentially causing crash