### PR TITLE
Reverted and readded changed files

### DIFF
--- a/dotnet/examples/OZWForm/src/ControllerCommandDlg.cs
+++ b/dotnet/examples/OZWForm/src/ControllerCommandDlg.cs
@@ -9,24 +9,29 @@ using OpenZWaveDotNet;
 
 namespace OZWForm
 {
-	public partial class ControllerCommandDlg : Form
-	{
-        static private ZWManager m_manager;
-        static private ControllerCommandDlg m_dlg;
-        static private UInt32 m_homeId;
-        static private ManagedControllerStateChangedHandler m_controllerStateChangedHandler = new ManagedControllerStateChangedHandler(ControllerCommandDlg.MyControllerStateChangedHandler);
-		static private ZWControllerCommand m_op;
-        static private Byte m_nodeId;
-		static private DialogResult result;
+    public partial class ControllerCommandDlg : Form
+    {
+        private static ZWManager m_manager;
+        private static ControllerCommandDlg m_dlg;
+        private static UInt32 m_homeId;
 
-		private MainForm m_mainDlg;
-		public MainForm MainDlg
-		{
-			get { return m_mainDlg; }
-		}
+        private static ManagedControllerStateChangedHandler m_controllerStateChangedHandler =
+            new ManagedControllerStateChangedHandler(ControllerCommandDlg.MyControllerStateChangedHandler);
 
-        public ControllerCommandDlg(MainForm _mainDlg, ZWManager _manager, UInt32 homeId, ZWControllerCommand _op, Byte nodeId)
-		{
+        private static ZWControllerCommand m_op;
+        private static Byte m_nodeId;
+        private static DialogResult result;
+
+        private MainForm m_mainDlg;
+
+        public MainForm MainDlg
+        {
+            get { return m_mainDlg; }
+        }
+
+        public ControllerCommandDlg(MainForm _mainDlg, ZWManager _manager, UInt32 homeId, ZWControllerCommand _op,
+            Byte nodeId)
+        {
             m_mainDlg = _mainDlg;
             m_manager = _manager;
             m_homeId = homeId;
@@ -36,133 +41,207 @@ namespace OZWForm
 
             InitializeComponent();
 
-			switch (m_op)
-			{
-				case ZWControllerCommand.RequestNodeNeighborUpdate:
-					{
-						this.Text = "Node Neighbor Update";
-						this.label1.Text = "Request that a node update its list of neighbors.";
-						break;
-					}
+            switch (m_op)
+            {
+                case ZWControllerCommand.RequestNodeNeighborUpdate:
+                {
+                    this.Text = "Node Neighbor Update";
+                    this.label1.Text = "Request that a node update its list of neighbors.";
 
+                    m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
+                    if (!m_manager.RequestNodeNeighborUpdate(m_homeId, m_nodeId))
+                    {
+                        m_manager.OnNotification -= NotificationHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.AddDevice:
-				{
-					this.Text = "Add Device";
-					this.label1.Text = "Press the program button on the Z-Wave device to add it to the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being added.";
-					break;
-				}
+                {
+                    this.Text = "Add Device";
+                    this.label1.Text =
+                        "Press the program button on the Z-Wave device to add it to the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being added.";
+
+                    m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
+                    if (!m_manager.AddNode(m_homeId, m_mainDlg.SecurityEnabled))
+                    {
+                        m_manager.OnNotification -= NotificationHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.CreateNewPrimary:
-				{
-					this.Text = "Create New Primary Controller";
-					this.label1.Text = "Put the target controller into receive configuration mode.\nThe PC Z-Wave Controller must be within 2m of the controller that is being made the primary.";
-					break;
-				}
+                {
+                    this.Text = "Create New Primary Controller";
+                    this.label1.Text =
+                        "Put the target controller into receive configuration mode.\nThe PC Z-Wave Controller must be within 2m of the controller that is being made the primary.";
+
+                    m_manager.OnControllerStateChanged += m_controllerStateChangedHandler;
+                    if (!m_manager.BeginControllerCommand(m_homeId, m_op, false, m_nodeId))
+                    {
+                        m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.ReceiveConfiguration:
-				{
-					this.Text = "Receive Configuration";
-					this.label1.Text = "Transfering the network configuration\nfrom another controller.\n\nPlease bring the other controller within 2m of the PC controller and set it to send its network configuration.";
-					break;
-				}
+                {
+                    this.Text = "Receive Configuration";
+                    this.label1.Text =
+                        "Transfering the network configuration\nfrom another controller.\n\nPlease bring the other controller within 2m of the PC controller and set it to send its network configuration.";
+
+                    m_manager.OnControllerStateChanged += m_controllerStateChangedHandler;
+                    if (!m_manager.BeginControllerCommand(m_homeId, m_op, false, m_nodeId))
+                    {
+                        m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.RemoveDevice:
-				{
-					this.Text = "Remove Device";
-					this.label1.Text = "Press the program button on the Z-Wave device to remove it from the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being removed.";
-					break;
-				}
+                {
+                    this.Text = "Remove Device";
+                    this.label1.Text =
+                        "Press the program button on the Z-Wave device to remove it from the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being removed.";
+
+                    m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
+                    if (!m_manager.RemoveNode(m_homeId))
+                    {
+                        m_manager.OnNotification -= NotificationHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.TransferPrimaryRole:
-				{
-					this.Text = "Transfer Primary Role";
-					this.label1.Text = "Transfering the primary role\nto another controller.\n\nPlease bring the new controller within 2m of the PC controller and set it to receive the network configuration.";
-					break;
-				}
+                {
+                    this.Text = "Transfer Primary Role";
+                    this.label1.Text =
+                        "Transfering the primary role\nto another controller.\n\nPlease bring the new controller within 2m of the PC controller and set it to receive the network configuration.";
+
+                    m_manager.OnControllerStateChanged += m_controllerStateChangedHandler;
+                    if (!m_manager.BeginControllerCommand(m_homeId, m_op, false, m_nodeId))
+                    {
+                        m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                    }
+                    break;
+                }
                 case ZWControllerCommand.HasNodeFailed:
                 {
                     this.ButtonCancel.Enabled = false;
                     this.Text = "Has Node Failed";
                     this.label1.Text = "Testing whether the node has failed.\nThis command cannot be cancelled.";
+
+                    m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
+                    if (!m_manager.HasNodeFailed(m_homeId, m_nodeId))
+                    {
+                        m_manager.OnNotification -= NotificationHandler;
+                    }
                     break;
                 }
                 case ZWControllerCommand.RemoveFailedNode:
                 {
                     this.ButtonCancel.Enabled = false;
                     this.Text = "Remove Failed Node";
-                    this.label1.Text = "Removing the failed node from the controller's list.\nThis command cannot be cancelled.";
-					break;
+                    this.label1.Text =
+                        "Removing the failed node from the controller's list.\nThis command cannot be cancelled.";
+
+                    m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
+                    if (!m_manager.RemoveFailedNode(m_homeId, m_nodeId))
+                    {
+                        m_manager.OnNotification -= NotificationHandler;
+                    }
+                    break;
                 }
                 case ZWControllerCommand.ReplaceFailedNode:
                 {
                     this.ButtonCancel.Enabled = false;
                     this.Text = "Replacing Failed Node";
                     this.label1.Text = "Testing the failed node.\nThis command cannot be cancelled.";
+
+                    m_manager.OnControllerStateChanged += m_controllerStateChangedHandler;
+                    if (!m_manager.BeginControllerCommand(m_homeId, m_op, false, m_nodeId))
+                    {
+                        m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                    }
                     break;
                 }
             }
+        }
 
-            m_manager.OnControllerStateChanged += m_controllerStateChangedHandler;
-            if (!m_manager.BeginControllerCommand(m_homeId, m_op, false, m_nodeId))
+        /// <summary>
+        /// Handles Notifications.
+        /// </summary>
+        /// <param name="notification">The notification.</param>
+        public static void NotificationHandler(ZWNotification notification)
+        {
+            switch (notification.GetType())
             {
-                m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                case ZWNotification.Type.ControllerCommand:
+                {
+                    MyControllerStateChangedHandler(((ZWControllerState) notification.GetEvent()));
+                    break;
+                }
             }
-		}
+        }
 
-        public static void MyControllerStateChangedHandler( ZWControllerState state )
-	    {
-		    // Handle the controller state notifications here.
+        /// <summary>
+        /// Handles controller state changes.
+        /// </summary>
+        /// <param name="state">The state.</param>
+        public static void MyControllerStateChangedHandler(ZWControllerState state)
+        {
+            // Handle the controller state notifications here.
             bool complete = false;
             String dlgText = "";
             bool buttonEnabled = true;
 
             switch (state)
-		    {
-		        case ZWControllerState.Waiting:
-		        {
-	                // Display a message to tell the user to press the include button on the controller
+            {
+                case ZWControllerState.Waiting:
+                {
+                    // Display a message to tell the user to press the include button on the controller
                     if (m_op == ZWControllerCommand.ReplaceFailedNode)
                     {
-                        dlgText = "Press the program button on the replacement Z-Wave device to add it to the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being added.\nThis command cannot be cancelled.";
+                        dlgText =
+                            "Press the program button on the replacement Z-Wave device to add it to the network.\nFor security reasons, the PC Z-Wave Controller must be close to the device being added.\nThis command cannot be cancelled.";
                     }
                     break;
-		        }
-		        case ZWControllerState.InProgress:
-		        {
-		            // Tell the user that the controller has been found and the adding process is in progress.
+                }
+                case ZWControllerState.InProgress:
+                {
+                    // Tell the user that the controller has been found and the adding process is in progress.
                     dlgText = "Please wait...";
                     buttonEnabled = false;
                     break;
-		        }
-		        case ZWControllerState.Completed:
-		        {
-		            // Tell the user that the controller has been successfully added.
-		            // The command is now complete
+                }
+                case ZWControllerState.Completed:
+                {
+                    // Tell the user that the controller has been successfully added.
+                    // The command is now complete
                     dlgText = "Command Completed OK.";
                     complete = true;
-					result = DialogResult.OK;
-		            break;
-		        }
-		        case ZWControllerState.Failed:
-		        {
-		            // Tell the user that the controller addition process has failed.
-		            // The command is now complete
+                    result = DialogResult.OK;
+                    break;
+                }
+                case ZWControllerState.Failed:
+                {
+                    // Tell the user that the controller addition process has failed.
+                    // The command is now complete
                     dlgText = "Command Failed.";
                     complete = true;
-					result = DialogResult.Abort;
-					break;
-		        }
+                    result = DialogResult.Abort;
+                    break;
+                }
                 case ZWControllerState.NodeOK:
                 {
                     dlgText = "Node has not failed.";
                     complete = true;
-					result = DialogResult.No;
-					break;
+                    result = DialogResult.No;
+                    break;
                 }
                 case ZWControllerState.NodeFailed:
                 {
                     dlgText = "Node has failed.";
                     complete = true;
-					result = DialogResult.Yes;
-					break;
+                    result = DialogResult.Yes;
+                    break;
                 }
-		    }
+            }
 
             if (dlgText != "")
             {
@@ -173,12 +252,13 @@ namespace OZWForm
 
             if (complete)
             {
-                m_dlg.SetButtonText( "OK" );
+                m_dlg.SetButtonText("OK");
 
                 // Remove the event handler
                 m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                m_manager.OnNotification -= NotificationHandler;
             }
-		}
+        }
 
         private void SetDialogText(String text)
         {
@@ -216,20 +296,21 @@ namespace OZWForm
             }
         }
 
-		private void ButtonCancel_Click( object sender, EventArgs e )
-		{
+        private void ButtonCancel_Click(object sender, EventArgs e)
+        {
             if (ButtonCancel.Text != "OK")
             {
                 // Remove the event handler
                 m_manager.OnControllerStateChanged -= m_controllerStateChangedHandler;
+                m_manager.OnNotification -= NotificationHandler;
 
                 // Cancel the operation
                 m_manager.CancelControllerCommand(m_homeId);
             }
 
-			// Close the dialog
-			Close();
-			m_dlg.DialogResult = result;
-		}
- 	}
+            // Close the dialog
+            Close();
+            m_dlg.DialogResult = result;
+        }
+    }
 }

--- a/dotnet/examples/OZWForm/src/MainForm.Designer.cs
+++ b/dotnet/examples/OZWForm/src/MainForm.Designer.cs
@@ -28,69 +28,70 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.components = new System.ComponentModel.Container();
-			this.NodeGridView = new System.Windows.Forms.DataGridView();
-			this.NodeContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.PowerOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PowerOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.requestNodeNeighborUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.assignReturnRouteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.deleteReturnRouteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.hasNodeFailedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.markNodeAsFailedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.replaceFailedNodeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.propertiesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuBar = new System.Windows.Forms.MenuStrip();
-			this.FileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.controllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.createNewPrmaryControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.transferPrimaryRoleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.addControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.addDeviceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.removeControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.removeDeviceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.receiveConfigurationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.requestNetworkUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.resetControllersoftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.softToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.eraseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-			this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
-			((System.ComponentModel.ISupportInitialize)(this.NodeGridView)).BeginInit();
-			this.NodeContextMenuStrip.SuspendLayout();
-			this.MenuBar.SuspendLayout();
-			this.statusStrip1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// NodeGridView
-			// 
-			this.NodeGridView.AllowUserToAddRows = false;
-			this.NodeGridView.AllowUserToDeleteRows = false;
-			this.NodeGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.components = new System.ComponentModel.Container();
+            this.NodeGridView = new System.Windows.Forms.DataGridView();
+            this.NodeContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.PowerOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.PowerOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.requestNodeNeighborUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.assignReturnRouteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteReturnRouteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.hasNodeFailedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.markNodeAsFailedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.replaceFailedNodeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.propertiesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuBar = new System.Windows.Forms.MenuStrip();
+            this.FileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.SaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.controllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.createNewPrmaryControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.transferPrimaryRoleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.addControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.addDeviceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.removeControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.removeDeviceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.receiveConfigurationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.requestNetworkUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.resetControllersoftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.softToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.eraseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.addSecureDeviceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.NodeGridView)).BeginInit();
+            this.NodeContextMenuStrip.SuspendLayout();
+            this.MenuBar.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // NodeGridView
+            // 
+            this.NodeGridView.AllowUserToAddRows = false;
+            this.NodeGridView.AllowUserToDeleteRows = false;
+            this.NodeGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.NodeGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-			this.NodeGridView.ContextMenuStrip = this.NodeContextMenuStrip;
-			this.NodeGridView.Location = new System.Drawing.Point(13, 37);
-			this.NodeGridView.MultiSelect = false;
-			this.NodeGridView.Name = "NodeGridView";
-			this.NodeGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-			this.NodeGridView.Size = new System.Drawing.Size(609, 381);
-			this.NodeGridView.TabIndex = 0;
-			this.NodeGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.NodeGridView_CellMouseDown);
-			this.NodeGridView.CellParsing += new System.Windows.Forms.DataGridViewCellParsingEventHandler(this.NodeGridView_CellParsing);
-			// 
-			// NodeContextMenuStrip
-			// 
-			this.NodeContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NodeGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.NodeGridView.ContextMenuStrip = this.NodeContextMenuStrip;
+            this.NodeGridView.Location = new System.Drawing.Point(13, 37);
+            this.NodeGridView.MultiSelect = false;
+            this.NodeGridView.Name = "NodeGridView";
+            this.NodeGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.NodeGridView.Size = new System.Drawing.Size(609, 381);
+            this.NodeGridView.TabIndex = 0;
+            this.NodeGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.NodeGridView_CellMouseDown);
+            this.NodeGridView.CellParsing += new System.Windows.Forms.DataGridViewCellParsingEventHandler(this.NodeGridView_CellParsing);
+            // 
+            // NodeContextMenuStrip
+            // 
+            this.NodeContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.PowerOnToolStripMenuItem,
             this.PowerOffToolStripMenuItem,
             this.toolStripSeparator4,
@@ -103,120 +104,121 @@
             this.replaceFailedNodeToolStripMenuItem,
             this.toolStripSeparator6,
             this.propertiesToolStripMenuItem});
-			this.NodeContextMenuStrip.Name = "NodeContextMenuStrip";
-			this.NodeContextMenuStrip.Size = new System.Drawing.Size(238, 220);
-			// 
-			// PowerOnToolStripMenuItem
-			// 
-			this.PowerOnToolStripMenuItem.Name = "PowerOnToolStripMenuItem";
-			this.PowerOnToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.PowerOnToolStripMenuItem.Text = "Power On";
-			this.PowerOnToolStripMenuItem.Click += new System.EventHandler(this.PowerOnToolStripMenuItem_Click);
-			// 
-			// PowerOffToolStripMenuItem
-			// 
-			this.PowerOffToolStripMenuItem.Name = "PowerOffToolStripMenuItem";
-			this.PowerOffToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.PowerOffToolStripMenuItem.Text = "Power Off";
-			this.PowerOffToolStripMenuItem.Click += new System.EventHandler(this.PowerOffToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(234, 6);
-			// 
-			// requestNodeNeighborUpdateToolStripMenuItem
-			// 
-			this.requestNodeNeighborUpdateToolStripMenuItem.Name = "requestNodeNeighborUpdateToolStripMenuItem";
-			this.requestNodeNeighborUpdateToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.requestNodeNeighborUpdateToolStripMenuItem.Text = "Request Node Neighbor Update";
-			this.requestNodeNeighborUpdateToolStripMenuItem.Click += new System.EventHandler(this.requestNodeNeighborUpdateToolStripMenuItem_Click);
-			// 
-			// assignReturnRouteToolStripMenuItem
-			// 
-			this.assignReturnRouteToolStripMenuItem.Name = "assignReturnRouteToolStripMenuItem";
-			this.assignReturnRouteToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.assignReturnRouteToolStripMenuItem.Text = "Assign Return Route";
-			this.assignReturnRouteToolStripMenuItem.Click += new System.EventHandler(this.assignReturnRouteToolStripMenuItem_Click);
-			// 
-			// deleteReturnRouteToolStripMenuItem
-			// 
-			this.deleteReturnRouteToolStripMenuItem.Name = "deleteReturnRouteToolStripMenuItem";
-			this.deleteReturnRouteToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.deleteReturnRouteToolStripMenuItem.Text = "Delete All Return Routes";
-			this.deleteReturnRouteToolStripMenuItem.Click += new System.EventHandler(this.deleteReturnRouteToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(234, 6);
-			// 
-			// hasNodeFailedToolStripMenuItem
-			// 
-			this.hasNodeFailedToolStripMenuItem.Name = "hasNodeFailedToolStripMenuItem";
-			this.hasNodeFailedToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.hasNodeFailedToolStripMenuItem.Text = "Has Node Failed";
-			this.hasNodeFailedToolStripMenuItem.Click += new System.EventHandler(this.hasNodeFailedToolStripMenuItem_Click);
-			// 
-			// markNodeAsFailedToolStripMenuItem
-			// 
-			this.markNodeAsFailedToolStripMenuItem.Name = "markNodeAsFailedToolStripMenuItem";
-			this.markNodeAsFailedToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.markNodeAsFailedToolStripMenuItem.Text = "Remove Failed Node";
-			this.markNodeAsFailedToolStripMenuItem.Click += new System.EventHandler(this.markNodeAsFailedToolStripMenuItem_Click);
-			// 
-			// replaceFailedNodeToolStripMenuItem
-			// 
-			this.replaceFailedNodeToolStripMenuItem.Name = "replaceFailedNodeToolStripMenuItem";
-			this.replaceFailedNodeToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.replaceFailedNodeToolStripMenuItem.Text = "Replace Failed Node";
-			this.replaceFailedNodeToolStripMenuItem.Click += new System.EventHandler(this.replaceFailedNodeToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(234, 6);
-			// 
-			// propertiesToolStripMenuItem
-			// 
-			this.propertiesToolStripMenuItem.Name = "propertiesToolStripMenuItem";
-			this.propertiesToolStripMenuItem.Size = new System.Drawing.Size(237, 22);
-			this.propertiesToolStripMenuItem.Text = "Properties";
-			this.propertiesToolStripMenuItem.Click += new System.EventHandler(this.propertiesToolStripMenuItem_Click);
-			// 
-			// MenuBar
-			// 
-			this.MenuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NodeContextMenuStrip.Name = "NodeContextMenuStrip";
+            this.NodeContextMenuStrip.Size = new System.Drawing.Size(243, 220);
+            // 
+            // PowerOnToolStripMenuItem
+            // 
+            this.PowerOnToolStripMenuItem.Name = "PowerOnToolStripMenuItem";
+            this.PowerOnToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.PowerOnToolStripMenuItem.Text = "Power On";
+            this.PowerOnToolStripMenuItem.Click += new System.EventHandler(this.PowerOnToolStripMenuItem_Click);
+            // 
+            // PowerOffToolStripMenuItem
+            // 
+            this.PowerOffToolStripMenuItem.Name = "PowerOffToolStripMenuItem";
+            this.PowerOffToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.PowerOffToolStripMenuItem.Text = "Power Off";
+            this.PowerOffToolStripMenuItem.Click += new System.EventHandler(this.PowerOffToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator4
+            // 
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            this.toolStripSeparator4.Size = new System.Drawing.Size(239, 6);
+            // 
+            // requestNodeNeighborUpdateToolStripMenuItem
+            // 
+            this.requestNodeNeighborUpdateToolStripMenuItem.Name = "requestNodeNeighborUpdateToolStripMenuItem";
+            this.requestNodeNeighborUpdateToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.requestNodeNeighborUpdateToolStripMenuItem.Text = "Request Node Neighbor Update";
+            this.requestNodeNeighborUpdateToolStripMenuItem.Click += new System.EventHandler(this.requestNodeNeighborUpdateToolStripMenuItem_Click);
+            // 
+            // assignReturnRouteToolStripMenuItem
+            // 
+            this.assignReturnRouteToolStripMenuItem.Name = "assignReturnRouteToolStripMenuItem";
+            this.assignReturnRouteToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.assignReturnRouteToolStripMenuItem.Text = "Assign Return Route";
+            this.assignReturnRouteToolStripMenuItem.Click += new System.EventHandler(this.assignReturnRouteToolStripMenuItem_Click);
+            // 
+            // deleteReturnRouteToolStripMenuItem
+            // 
+            this.deleteReturnRouteToolStripMenuItem.Name = "deleteReturnRouteToolStripMenuItem";
+            this.deleteReturnRouteToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.deleteReturnRouteToolStripMenuItem.Text = "Delete All Return Routes";
+            this.deleteReturnRouteToolStripMenuItem.Click += new System.EventHandler(this.deleteReturnRouteToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(239, 6);
+            // 
+            // hasNodeFailedToolStripMenuItem
+            // 
+            this.hasNodeFailedToolStripMenuItem.Name = "hasNodeFailedToolStripMenuItem";
+            this.hasNodeFailedToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.hasNodeFailedToolStripMenuItem.Text = "Has Node Failed";
+            this.hasNodeFailedToolStripMenuItem.Click += new System.EventHandler(this.hasNodeFailedToolStripMenuItem_Click);
+            // 
+            // markNodeAsFailedToolStripMenuItem
+            // 
+            this.markNodeAsFailedToolStripMenuItem.Name = "markNodeAsFailedToolStripMenuItem";
+            this.markNodeAsFailedToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.markNodeAsFailedToolStripMenuItem.Text = "Remove Failed Node";
+            this.markNodeAsFailedToolStripMenuItem.Click += new System.EventHandler(this.markNodeAsFailedToolStripMenuItem_Click);
+            // 
+            // replaceFailedNodeToolStripMenuItem
+            // 
+            this.replaceFailedNodeToolStripMenuItem.Name = "replaceFailedNodeToolStripMenuItem";
+            this.replaceFailedNodeToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.replaceFailedNodeToolStripMenuItem.Text = "Replace Failed Node";
+            this.replaceFailedNodeToolStripMenuItem.Click += new System.EventHandler(this.replaceFailedNodeToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(239, 6);
+            // 
+            // propertiesToolStripMenuItem
+            // 
+            this.propertiesToolStripMenuItem.Name = "propertiesToolStripMenuItem";
+            this.propertiesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
+            this.propertiesToolStripMenuItem.Text = "Properties";
+            this.propertiesToolStripMenuItem.Click += new System.EventHandler(this.propertiesToolStripMenuItem_Click);
+            // 
+            // MenuBar
+            // 
+            this.MenuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.FileToolStripMenuItem,
             this.controllerToolStripMenuItem});
-			this.MenuBar.Location = new System.Drawing.Point(0, 0);
-			this.MenuBar.Name = "MenuBar";
-			this.MenuBar.Size = new System.Drawing.Size(634, 24);
-			this.MenuBar.TabIndex = 1;
-			this.MenuBar.Text = "menuStrip1";
-			// 
-			// FileToolStripMenuItem
-			// 
-			this.FileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.MenuBar.Location = new System.Drawing.Point(0, 0);
+            this.MenuBar.Name = "MenuBar";
+            this.MenuBar.Size = new System.Drawing.Size(634, 24);
+            this.MenuBar.TabIndex = 1;
+            this.MenuBar.Text = "menuStrip1";
+            // 
+            // FileToolStripMenuItem
+            // 
+            this.FileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SaveToolStripMenuItem});
-			this.FileToolStripMenuItem.Name = "FileToolStripMenuItem";
-			this.FileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-			this.FileToolStripMenuItem.Text = "&File";
-			// 
-			// SaveToolStripMenuItem
-			// 
-			this.SaveToolStripMenuItem.Name = "SaveToolStripMenuItem";
-			this.SaveToolStripMenuItem.Size = new System.Drawing.Size(98, 22);
-			this.SaveToolStripMenuItem.Text = "&Save";
-			this.SaveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
-			// 
-			// controllerToolStripMenuItem
-			// 
-			this.controllerToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.FileToolStripMenuItem.Name = "FileToolStripMenuItem";
+            this.FileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.FileToolStripMenuItem.Text = "&File";
+            // 
+            // SaveToolStripMenuItem
+            // 
+            this.SaveToolStripMenuItem.Name = "SaveToolStripMenuItem";
+            this.SaveToolStripMenuItem.Size = new System.Drawing.Size(98, 22);
+            this.SaveToolStripMenuItem.Text = "&Save";
+            this.SaveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
+            // 
+            // controllerToolStripMenuItem
+            // 
+            this.controllerToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.createNewPrmaryControllerToolStripMenuItem,
             this.transferPrimaryRoleToolStripMenuItem,
             this.addControllerToolStripMenuItem,
             this.addDeviceToolStripMenuItem,
+            this.addSecureDeviceToolStripMenuItem,
             this.toolStripSeparator1,
             this.removeControllerToolStripMenuItem,
             this.removeDeviceToolStripMenuItem,
@@ -226,130 +228,147 @@
             this.requestNetworkUpdateToolStripMenuItem,
             this.toolStripSeparator7,
             this.resetControllersoftToolStripMenuItem});
-			this.controllerToolStripMenuItem.Name = "controllerToolStripMenuItem";
-			this.controllerToolStripMenuItem.Size = new System.Drawing.Size(72, 20);
-			this.controllerToolStripMenuItem.Text = "Controller";
-			// 
-			// createNewPrmaryControllerToolStripMenuItem
-			// 
-			this.createNewPrmaryControllerToolStripMenuItem.Name = "createNewPrmaryControllerToolStripMenuItem";
-			this.createNewPrmaryControllerToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.createNewPrmaryControllerToolStripMenuItem.Text = "Create New Prmary Controller";
-			this.createNewPrmaryControllerToolStripMenuItem.Click += new System.EventHandler(this.createNewPrmaryControllerToolStripMenuItem_Click);
-			// 
-			// transferPrimaryRoleToolStripMenuItem
-			// 
-			this.transferPrimaryRoleToolStripMenuItem.Name = "transferPrimaryRoleToolStripMenuItem";
-			this.transferPrimaryRoleToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.transferPrimaryRoleToolStripMenuItem.Text = "Transfer Primary Role";
-			this.transferPrimaryRoleToolStripMenuItem.Click += new System.EventHandler(this.transferPrimaryRoleToolStripMenuItem_Click);
-			// 
-			// addDeviceToolStripMenuItem
-			// 
-			this.addDeviceToolStripMenuItem.Name = "addDeviceToolStripMenuItem";
-			this.addDeviceToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.addDeviceToolStripMenuItem.Text = "Add Device";
-			this.addDeviceToolStripMenuItem.Click += new System.EventHandler(this.addDeviceToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(229, 6);
-			// 
-			// removeDeviceToolStripMenuItem
-			// 
-			this.removeDeviceToolStripMenuItem.Name = "removeDeviceToolStripMenuItem";
-			this.removeDeviceToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.removeDeviceToolStripMenuItem.Text = "Remove Device";
-			this.removeDeviceToolStripMenuItem.Click += new System.EventHandler(this.removeDeviceToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(229, 6);
-			// 
-			// receiveConfigurationToolStripMenuItem
-			// 
-			this.receiveConfigurationToolStripMenuItem.Name = "receiveConfigurationToolStripMenuItem";
-			this.receiveConfigurationToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.receiveConfigurationToolStripMenuItem.Text = "Receive Configuration";
-			this.receiveConfigurationToolStripMenuItem.Click += new System.EventHandler(this.receiveConfigurationToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(229, 6);
-			// 
-			// requestNetworkUpdateToolStripMenuItem
-			// 
-			this.requestNetworkUpdateToolStripMenuItem.Name = "requestNetworkUpdateToolStripMenuItem";
-			this.requestNetworkUpdateToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.requestNetworkUpdateToolStripMenuItem.Text = "Request Network Update";
-			this.requestNetworkUpdateToolStripMenuItem.Click += new System.EventHandler(this.requestNetworkUpdateToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(229, 6);
-			// 
-			// resetControllersoftToolStripMenuItem
-			// 
-			this.resetControllersoftToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.controllerToolStripMenuItem.Name = "controllerToolStripMenuItem";
+            this.controllerToolStripMenuItem.Size = new System.Drawing.Size(72, 20);
+            this.controllerToolStripMenuItem.Text = "Controller";
+            // 
+            // createNewPrmaryControllerToolStripMenuItem
+            // 
+            this.createNewPrmaryControllerToolStripMenuItem.Name = "createNewPrmaryControllerToolStripMenuItem";
+            this.createNewPrmaryControllerToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.createNewPrmaryControllerToolStripMenuItem.Text = "Create New Prmary Controller";
+            this.createNewPrmaryControllerToolStripMenuItem.Click += new System.EventHandler(this.createNewPrmaryControllerToolStripMenuItem_Click);
+            // 
+            // transferPrimaryRoleToolStripMenuItem
+            // 
+            this.transferPrimaryRoleToolStripMenuItem.Name = "transferPrimaryRoleToolStripMenuItem";
+            this.transferPrimaryRoleToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.transferPrimaryRoleToolStripMenuItem.Text = "Transfer Primary Role";
+            this.transferPrimaryRoleToolStripMenuItem.Click += new System.EventHandler(this.transferPrimaryRoleToolStripMenuItem_Click);
+            // 
+            // addControllerToolStripMenuItem
+            // 
+            this.addControllerToolStripMenuItem.Name = "addControllerToolStripMenuItem";
+            this.addControllerToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            // 
+            // addDeviceToolStripMenuItem
+            // 
+            this.addDeviceToolStripMenuItem.Name = "addDeviceToolStripMenuItem";
+            this.addDeviceToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.addDeviceToolStripMenuItem.Text = "Add Device";
+            this.addDeviceToolStripMenuItem.Click += new System.EventHandler(this.addDeviceToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(229, 6);
+            // 
+            // removeControllerToolStripMenuItem
+            // 
+            this.removeControllerToolStripMenuItem.Name = "removeControllerToolStripMenuItem";
+            this.removeControllerToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            // 
+            // removeDeviceToolStripMenuItem
+            // 
+            this.removeDeviceToolStripMenuItem.Name = "removeDeviceToolStripMenuItem";
+            this.removeDeviceToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.removeDeviceToolStripMenuItem.Text = "Remove Device";
+            this.removeDeviceToolStripMenuItem.Click += new System.EventHandler(this.removeDeviceToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(229, 6);
+            // 
+            // receiveConfigurationToolStripMenuItem
+            // 
+            this.receiveConfigurationToolStripMenuItem.Name = "receiveConfigurationToolStripMenuItem";
+            this.receiveConfigurationToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.receiveConfigurationToolStripMenuItem.Text = "Receive Configuration";
+            this.receiveConfigurationToolStripMenuItem.Click += new System.EventHandler(this.receiveConfigurationToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(229, 6);
+            // 
+            // requestNetworkUpdateToolStripMenuItem
+            // 
+            this.requestNetworkUpdateToolStripMenuItem.Name = "requestNetworkUpdateToolStripMenuItem";
+            this.requestNetworkUpdateToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.requestNetworkUpdateToolStripMenuItem.Text = "Request Network Update";
+            this.requestNetworkUpdateToolStripMenuItem.Click += new System.EventHandler(this.requestNetworkUpdateToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(229, 6);
+            // 
+            // resetControllersoftToolStripMenuItem
+            // 
+            this.resetControllersoftToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.softToolStripMenuItem,
             this.eraseAllToolStripMenuItem});
-			this.resetControllersoftToolStripMenuItem.Name = "resetControllersoftToolStripMenuItem";
-			this.resetControllersoftToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-			this.resetControllersoftToolStripMenuItem.Text = "Reset Controller";
-			// 
-			// softToolStripMenuItem
-			// 
-			this.softToolStripMenuItem.Name = "softToolStripMenuItem";
-			this.softToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.softToolStripMenuItem.Text = "Soft";
-			this.softToolStripMenuItem.Click += new System.EventHandler(this.softToolStripMenuItem_Click);
-			// 
-			// eraseAllToolStripMenuItem
-			// 
-			this.eraseAllToolStripMenuItem.Name = "eraseAllToolStripMenuItem";
-			this.eraseAllToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.eraseAllToolStripMenuItem.Text = "Erase All";
-			this.eraseAllToolStripMenuItem.Click += new System.EventHandler(this.eraseAllToolStripMenuItem_Click);
-			// 
-			// statusStrip1
-			// 
-			this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.resetControllersoftToolStripMenuItem.Name = "resetControllersoftToolStripMenuItem";
+            this.resetControllersoftToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.resetControllersoftToolStripMenuItem.Text = "Reset Controller";
+            // 
+            // softToolStripMenuItem
+            // 
+            this.softToolStripMenuItem.Name = "softToolStripMenuItem";
+            this.softToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.softToolStripMenuItem.Text = "Soft";
+            this.softToolStripMenuItem.Click += new System.EventHandler(this.softToolStripMenuItem_Click);
+            // 
+            // eraseAllToolStripMenuItem
+            // 
+            this.eraseAllToolStripMenuItem.Name = "eraseAllToolStripMenuItem";
+            this.eraseAllToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.eraseAllToolStripMenuItem.Text = "Erase All";
+            this.eraseAllToolStripMenuItem.Click += new System.EventHandler(this.eraseAllToolStripMenuItem_Click);
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1});
-			this.statusStrip1.Location = new System.Drawing.Point(0, 430);
-			this.statusStrip1.Name = "statusStrip1";
-			this.statusStrip1.Size = new System.Drawing.Size(634, 22);
-			this.statusStrip1.TabIndex = 2;
-			this.statusStrip1.Text = "statusStrip1";
-			// 
-			// toolStripStatusLabel1
-			// 
-			this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-			this.toolStripStatusLabel1.Size = new System.Drawing.Size(70, 17);
-			this.toolStripStatusLabel1.Text = "Initializing...";
-			// 
-			// MainForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(634, 452);
-			this.Controls.Add(this.statusStrip1);
-			this.Controls.Add(this.NodeGridView);
-			this.Controls.Add(this.MenuBar);
-			this.MainMenuStrip = this.MenuBar;
-			this.Name = "MainForm";
-			this.Text = "OpenZWave Test";
-			((System.ComponentModel.ISupportInitialize)(this.NodeGridView)).EndInit();
-			this.NodeContextMenuStrip.ResumeLayout(false);
-			this.MenuBar.ResumeLayout(false);
-			this.MenuBar.PerformLayout();
-			this.statusStrip1.ResumeLayout(false);
-			this.statusStrip1.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.statusStrip1.Location = new System.Drawing.Point(0, 430);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(634, 22);
+            this.statusStrip1.TabIndex = 2;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(70, 17);
+            this.toolStripStatusLabel1.Text = "Initializing...";
+            // 
+            // addSecureDeviceToolStripMenuItem
+            // 
+            this.addSecureDeviceToolStripMenuItem.Name = "addSecureDeviceToolStripMenuItem";
+            this.addSecureDeviceToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.addSecureDeviceToolStripMenuItem.Text = "Add Secure Device";
+            this.addSecureDeviceToolStripMenuItem.Click += new System.EventHandler(this.addSecureDeviceToolStripMenuItem_Click);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(634, 452);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.NodeGridView);
+            this.Controls.Add(this.MenuBar);
+            this.MainMenuStrip = this.MenuBar;
+            this.Name = "MainForm";
+            this.Text = "OpenZWave Test";
+            ((System.ComponentModel.ISupportInitialize)(this.NodeGridView)).EndInit();
+            this.NodeContextMenuStrip.ResumeLayout(false);
+            this.MenuBar.ResumeLayout(false);
+            this.MenuBar.PerformLayout();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -390,6 +409,7 @@
 		private System.Windows.Forms.ToolStripMenuItem resetControllersoftToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem softToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem eraseAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem addSecureDeviceToolStripMenuItem;
     }
 }
 

--- a/dotnet/examples/OZWForm/src/MainForm.cs
+++ b/dotnet/examples/OZWForm/src/MainForm.cs
@@ -9,25 +9,36 @@ using OpenZWaveDotNet;
 
 namespace OZWForm
 {
+    //temp
     public partial class MainForm : Form
     {
-        static private ZWOptions m_options = null;
-        static public ZWOptions Options
+        private static ZWOptions m_options = null;
+
+        public static ZWOptions Options
         {
             get { return m_options; }
         }
 
-        static private ZWManager m_manager = null;
-        static public ZWManager Manager
+        private static ZWManager m_manager = null;
+
+        public static ZWManager Manager
         {
             get { return m_manager; }
+        }
+
+        private bool m_securityEnabled = false;
+
+        public bool SecurityEnabled
+        {
+            get { return m_securityEnabled; }
         }
 
         private UInt32 m_homeId = 0;
         private ZWNotification m_notification = null;
         private BindingList<Node> m_nodeList = new BindingList<Node>();
         private Byte m_rightClickNode = 0xff;
-		private string m_driverPort = string.Empty;
+        private string m_driverPort = string.Empty;
+        
 
         public MainForm()
         {
@@ -167,9 +178,12 @@ namespace OZWForm
             m_options.Create(@"..\..\..\..\..\..\..\config\", @"", @"");
 
             // Add any app specific options here...
-			m_options.AddOptionInt("SaveLogLevel", (int)ZWLogLevel.Detail);			// ordinarily, just write "Detail" level messages to the log
-			m_options.AddOptionInt("QueueLogLevel", (int)ZWLogLevel.Debug);			// save recent messages with "Debug" level messages to be dumped if an error occurs
-			m_options.AddOptionInt("DumpTriggerLevel", (int)ZWLogLevel.Error);		// only "dump" Debug  to the log emessages when an error-level message is logged
+            m_options.AddOptionInt("SaveLogLevel", (int) ZWLogLevel.Detail);
+                // ordinarily, just write "Detail" level messages to the log
+            m_options.AddOptionInt("QueueLogLevel", (int) ZWLogLevel.Debug);
+                // save recent messages with "Debug" level messages to be dumped if an error occurs
+            m_options.AddOptionInt("DumpTriggerLevel", (int) ZWLogLevel.Error);
+                // only "dump" Debug  to the log emessages when an error-level message is logged
 
             // Lock the options
             m_options.Lock();
@@ -180,7 +194,7 @@ namespace OZWForm
             m_manager.OnNotification += new ManagedNotificationsHandler(NotificationHandler);
 
             // Add a driver
-			m_driverPort = @"\\.\COM4";
+            m_driverPort = @"\\.\COM5";
             m_manager.AddDriver(m_driverPort);
 //			m_manager.AddDriver(@"HID Controller", ZWControllerInterface.Hid);
         }
@@ -199,27 +213,27 @@ namespace OZWForm
             switch (m_notification.GetType())
             {
                 case ZWNotification.Type.ValueAdded:
+                {
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    if (node != null)
                     {
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-                        if (node != null)
-                        {
-                            node.AddValue(m_notification.GetValueID());
-                        }
-                        break;
+                        node.AddValue(m_notification.GetValueID());
                     }
+                    break;
+                }
 
                 case ZWNotification.Type.ValueRemoved:
+                {
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    if (node != null)
                     {
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-                        if (node != null)
-                        {
-                            node.RemoveValue(m_notification.GetValueID());
-                        }
-                        break;
+                        node.RemoveValue(m_notification.GetValueID());
                     }
+                    break;
+                }
 
                 case ZWNotification.Type.ValueChanged:
-                    {
+                {
 /*						Console.WriteLine("Value Changed");
 						ZWValueID v = m_notification.GetValueID();
 						Console.WriteLine("  Node : " + v.GetNodeId().ToString());
@@ -231,136 +245,138 @@ namespace OZWForm
 						Console.WriteLine("  Label: " + m_manager.GetValueLabel(v));
 						Console.WriteLine("  Help : " + m_manager.GetValueHelp(v));
 						Console.WriteLine("  Units: " + m_manager.GetValueUnits(v));
-*/						break;
-                    }
+*/
+                    break;
+                }
 
                 case ZWNotification.Type.Group:
-                    {
-                        break;
-                    }
+                {
+                    break;
+                }
 
                 case ZWNotification.Type.NodeAdded:
+                {
+                    // if this node was in zwcfg*.xml, this is the first node notification
+                    // if not, the NodeNew notification should already have been received
+                    if (GetNode(m_notification.GetHomeId(), m_notification.GetNodeId()) == null)
                     {
-						// if this node was in zwcfg*.xml, this is the first node notification
-						// if not, the NodeNew notification should already have been received
-						if (GetNode(m_notification.GetHomeId(), m_notification.GetNodeId()) == null)
-						{
-							Node node = new Node();
-	                        node.ID = m_notification.GetNodeId();
-		                    node.HomeID = m_notification.GetHomeId();
-			                m_nodeList.Add(node);
-						}
-                        break;
+                        Node node = new Node();
+                        node.ID = m_notification.GetNodeId();
+                        node.HomeID = m_notification.GetHomeId();
+                        m_nodeList.Add(node);
                     }
+                    break;
+                }
 
-				case ZWNotification.Type.NodeNew:
-					{
-						// Add the new node to our list (and flag as uninitialized)
-						Node node = new Node();
-						node.ID = m_notification.GetNodeId();
-						node.HomeID = m_notification.GetHomeId();
-						m_nodeList.Add(node);
-						break;
-					}
+                case ZWNotification.Type.NodeNew:
+                {
+                    // Add the new node to our list (and flag as uninitialized)
+                    Node node = new Node();
+                    node.ID = m_notification.GetNodeId();
+                    node.HomeID = m_notification.GetHomeId();
+                    m_nodeList.Add(node);
+                    break;
+                }
 
                 case ZWNotification.Type.NodeRemoved:
+                {
+                    foreach (Node node in m_nodeList)
                     {
-                        foreach (Node node in m_nodeList)
+                        if (node.ID == m_notification.GetNodeId())
                         {
-                            if (node.ID == m_notification.GetNodeId())
-                            {
-                                m_nodeList.Remove(node);
-                                break;
-                            }
+                            m_nodeList.Remove(node);
+                            break;
                         }
-                        break;
                     }
+                    break;
+                }
 
                 case ZWNotification.Type.NodeProtocolInfo:
+                {
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    if (node != null)
                     {
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-                        if (node != null)
-                        {
-                            node.Label = m_manager.GetNodeType(m_homeId, node.ID);
-                        }
-                        break;
+                        node.Label = m_manager.GetNodeType(m_homeId, node.ID);
                     }
+                    break;
+                }
 
                 case ZWNotification.Type.NodeNaming:
+                {
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    if (node != null)
                     {
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-                        if (node != null)
-                        {
-                            node.Manufacturer = m_manager.GetNodeManufacturerName(m_homeId, node.ID);
-                            node.Product = m_manager.GetNodeProductName(m_homeId, node.ID);
-                            node.Location = m_manager.GetNodeLocation(m_homeId, node.ID);
-                            node.Name = m_manager.GetNodeName(m_homeId, node.ID);
-                        }
-                        break;
+                        node.Manufacturer = m_manager.GetNodeManufacturerName(m_homeId, node.ID);
+                        node.Product = m_manager.GetNodeProductName(m_homeId, node.ID);
+                        node.Location = m_manager.GetNodeLocation(m_homeId, node.ID);
+                        node.Name = m_manager.GetNodeName(m_homeId, node.ID);
                     }
+                    break;
+                }
 
                 case ZWNotification.Type.NodeEvent:
-                    {
-                        break;
-                    }
+                {
+                    break;
+                }
 
                 case ZWNotification.Type.PollingDisabled:
-                    {
-                        Console.WriteLine("Polling disabled notification");
-                        break;
-                    }
+                {
+                    Console.WriteLine("Polling disabled notification");
+                    break;
+                }
 
                 case ZWNotification.Type.PollingEnabled:
-                    {
-                        Console.WriteLine("Polling enabled notification");
-                        break;
-                    }
+                {
+                    Console.WriteLine("Polling enabled notification");
+                    break;
+                }
 
                 case ZWNotification.Type.DriverReady:
-                    {
-                        m_homeId = m_notification.GetHomeId();
-						toolStripStatusLabel1.Text = "Initializing...driver with Home ID 0x" + m_homeId.ToString("X8") + " is ready.";
-						break;
-                    }
+                {
+                    m_homeId = m_notification.GetHomeId();
+                    toolStripStatusLabel1.Text = "Initializing...driver with Home ID 0x" + m_homeId.ToString("X8") +
+                                                 " is ready.";
+                    break;
+                }
                 case ZWNotification.Type.NodeQueriesComplete:
-                    {
-						// as an example, enable query of BASIC info (CommandClass = 0x20)
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-                        //if (node != null)
-                        //{
-                        //    foreach (ZWValueID vid in node.Values)
-                        //    {
-                        //        if (vid.GetCommandClassId() == 0x84)	// remove this "if" to poll all values
-                        //            m_manager.EnablePoll(vid);
-                        //    }
-                        //}
-						toolStripStatusLabel1.Text = "Initializing...node " + node.ID + " query complete.";
-						break;
-					}
-				case ZWNotification.Type.EssentialNodeQueriesComplete:
-					{
-                        Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
-						toolStripStatusLabel1.Text = "Initializing...node " + node.ID + " essential queries complete.";
-						break;
-                    }
+                {
+                    // as an example, enable query of BASIC info (CommandClass = 0x20)
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    //if (node != null)
+                    //{
+                    //    foreach (ZWValueID vid in node.Values)
+                    //    {
+                    //        if (vid.GetCommandClassId() == 0x84)	// remove this "if" to poll all values
+                    //            m_manager.EnablePoll(vid);
+                    //    }
+                    //}
+                    toolStripStatusLabel1.Text = "Initializing...node " + node.ID + " query complete.";
+                    break;
+                }
+                case ZWNotification.Type.EssentialNodeQueriesComplete:
+                {
+                    Node node = GetNode(m_notification.GetHomeId(), m_notification.GetNodeId());
+                    toolStripStatusLabel1.Text = "Initializing...node " + node.ID + " essential queries complete.";
+                    break;
+                }
                 case ZWNotification.Type.AllNodesQueried:
-                    {
-						toolStripStatusLabel1.Text = "Ready:  All nodes queried.";
-						m_manager.WriteConfig(m_notification.GetHomeId());
-                        break;
-                    }
+                {
+                    toolStripStatusLabel1.Text = "Ready:  All nodes queried.";
+                    m_manager.WriteConfig(m_notification.GetHomeId());
+                    break;
+                }
                 case ZWNotification.Type.AllNodesQueriedSomeDead:
-                    {
-						toolStripStatusLabel1.Text = "Ready:  All nodes queried but some are dead.";
-						m_manager.WriteConfig(m_notification.GetHomeId());
-                        break;
-                    }
+                {
+                    toolStripStatusLabel1.Text = "Ready:  All nodes queried but some are dead.";
+                    m_manager.WriteConfig(m_notification.GetHomeId());
+                    break;
+                }
                 case ZWNotification.Type.AwakeNodesQueried:
-                    {
-						toolStripStatusLabel1.Text = "Ready:  Awake nodes queried (but not some sleeping nodes).";
-						m_manager.WriteConfig(m_notification.GetHomeId());
-						break;
-                    }
+                {
+                    toolStripStatusLabel1.Text = "Ready:  Awake nodes queried (but not some sleeping nodes).";
+                    m_manager.WriteConfig(m_notification.GetHomeId());
+                    break;
+                }
             }
 
             //NodeGridView.Refresh();
@@ -425,7 +441,7 @@ namespace OZWForm
 
         private void createNewPrmaryControllerToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            DoCommand( ZWControllerCommand.CreateNewPrimary);
+            DoCommand(ZWControllerCommand.CreateNewPrimary);
         }
 
         private void addDeviceToolStripMenuItem_Click(object sender, EventArgs e)
@@ -481,7 +497,7 @@ namespace OZWForm
             if (node != null)
             {
                 // Wait for refreshed config param values
-                ConfigurationWakeUpDlg configDlg = new ConfigurationWakeUpDlg( m_manager, node.HomeID, node.ID);
+                ConfigurationWakeUpDlg configDlg = new ConfigurationWakeUpDlg(m_manager, node.HomeID, node.ID);
                 if (DialogResult.OK == configDlg.ShowDialog(this))
                 {
                     // Show the form
@@ -532,64 +548,74 @@ namespace OZWForm
             }
         }
 
-		string GetValue(ZWValueID v)
-		{
-			switch (v.GetType())
-			{
-				case ZWValueID.ValueType.Bool:
-					bool r1;
-					m_manager.GetValueAsBool(v, out r1);
-					return r1.ToString();
-				case ZWValueID.ValueType.Byte:
-					byte r2;
-					m_manager.GetValueAsByte(v, out r2);
-					return r2.ToString();
-				case ZWValueID.ValueType.Decimal:
-					decimal r3;
-					m_manager.GetValueAsDecimal(v, out r3);
-					return r3.ToString();
-				case ZWValueID.ValueType.Int:
-					Int32 r4;
-					m_manager.GetValueAsInt(v, out r4);
-					return r4.ToString();
-				case ZWValueID.ValueType.List:
-					string[] r5;
-					m_manager.GetValueListItems(v, out r5);
-					string r6 = "";
-					foreach (string s in r5)
-					{
-						r6 += s;
-						r6 += "/";
-					}
-					return r6;
-				case ZWValueID.ValueType.Schedule:
-					return "Schedule";
-				case ZWValueID.ValueType.Short:
-					short r7;
-					m_manager.GetValueAsShort(v, out r7);
-					return r7.ToString();
-				case ZWValueID.ValueType.String:
-					string r8;
-					m_manager.GetValueAsString(v, out r8);
-					return r8;
-				default:
-					return "";
-			}
-		}
+        private string GetValue(ZWValueID v)
+        {
+            switch (v.GetType())
+            {
+                case ZWValueID.ValueType.Bool:
+                    bool r1;
+                    m_manager.GetValueAsBool(v, out r1);
+                    return r1.ToString();
+                case ZWValueID.ValueType.Byte:
+                    byte r2;
+                    m_manager.GetValueAsByte(v, out r2);
+                    return r2.ToString();
+                case ZWValueID.ValueType.Decimal:
+                    decimal r3;
+                    m_manager.GetValueAsDecimal(v, out r3);
+                    return r3.ToString();
+                case ZWValueID.ValueType.Int:
+                    Int32 r4;
+                    m_manager.GetValueAsInt(v, out r4);
+                    return r4.ToString();
+                case ZWValueID.ValueType.List:
+                    string[] r5;
+                    m_manager.GetValueListItems(v, out r5);
+                    string r6 = "";
+                    foreach (string s in r5)
+                    {
+                        r6 += s;
+                        r6 += "/";
+                    }
+                    return r6;
+                case ZWValueID.ValueType.Schedule:
+                    return "Schedule";
+                case ZWValueID.ValueType.Short:
+                    short r7;
+                    m_manager.GetValueAsShort(v, out r7);
+                    return r7.ToString();
+                case ZWValueID.ValueType.String:
+                    string r8;
+                    m_manager.GetValueAsString(v, out r8);
+                    return r8;
+                default:
+                    return "";
+            }
+        }
 
-		private void softToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			m_manager.SoftReset(m_homeId);
-		}
+        private void softToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            m_manager.SoftReset(m_homeId);
+        }
 
-		private void eraseAllToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			if (DialogResult.Yes == MessageBox.Show("Are you sure you want to fully reset the controller?  This will delete all network information and require re-including all nodes.", "Hard Reset", MessageBoxButtons.YesNo))
-			{
-				m_manager.ResetController(m_homeId);
-				m_manager.RemoveDriver(m_driverPort);
-				m_manager.AddDriver(m_driverPort);
-			}
-		}
+        private void eraseAllToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (DialogResult.Yes ==
+                MessageBox.Show(
+                    "Are you sure you want to fully reset the controller?  This will delete all network information and require re-including all nodes.",
+                    "Hard Reset", MessageBoxButtons.YesNo))
+            {
+                m_manager.ResetController(m_homeId);
+                m_manager.RemoveDriver(m_driverPort);
+                m_manager.AddDriver(m_driverPort);
+            }
+        }
+
+        private void addSecureDeviceToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            m_securityEnabled = true;
+            DoCommand(ZWControllerCommand.AddDevice);
+            m_securityEnabled = false;
+        }
     }
 }

--- a/dotnet/src/ZWManager.cpp
+++ b/dotnet/src/ZWManager.cpp
@@ -351,6 +351,108 @@ bool ZWManager::BeginControllerCommand
 	return( Manager::Get()->BeginControllerCommand( homeId, (Driver::ControllerCommand)command, (Driver::pfnControllerCallback_t)ip.ToPointer(), NULL, highPower, nodeId ) );
 }
 
