### PR TITLE
ValueShort: use short iso byte

### DIFF
--- a/cpp/src/value_classes/ValueShort.cpp
+++ b/cpp/src/value_classes/ValueShort.cpp
@@ -56,7 +56,7 @@ ValueShort::ValueShort
 	int16 const _value,
 	uint8 const _pollIntensity
 ):
-  	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Byte, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
+  	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Short, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
 	m_valueCheck( 0 ),
 	m_newValue( 0 )


### PR DESCRIPTION
The value class ValueShort uses a ValueID::ValueType_Byte as argument for the _type argument of the Value constructor. This should have been a ValueType_Short.