### PR TITLE
Non-blocking open() on OS X

### DIFF
--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -184,7 +184,7 @@ bool SerialControllerImpl::Init
 	
 	Log::Write( LogLevel_Info, "Trying to open serial port %s (attempt %d)", device.c_str(), _attempts );
 	
-	m_hSerialController = open( device.c_str(), O_RDWR | O_NOCTTY, 0 );
+	m_hSerialController = open( device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK, 0 );
 
 	if( -1 == m_hSerialController )
 	{


### PR DESCRIPTION
When using the Aeon Labs Z-Stick on OS X, it appears to be necessary to call `open()` with `O_NONBLOCK` specified. Otherwise, the `open()` call never seems to return.

From the testing I've done, this doesn't appear to have any adverse affects, but some feedback here would be great, if perhaps I've overlooked something.