### PR TITLE
Fix : Dotnet GetValueAsDecimal

### DIFF
--- a/dotnet/src/ZWManager.cpp
+++ b/dotnet/src/ZWManager.cpp
@@ -474,7 +474,8 @@ bool ZWManager::SceneGetValueAsDecimal
 	if( Manager::Get()->SceneGetValueAsString( sceneId, valueId->CreateUnmanagedValueID(), &value ) )
 	{
 		String^ decimal = gcnew String(value.c_str());
-		o_value = Decimal::Parse( decimal );
+		CultureInfo^ culture = gcnew CultureInfo("en-GB");
+		o_value = Decimal::Parse( decimal, NumberStyles::Float | NumberStyles::AllowThousands, culture); 
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Hi,

Following the issue https://github.com/OpenZWave/open-zwave/issues/461, could you integrate this patch in order to fix the FormatException with the dotnet wrapper.

Thank,