### PR TITLE
Update recessed_doorsensor.xml

### DIFF
--- a/config/aeon_labs/recessed_doorsensor.xml
+++ b/config/aeon_labs/recessed_doorsensor.xml
@@ -30,7 +30,7 @@
               Default setting: 86640
             </Help>
         </Value>
-        <Value type="int" genre="config" instance="1" index="121" label="Flag values for which reports to send when the Magnet of Recessed Door Sensor is triggered." min="0" max="1" value="256">
+        <Value type="int" genre="config" instance="1" index="121" label="Flag values for which reports to send when the Magnet of Recessed Door Sensor is triggered." min="0" max="65535" value="256" size="4">
             <Help>Bitsets:
                 4 -> Sensor Binary
                 8 -> Basic Set


### PR DESCRIPTION
fix the max="65535" and size="4" attributs for parameter 121.
a default value of 256 whit a max set to 1... I also add the size as wrote in doc.