### PR TITLE
Patch vision security zd2102 gen5

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -634,10 +634,10 @@
 	<Manufacturer id="0109" name="Vision">
 		<Product type="1001" id="0101" name="ZU1401 Z-Wave USB Stick"/>
 		<Product type="1001" id="0105" name="ZU1401 Z-Wave USB Stick"/>
-		<Product type="2001" id="0101" name="ZD2102 Door/Window Sensor"/>
-		<Product type="2001" id="0102" name="ZD2102 Door/Window Sensor"/>
-		<Product type="2001" id="0104" name="ZD2102 Door/Window Sensor"/>
-		<Product type="2001" id="0105" name="ZD2102 Door/Window Sensor"/>
+		<Product type="2001" id="0101" name="ZD2102 US Door/Window Sensor" config="vision/zd2102.xml"/>
+		<Product type="2001" id="0102" name="ZD2102 AU Door/Window Sensor" config="vision/zd2102.xml"/>
+		<Product type="2001" id="0104" name="ZD2102 JP Door/Window Sensor" config="vision/zd2102.xml"/>
+		<Product type="2001" id="0105" name="ZD2102 EU Door/Window Sensor" config="vision/zd2102.xml"/>
 		<Product type="2002" id="0201" name="ZP3102 US PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2002" id="0202" name="ZP3102 AU PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2002" id="0203" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>

--- a/config/vision/zd2102.xml
+++ b/config/vision/zd2102.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Vision ZD2102 Door/Window Sensor -->
+	<CommandClass id="112">
+		<Value type="list" genre="config"  index="1" label="External Switch" size="1" min="0" max="255" value="0">
+			<Help>External Switch Status</Help>
+			<Item label="On" value="255" />
+			<Item label="Off" value="0" />
+		</Value>
+	</CommandClass>
+
+	<!-- COMMAND_CLASS_BASIC -->
+	<CommandClass id="32" setasreport="true"/>
+
+	<!-- COMMAND_CLASS_ASSOCIATION -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<Group index="1" max_associations="5" label="All triggering reports & low voltage report will be sent to the associated nodes." auto="true"/>
+		</Associations>
+	</CommandClass>
+</Product>


### PR DESCRIPTION
Right now the vision zd2102 gen5 is working good with Issue-352-Security branch.

Attached the config file pull.

The old zd2102 and the new gen5 zd2102-5 devices share the same product id.
Moreover the manual (http://www.lorenzhd.com/thesmartesthouse/downloads/zd-2102-eu-5-door-window-sensor.pdf) and the pepper1 database (http://www.pepper1.net/zwavedb/device/547) are discordant.
The official zd2102 manual reports only one configuration parameter, instead pepper1 reports 2 config parameters (without descriptions).

Anyway I used the manual as official documentation source.

Try the patch and let me know.

King regards