+//-----------------------------------------------------------------------------
+// <ZWManager::AddNode>
+// Add a Device to the Network.
+//-----------------------------------------------------------------------------
+bool ZWManager::AddNode
+(
+	uint32 const homeId, bool doSecurity
+)
+{
+	return Manager::Get()->AddNode(homeId, doSecurity);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::RemoveNode>
+// Remove a Device from the Network.
+//-----------------------------------------------------------------------------
+bool ZWManager::RemoveNode
+(
+	uint32 const homeId
+)
+{
+	return Manager::Get()->RemoveNode(homeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::RemoveFailedNode>
+// Remove a Specific Device from the network if its non-responsive.
+//-----------------------------------------------------------------------------
+bool ZWManager::RemoveFailedNode
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->RemoveFailedNode(homeId, nodeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::HasNodeFailed>
+// Test if the Controller Believes the Node has Failed.
+//-----------------------------------------------------------------------------
+bool ZWManager::HasNodeFailed
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->HasNodeFailed(homeId, nodeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::AssignReturnRoute>
+// Ask a Node to update its Return Route to the Controller
+//-----------------------------------------------------------------------------
+bool ZWManager::AssignReturnRoute
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->AssignReturnRoute(homeId, nodeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::RequestNodeNeighborUpdate>
+// Ask a Node to update its Neighbor Table.
+//-----------------------------------------------------------------------------
+bool ZWManager::RequestNodeNeighborUpdate
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->RequestNodeNeighborUpdate(homeId, nodeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::DeleteAllReturnRoutes>
+// Ask a Node to delete all its Return Routes
+//-----------------------------------------------------------------------------
+bool ZWManager::DeleteAllReturnRoutes
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->DeleteAllReturnRoutes(homeId, nodeId);
+}
+
+//-----------------------------------------------------------------------------
+// <ZWManager::SendNodeInformation>
+// Send a NIF frame from the Controller to the Node
+//-----------------------------------------------------------------------------
+bool ZWManager::SendNodeInformation
+(
+	uint32 const homeId,
+	uint8 const nodeId
+)
+{
+	return Manager::Get()->SendNodeInformation(homeId, nodeId);
+}
+
 bool ZWManager::GetNodeClassInformation
 (
 	uint32 homeId, 

--- a/dotnet/src/ZWManager.h
+++ b/dotnet/src/ZWManager.h
@@ -1590,7 +1590,119 @@ namespace OpenZWaveDotNet
 		 * \return true if a command was running and was cancelled.
 		 * \see BeginControllerCommand 
 		 */
-		bool CancelControllerCommand( uint32 homeId ){ return Manager::Get()->CancelControllerCommand( homeId ); }
+		bool CancelControllerCommand(uint32 homeId){ return Manager::Get()->CancelControllerCommand(homeId); }
+				
+		/**
+		* \brief Start the Inclusion Process to add a Node to the Network.
+		* The Status of the Node Inclusion is communicated via Notifications. Specifically, you should
+		* monitor ControllerCommand Notifications.
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The Home ID of the Z-Wave network where the device should be added.
+		* \param doSecurity Whether to initialize the Network Key on the device if it supports the Security CC
+		* \return if the Command was sent succcesfully to the Controller
+		*/
+		bool AddNode(uint32 const homeId, bool doSecurity);
+
+		/**
+		* \brief Remove a Device from the Z-Wave Network
+		* The Status of the Node Removal is communicated via Notifications. Specifically, you should
+		* monitor ControllerCommand Notifications.
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to remove the device
+		* \return if the Command was send succesfully to the Controller
+		*/
+		bool RemoveNode(uint32 const homeId);
+
+		/**
+		* \brief Remove a Failed Device from the Z-Wave Network
+		* This Command will remove a failed node from the network. The Node should be on the Controllers Failed
+		* Node List, otherwise this command will fail. You can use the HasNodeFailed function below to test if the Controller
+		* believes the Node has Failed.
+		* The Status of the Node Removal is communicated via Notifications. Specifically, you should
+		* monitor ControllerCommand Notifications.
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to remove the device
+		* \param nodeId The NodeID of the Failed Node.
+		* \return if the Command was send succesfully to the Controller
+		*/
+		bool RemoveFailedNode(uint32 const homeId, uint8 const nodeId);
+
+		/**
+		* \brief Check if the Controller Believes a Node has Failed.
+		* This is different from the IsNodeFailed call in that we test the Controllers Failed Node List, whereas the IsNodeFailed is testing
+		* our list of Failed Nodes, which might be different.
+		* The Results will be communicated via Notifications. Specifically, you should monitor the ControllerCommand notifications
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to test the device
+		* \param nodeId The NodeID of the Failed Node.
+		* \return if the RemoveDevice Command was send succesfully to the Controller
+		*/
+		bool HasNodeFailed(uint32 const homeId, uint8 const nodeId);
+
+		/**
+		* \brief Ask a Node to update its update its Return Route to the Controller
+		* This command will ask a Node to update its Return Route to the Controller
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to update the device
+		* \param nodeId The NodeID of the Node.
+		* \return if the Command was send succesfully to the Controller
+		*/
+		bool AssignReturnRoute(uint32 const homeId, uint8 const nodeId);
+
+		/**
+		* \brief Ask a Node to update its Neighbor Tables
+		* This command will ask a Node to update its Neighbor Tables.
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to update the device
+		* \param nodeId The NodeID of the Node.
+		* \return if the Command was send succesfully to the Controller
+		*/
+		bool RequestNodeNeighborUpdate(uint32 const homeId, uint8 const nodeId);
+
+		/**
+		* \brief Ask a Node to delete all Return Route.
+		* This command will ask a Node to delete all its return routes, and will rediscover when needed.
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network where you want to update the device
+		* \param nodeId The NodeID of the Node.
+		* \return if the Command was send succesfully to the Controller
+		*/
+		bool DeleteAllReturnRoutes(uint32 const homeId, uint8 const nodeId);
+
+		/**
+		* \brief Send a NIF frame from the Controller to a Node.
+		* This command send a NIF frame from the Controller to a Node
+		*
+		* Results of the AddNode Command will be send as a Notification with the Notification type as
+		* Notification::Type_ControllerCommand
+		*
+		* \param homeId The HomeID of the Z-Wave network
+		* \param nodeId The NodeID of the Node to recieve the NIF
+		* \return if the sendNIF Command was send succesfully to the Controller
+		*/
+		bool SendNodeInformation(uint32 const homeId, uint8 const nodeId);
+		
 	/*@}*/
 
 	//-----------------------------------------------------------------------------

--- a/dotnet/src/ZWNotification.h
+++ b/dotnet/src/ZWNotification.h
@@ -84,7 +84,8 @@ namespace OpenZWaveDotNet
 			AllNodesQueriedSomeDead			= Notification::Type_AllNodesQueriedSomeDead,
 			AllNodesQueried					= Notification::Type_AllNodesQueried,
 			Notification					= Notification::Type_Notification,
-			DriverRemoved					= Notification::Type_DriverRemoved
+			DriverRemoved					= Notification::Type_DriverRemoved,
+			ControllerCommand				= Notification::Type_ControllerCommand
 		};
 
 	public:
@@ -103,6 +104,13 @@ namespace OpenZWaveDotNet
 		{
 			m_type = (Type)Enum::ToObject( Type::typeid, notification->GetType() );
 			m_byte = notification->GetByte();
+
+			//Check if notification is either NodeEvent or ControllerCommand, otherwise GetEvent() will fail
+			if ((m_type == Type::NodeEvent) || (m_type == Type::ControllerCommand))
+			{
+				m_event = notification->GetEvent();
+			}			
+
 			m_valueId = gcnew ZWValueID( notification->GetValueID() );
 		}
 
@@ -111,12 +119,13 @@ namespace OpenZWaveDotNet
 		uint8 GetNodeId(){ return m_valueId->GetNodeId(); }
 		ZWValueID^ GetValueID(){ return m_valueId; }
 		uint8 GetGroupIdx(){ assert(Type::Group==m_type); return m_byte; } 
-		uint8 GetEvent(){ assert(Type::NodeEvent==m_type); return m_byte; }
+		uint8 GetEvent(){ return m_event; }
 		uint8 GetByte(){ return m_byte; }
 
 	internal:
 		Type		m_type;
 		ZWValueID^	m_valueId;
 		uint8		m_byte;
+		uint8		m_event;
 	};
 }


### PR DESCRIPTION
Update:
Had to revert to a new branch and re-add all my changed files, because my working branch of my fork got completely messed up. This new branch should now only contain the necessary files and updates.

Old updates: 
(from new to old)
*Updated OZWForm with a new menu item to add secure devices

*Edited .Net wrapper and OZWForm to use the new methods:
Edited the .Net wrapper and OZWForm to work with the new methods. For
now I have used only one way of adding nodes, which always uses the
security enabled way. I have no other devices, so can't test if this is
right or not. Furthermore, I split the implementation and definition of
the methods between the ZWManager.cpp and ZWManager.h. But the methods
are just one line calls to the manager, and as some other methods like
that in ZWManager are just implemented in the header file, this might be
part of the coding standard? If so, I'll have to change that.

When BeginControllerCommand is fully deprecated everything should be
looked over and edited further. For now my changes seem to work as they
should, but I have had some problems with assertions failing in
"output.c", when I was trying to remove a node, but it does not seem to
fail every time. I believe this is not due to my code, so I let it be.

Finally, my code should be tested more extensively, by someone with more
devices and (maybe) more experience with the project, to test whether
everything actually works as it should!

*Update .Net wrapper for new Manager API's:
Added Methods to ZWManager corresponding to the new API methods in
Manager.
ToDo: Change the examples so they use the new API methods (Use
Notification::Type_ControllerCommand as the reply for the API methods.
The (OpenZWave::Driver::ControllerState)_notification->GetEvent(),
(OpenZWave::Driver::ControllerError)_notification->GetNotification() can
be used as parameters for the original callback method, I believe)!