### PR TITLE
Adds new product IDs for Aeon Labs Recessed Door Sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -48,6 +48,7 @@
 		<Product type="0002" id="001c" name="Home Energy Meter G2" config="aeon_labs/hemg2.xml"/>
 		<Product type="0002" id="001d" name="Door/Window Sensor" config="aeon_labs/doorwindow.xml"/>
 		<Product type="0002" id="0036" name="Recessed Door Sensor" config="aeon_labs/recessed_doorsensor.xml"/>
+		<Product type="0002" id="0059" name="Recessed Door Sensor" config="aeon_labs/recessed_doorsensor.xml"/>
 		<Product type="0003" id="0006" name="Smart Energy Switch" config="aeon_labs/ses.xml"/>
 		<Product type="0003" id="0008" name="Smart Energy Illuminator"/>
 		<Product type="0003" id="000a" name="Smart Energy 220V Utility Switch"/>
@@ -63,6 +64,10 @@
 		<Product type="0003" id="004b" name="Smart Energy Switch v2" config="aeon_labs/ses2.xml"/>
 		<Product type="0004" id="0025" name="Z-Wave Repeater"/>
 		<Product type="0004" id="0050" name="DSD31 Siren Gen5" config="aeon_labs/dsd31.xml"/>
+        <!-- US-market products start with type prefix "01" -->
+		<Product type="0102" id="0059" name="Recessed Door Sensor" config="aeon_labs/recessed_doorsensor.xml"/>
+        <!-- AU-market products start with type prefix "02" -->
+		<Product type="0202" id="0059" name="Recessed Door Sensor" config="aeon_labs/recessed_doorsensor.xml"/>
 	</Manufacturer>
         <Manufacturer id="0111" name="Airline Mechanical">
                 <Product type="8200" id="0200" name="ZDS-100"/>
@@ -634,7 +639,7 @@
 		<Product type="2002" id="0202" name="ZP3102 AU PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2002" id="0203" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2002" id="0204" name="ZP3102 JP PIR Motion Sensor" config="vision/zp3102.xml"/>
-		<Product type="2002" id="0205" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>		
+		<Product type="2002" id="0205" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2003" id="0302" name="ZS5101 Shock and Vibration Sensor"/>
 		<Product type="2004" id="0403" name="ZS6101 Smoke Detector"/>
 		<Product type="2005" id="0503" name="ZM1601 Battery Operated Siren" config="vision/zm1601eu.xml"/>


### PR DESCRIPTION
I'm not sure why this is different than the existing entry, but it matches the datasheet linked linked off https://github.com/OpenZWave/open-zwave/wiki/Technical-Documents and the hardware that I have. The device is labeled "Gen 5". There don't appear to be any configuration changes.