### PR TITLE
Update fgfs101.xml association group 3

### DIFF
--- a/config/fibaro/fgfs101.xml
+++ b/config/fibaro/fgfs101.xml
@@ -113,7 +113,7 @@ Value of 0 cancels an alarm frame retransmission.</Help>
     <Associations num_groups="3">
       <Group index="1" max_associations="5" label="Flood Alarm" auto="true"/>
       <Group index="2" max_associations="5" label="Tamper Alarm" auto="true" />
-      <Group index="3" max_associations="5" label="Device Status" auto="true"/>
+      <Group index="3" max_associations="1" label="Device Status" auto="true"/>
     </Associations>
   </CommandClass>
 


### PR DESCRIPTION
According to documentation, only one device for groupe 3:
3-rd Association Group reports the device status and allows for assigning single device only (the main controller by default - the device reports its status to the main controller).