### PR TITLE
Add support for Dragon Tech In wall dimmer to the database

### DIFF
--- a/config/dragontech/wd-100.xml
+++ b/config/dragontech/wd-100.xml
@@ -12,7 +12,7 @@
 		    indicates the number of levels the lighting will change when the timer runs out
 		  </Help>
 		</Value>
-		<Value type="byte" index="10" genre="config" label="duration" units="10 ms" min="1" max="255" value"3">
+		<Value type="byte" index="10" genre="config" label="duration" units="10 ms" min="1" max="255" value="3">
 		  <Help>
 		    indicates the time duration of each level.  The resolution is 10 miliseconds.  for example, a default value of 3 means the timer runs out every 30 milliseconds.
 		  </Help>

--- a/config/dragontech/wd-100.xml
+++ b/config/dragontech/wd-100.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="byte" index="4" genre="config" label="Orientation" units="" min="0" max="1" value="0">
+		  <Help>
+		     The orientation of the ON/OFF on the rocker switch can be inverted by changing the configuration item from 0 to 1
+		  </Help>
+		</Value>
+		<Value type="byte" index="9" genre="config" label="Levels" units="" min="1" max="99" value="1">
+		  <Help>
+		    indicates the number of levels the lighting will change when the timer runs out
+		  </Help>
+		</Value>
+		<Value type="byte" index="10" genre="config" label="duration" units="10 ms" min="1" max="255" value"3">
+		  <Help>
+		    indicates the time duration of each level.  The resolution is 10 miliseconds.  for example, a default value of 3 means the timer runs out every 30 milliseconds.
+		  </Help>
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -679,4 +679,7 @@
 	</Manufacturer>
 	<Manufacturer id="0021" name="Zykronix">
 	</Manufacturer>
+	<Manufacturer id="0184" name="Dragon Tech">
+		<Product type="4447" id="3034" name="In Wall Dimmer" config="dragontech/wd-100.xml" />
+	</Manufacturer>
 </ManufacturerSpecificData>


### PR DESCRIPTION
This adds support for the Dragon Tech Zwave plus in wall dimmer to the configuration database.  This device supports group 1 associations as well as the ability to change the ramp rate and switch orientation.