### PR TITLE
[RFC] MultiInstanceAssociation support

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -5649,24 +5649,6 @@ void Driver::AddAssociation
 (
 		uint8 const _nodeId,
 		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	LockGuard LG(m_nodeMutex);
-	if( Node* node = GetNode( _nodeId ) )
-	{
-		node->AddAssociation( _groupIdx, _targetNodeId );
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Driver::AddAssociation>
-// Adds a node to an association group
-//-----------------------------------------------------------------------------
-void Driver::AddAssociation
-(
-		uint8 const _nodeId,
-		uint8 const _groupIdx,
 		uint8 const _targetNodeId,
 		uint8 const _instance
 )
@@ -5675,24 +5657,6 @@ void Driver::AddAssociation
 	if( Node* node = GetNode( _nodeId ) )
 	{
 		node->AddAssociation( _groupIdx, _targetNodeId, _instance );
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Driver::RemoveAssociation>
-// Removes a node from an association group
-//-----------------------------------------------------------------------------
-void Driver::RemoveAssociation
-(
-		uint8 const _nodeId,
-		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	LockGuard LG(m_nodeMutex);
-	if( Node* node = GetNode( _nodeId ) )
-	{
-		node->RemoveAssociation( _groupIdx, _targetNodeId );
 	}
 }
 

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -6349,7 +6349,7 @@ void Driver::UpdateNodeRoutes
 		uint8 numGroups = GetNumGroups( _nodeId );
 		uint8 numNodes = 0;
 		uint8 nodes[5];
-		uint8* associations;
+		InstanceAssociation* associations;
 		uint8 i;
 
 		// Determine up to 5 destinations
@@ -6364,14 +6364,14 @@ void Driver::UpdateNodeRoutes
 				uint8 k;
 				for( k = 0; k < numNodes; k++ )
 				{
-					if( nodes[k] == associations[j] )
+					if( nodes[k] == associations[j].m_nodeId )
 					{
 						break;
 					}
 				}
 				if( k >= numNodes && numNodes < sizeof(nodes) )	// not in list so add it
 				{
-					nodes[numNodes++] = associations[j];
+					nodes[numNodes++] = associations[j].m_nodeId;
 				}
 			}
 			if( associations != NULL )

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -5660,6 +5660,25 @@ void Driver::AddAssociation
 }
 
 //-----------------------------------------------------------------------------
+// <Driver::AddAssociation>
+// Adds a node to an association group
+//-----------------------------------------------------------------------------
+void Driver::AddAssociation
+(
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	LockGuard LG(m_nodeMutex);
+	if( Node* node = GetNode( _nodeId ) )
+	{
+		node->AddAssociation( _groupIdx, _targetNodeId, _instance );
+	}
+}
+
+//-----------------------------------------------------------------------------
 // <Driver::RemoveAssociation>
 // Removes a node from an association group
 //-----------------------------------------------------------------------------
@@ -5674,6 +5693,25 @@ void Driver::RemoveAssociation
 	if( Node* node = GetNode( _nodeId ) )
 	{
 		node->RemoveAssociation( _groupIdx, _targetNodeId );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <Driver::RemoveAssociation>
+// Removes a node from an association group
+//-----------------------------------------------------------------------------
+void Driver::RemoveAssociation
+(
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	LockGuard LG(m_nodeMutex);
+	if( Node* node = GetNode( _nodeId ) )
+	{
+		node->RemoveAssociation( _groupIdx, _targetNodeId, _instance );
 	}
 }
 

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -5602,6 +5602,27 @@ uint32 Driver::GetAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Driver::GetAssociations>
+// Gets the associations for a group
+//-----------------------------------------------------------------------------
+uint32 Driver::GetAssociations
+(
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		InstanceAssociation** o_associations
+)
+{
+	uint32 numAssociations = 0;
+	LockGuard LG(m_nodeMutex);
+	if( Node* node = GetNode( _nodeId ) )
+	{
+		numAssociations = node->GetAssociations( _groupIdx, o_associations );
+	}
+
+	return numAssociations;
+}
+
+//-----------------------------------------------------------------------------
 // <Driver::GetMaxAssociations>
 // Gets the maximum number of associations for a group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -741,7 +741,9 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint8 GetMaxAssociations( uint8 const _nodeId, uint8 const _groupIdx );
 		string GetGroupLabel( uint8 const _nodeId, uint8 const _groupIdx );
 		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
+		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
 		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
+		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance  );
 
 	//-----------------------------------------------------------------------------
 	//	Notifications

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -33,6 +33,7 @@
 #include <list>
 
 #include "Defs.h"
+#include "Group.h"
 #include "value_classes/ValueID.h"
 #include "Node.h"
 #include "platform/Event.h"
@@ -738,6 +739,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		// The public interface is provided via the wrappers in the Manager class
 		uint8 GetNumGroups( uint8 const _nodeId );
 		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, uint8** o_associations );
+		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, InstanceAssociation** o_associations );
 		uint8 GetMaxAssociations( uint8 const _nodeId, uint8 const _groupIdx );
 		string GetGroupLabel( uint8 const _nodeId, uint8 const _groupIdx );
 		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -740,7 +740,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, uint8** o_associations );
 		uint8 GetMaxAssociations( uint8 const _nodeId, uint8 const _groupIdx );
 		string GetGroupLabel( uint8 const _nodeId, uint8 const _groupIdx );
-		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
+		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 
 	//-----------------------------------------------------------------------------

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -740,10 +740,8 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, uint8** o_associations );
 		uint8 GetMaxAssociations( uint8 const _nodeId, uint8 const _groupIdx );
 		string GetGroupLabel( uint8 const _nodeId, uint8 const _groupIdx );
-		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
 		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
-		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
-		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance  );
+		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 
 	//-----------------------------------------------------------------------------
 	//	Notifications

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -106,7 +106,7 @@ Group::Group
 {
 	int intVal;
 	char const* str;
-	vector<uint8> pending;
+	vector<InstanceAssociation> pending;
 
 	if( TIXML_SUCCESS == _groupElement->QueryIntAttribute( "index", &intVal ) )
 	{
@@ -137,8 +137,18 @@ Group::Group
 		char const* elementName = associationElement->Value();
 		if( elementName && !strcmp( elementName, "Node" ) )
 		{
-			if (associationElement->QueryIntAttribute( "id", &intVal ) == TIXML_SUCCESS) 
-				pending.push_back( (uint8)intVal );
+			
+			if( associationElement->QueryIntAttribute( "id", &intVal ) == TIXML_SUCCESS )
+			{
+				InstanceAssociation association;
+				association.m_nodeId = (uint8)intVal;
+				if( associationElement->QueryIntAttribute( "instance", &intVal ) == TIXML_SUCCESS )
+					association.m_instance = (uint8)intVal;
+				else
+					association.m_instance = 0x00;
+
+				pending.push_back( association );
+			}
 		}
 
 		associationElement = associationElement->NextSiblingElement();
@@ -177,7 +187,7 @@ void Group::WriteXML
 		
 		snprintf( str, 16, "%d", it->first.m_nodeId );
 		associationElement->SetAttribute( "id", str );
-//		if (it->first.m_instance != 0)
+		if (it->first.m_instance != 0)
 		{
 			snprintf( str, 16, "%d", it->first.m_instance );
 			associationElement->SetAttribute( "instance", str );

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -231,7 +231,6 @@ void Group::AddAssociation
 	{
 		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
 		{
-			// TODO add options to use Association when _instance == 0
 			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() )))
 			{
 				cc->Set( m_groupIdx, _nodeId, _instance );
@@ -263,7 +262,6 @@ void Group::RemoveAssociation
 	{
 		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
 		{
-			// TODO add options to use Association when _instance == 0
 			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) ) )
 			{
 				cc->Remove( m_groupIdx, _nodeId, _instance );
@@ -403,7 +401,7 @@ uint32 Group::GetAssociations
 		return 0;
 	}
 
-	uint8* associations = new uint8[numNodes]; // TODO
+	uint8* associations = new uint8[numNodes]; // room for all associations, we only need room for the associations without instance
 	uint32 i = 0;
 	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
 	{

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -193,14 +193,13 @@ void Group::WriteXML
 //-----------------------------------------------------------------------------
 bool Group::Contains
 (
-	uint8 const _nodeId
+	uint8 const _nodeId,
+	uint8 const _instance
 )
 {
-//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-//	return( it != m_associations.end() );
 	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
 	{
-		if (it->first.m_nodeId == _nodeId)
+		if ((it->first.m_nodeId == _nodeId) and (it->first.m_instance == _instance))
 		{
 			return true;
 		}
@@ -214,28 +213,6 @@ bool Group::Contains
 //-----------------------------------------------------------------------------
 void Group::AddAssociation
 (
-	uint8 const _nodeId
-)
-{
-	if( Driver* driver = Manager::Get()->GetDriver( m_homeId ) )
-	{
-		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
-		{
-			if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
-			{
-				cc->Set( m_groupIdx, _nodeId );
-				cc->QueryGroup( m_groupIdx, 0 );
-			}
-		}
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Group::AddAssociation>
-// Associate a node with this group
-//-----------------------------------------------------------------------------
-void Group::AddAssociation
-(
 	uint8 const _nodeId,
 	uint8 const _instance
 )
@@ -244,38 +221,20 @@ void Group::AddAssociation
 	{
 		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
 		{
-			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) ) )
+			// TODO add options to use Association when _instance == 0
+			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() )))
 			{
 				cc->Set( m_groupIdx, _nodeId, _instance );
 				cc->QueryGroup( m_groupIdx, 0 );
 			}
-//			if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
-//			{
-//				cc->Set( m_groupIdx, _nodeId );
-//				cc->QueryGroup( m_groupIdx, 0 );
-//			}
-		}
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Group:RemoveAssociation>
-// Remove a node from this group
-//-----------------------------------------------------------------------------
-void Group::RemoveAssociation
-(
-	uint8 const _nodeId
-)
-{
-	if( Driver* driver = Manager::Get()->GetDriver( m_homeId ) )
-	{
-		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
-		{
-			if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
+			else
 			{
-				cc->Remove( m_groupIdx, _nodeId );
-				cc->QueryGroup( m_groupIdx, 0 );
-			}
+				if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
+				{
+					cc->Set( m_groupIdx, _nodeId );
+					cc->QueryGroup( m_groupIdx, 0 );
+				}
+			} 
 		}
 	}
 }
@@ -294,10 +253,19 @@ void Group::RemoveAssociation
 	{
 		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
 		{
+			// TODO add options to use Association when _instance == 0
 			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) ) )
 			{
 				cc->Remove( m_groupIdx, _nodeId, _instance );
 				cc->QueryGroup( m_groupIdx, 0 );
+			} 
+			else
+			{
+				if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
+				{
+					cc->Remove( m_groupIdx, _nodeId );
+					cc->QueryGroup( m_groupIdx, 0 );
+				}
 			}
 		}
 	}

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -35,6 +35,7 @@
 #include "command_classes/Association.h"
 #include "command_classes/AssociationCommandConfiguration.h"
 #include "command_classes/MultiInstanceAssociation.h"
+#include "platform/Log.h"
 
 #include "tinyxml.h"
 
@@ -236,13 +237,14 @@ void Group::AddAssociation
 				cc->Set( m_groupIdx, _nodeId, _instance );
 				cc->QueryGroup( m_groupIdx, 0 );
 			}
+			else if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
+			{
+				cc->Set( m_groupIdx, _nodeId );
+				cc->QueryGroup( m_groupIdx, 0 );
+			}
 			else
 			{
-				if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
-				{
-					cc->Set( m_groupIdx, _nodeId );
-					cc->QueryGroup( m_groupIdx, 0 );
-				}
+				Log::Write( LogLevel_Info, m_nodeId, "No supported Association CC found" );
 			} 
 		}
 	}
@@ -267,14 +269,15 @@ void Group::RemoveAssociation
 				cc->Remove( m_groupIdx, _nodeId, _instance );
 				cc->QueryGroup( m_groupIdx, 0 );
 			} 
-			else
+			else if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
 			{
-				if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
-				{
 					cc->Remove( m_groupIdx, _nodeId );
 					cc->QueryGroup( m_groupIdx, 0 );
-				}
 			}
+			else
+			{
+				Log::Write( LogLevel_Info, m_nodeId, "No supported Association CC found" );
+			}	
 		}
 	}
 }

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -404,7 +404,7 @@ uint32 Group::GetAssociations
 	}
 
 	*o_associations = associations;
-	return (uint32) numNodes;
+	return (uint32) i;
 }
 
 //-----------------------------------------------------------------------------
@@ -444,15 +444,18 @@ uint32 Group::GetAssociations
 //-----------------------------------------------------------------------------
 bool Group::ClearCommands
 ( 
-	uint8 const _nodeId
+	uint8 const _nodeId,
+	uint8 const _instance
 )
-{
-//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-//	if( it != m_associations.end() )
-//	{
-//		it->second.clear();
-//		return true;
-//	}
+{	
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	{
+		if( (it->first.m_nodeId == _nodeId) and (it->first.m_instance == _instance) )
+		{
+			it->second.clear();
+			return true;
+		}
+    }
 
 	return false;
 }
@@ -465,16 +468,19 @@ bool Group::AddCommand
 (
 	uint8 const _nodeId,
 	uint8 const _length,
-	uint8 const* _data
+	uint8 const* _data,
+	uint8 const _instance
 )
 {
-//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-//	if( it != m_associations.end() )
-//	{
-//		it->second.push_back( AssociationCommand( _length, _data ) );
-//		return true;
-//	}
-
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	{
+		if( (it->first.m_nodeId == _nodeId) and (it->first.m_instance == _instance) )
+		{
+			it->second.push_back( AssociationCommand( _length, _data ) );
+			return true;
+		}
+	}
+	
 	return false;
 }
 

--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -34,6 +34,7 @@
 #include "Options.h"
 #include "command_classes/Association.h"
 #include "command_classes/AssociationCommandConfiguration.h"
+#include "command_classes/MultiInstanceAssociation.h"
 
 #include "tinyxml.h"
 
@@ -170,12 +171,17 @@ void Group::WriteXML
 	_groupElement->SetAttribute( "label", m_label.c_str() );
 	_groupElement->SetAttribute( "auto", m_auto ? "true" : "false" );
 
-	for( map<uint8,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
 	{
 		TiXmlElement* associationElement = new TiXmlElement( "Node" );
 		
-		snprintf( str, 16, "%d", it->first );
+		snprintf( str, 16, "%d", it->first.m_nodeId );
 		associationElement->SetAttribute( "id", str );
+//		if (it->first.m_instance != 0)
+		{
+			snprintf( str, 16, "%d", it->first.m_instance );
+			associationElement->SetAttribute( "instance", str );
+		}
 
 		_groupElement->LinkEndChild( associationElement );
 	}
@@ -190,8 +196,16 @@ bool Group::Contains
 	uint8 const _nodeId
 )
 {
-	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-	return( it != m_associations.end() );
+//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
+//	return( it != m_associations.end() );
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	{
+		if (it->first.m_nodeId == _nodeId)
+		{
+			return true;
+		}
+	}
+	return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -212,6 +226,34 @@ void Group::AddAssociation
 				cc->Set( m_groupIdx, _nodeId );
 				cc->QueryGroup( m_groupIdx, 0 );
 			}
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <Group::AddAssociation>
+// Associate a node with this group
+//-----------------------------------------------------------------------------
+void Group::AddAssociation
+(
+	uint8 const _nodeId,
+	uint8 const _instance
+)
+{
+	if( Driver* driver = Manager::Get()->GetDriver( m_homeId ) )
+	{
+		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
+		{
+			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) ) )
+			{
+				cc->Set( m_groupIdx, _nodeId, _instance );
+				cc->QueryGroup( m_groupIdx, 0 );
+			}
+//			if( Association* cc = static_cast<Association*>( node->GetCommandClass( Association::StaticGetCommandClassId() ) ) )
+//			{
+//				cc->Set( m_groupIdx, _nodeId );
+//				cc->QueryGroup( m_groupIdx, 0 );
+//			}
 		}
 	}
 }
@@ -239,12 +281,57 @@ void Group::RemoveAssociation
 }
 
 //-----------------------------------------------------------------------------
+// <Group:RemoveAssociation>
+// Remove a node from this group
+//-----------------------------------------------------------------------------
+void Group::RemoveAssociation
+(
+	uint8 const _nodeId,
+	uint8 const _instance
+)
+{
+	if( Driver* driver = Manager::Get()->GetDriver( m_homeId ) )
+	{
+		if( Node* node = driver->GetNodeUnsafe( m_nodeId ) )
+		{
+			if( MultiInstanceAssociation* cc = static_cast<MultiInstanceAssociation*>( node->GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) ) )
+			{
+				cc->Remove( m_groupIdx, _nodeId, _instance );
+				cc->QueryGroup( m_groupIdx, 0 );
+			}
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
 // <Group::OnGroupChanged>
 // Change the group contents and notify the watchers
 //-----------------------------------------------------------------------------
 void Group::OnGroupChanged
 (
 	vector<uint8> const& _associations
+)
+{
+	vector<InstanceAssociation> instanceAssociations;
+	uint8 i;
+	for( i=0; i<_associations.size(); ++i )
+	{
+		InstanceAssociation association;
+		association.m_nodeId	= _associations[i];
+		association.m_instance  = 0x00;								
+		instanceAssociations.push_back( association );
+	}
+	OnGroupChanged(instanceAssociations);
+	instanceAssociations.clear();
+}
+
+//-----------------------------------------------------------------------------
+// <Group::OnGroupChanged>
+// Change the group contents and notify the watchers
+//-----------------------------------------------------------------------------
+void Group::OnGroupChanged
+(
+	vector<InstanceAssociation> const& _associations
 )
 {
 	bool notify = false;
@@ -297,9 +384,9 @@ void Group::OnGroupChanged
 			{
 				if( AssociationCommandConfiguration* cc = static_cast<AssociationCommandConfiguration*>( node->GetCommandClass( AssociationCommandConfiguration::StaticGetCommandClassId() ) ) )
 				{
-					for( map<uint8,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+					for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
 					{
-						cc->RequestCommands( m_groupIdx, it->first );
+						cc->RequestCommands( m_groupIdx, it->first.m_nodeId );
 					}
 				}
 			}
@@ -338,9 +425,39 @@ uint32 Group::GetAssociations
 		return 0;
 	}
 
-	uint8* associations = new uint8[numNodes];
+	uint8* associations = new uint8[numNodes]; // TODO
 	uint32 i = 0;
-	for( map<uint8,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
+	{
+		if ( it->first.m_instance == 0x00) 
+		{
+			associations[i++] = it->first.m_nodeId;
+		}
+	}
+
+	*o_associations = associations;
+	return (uint32) numNodes;
+}
+
+//-----------------------------------------------------------------------------
+// <Group::GetAssociations>
+// Get a list of associations for this group
+//-----------------------------------------------------------------------------
+uint32 Group::GetAssociations
+( 
+	InstanceAssociation** o_associations 
+)
+{
+	size_t numNodes = m_associations.size();
+	if( !numNodes )
+	{
+		*o_associations = NULL;
+		return 0;
+	}
+
+	InstanceAssociation* associations = new InstanceAssociation[numNodes];
+	uint32 i = 0;
+	for( map<InstanceAssociation,AssociationCommandVec>::iterator it = m_associations.begin(); it != m_associations.end(); ++it )
 	{
 		associations[i++] = it->first;
 	}
@@ -362,12 +479,12 @@ bool Group::ClearCommands
 	uint8 const _nodeId
 )
 {
-	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-	if( it != m_associations.end() )
-	{
-		it->second.clear();
-		return true;
-	}
+//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
+//	if( it != m_associations.end() )
+//	{
+//		it->second.clear();
+//		return true;
+//	}
 
 	return false;
 }
@@ -383,12 +500,12 @@ bool Group::AddCommand
 	uint8 const* _data
 )
 {
-	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
-	if( it != m_associations.end() )
-	{
-		it->second.push_back( AssociationCommand( _length, _data ) );
-		return true;
-	}
+//	map<uint8,AssociationCommandVec>::iterator it = m_associations.find( _nodeId );
+//	if( it != m_associations.end() )
+//	{
+//		it->second.push_back( AssociationCommand( _length, _data ) );
+//		return true;
+//	}
 
 	return false;
 }

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -39,12 +39,18 @@ namespace OpenZWave
 {
 	class Node;
 
+	typedef struct InstanceAssociation {
+		uint8 m_nodeId;
+		uint8 m_instance;
+	} InstanceAssociation;
+	
 	/** \brief Manages a group of devices (various nodes associated with each other).
 	 */
 	class Group
 	{
 		friend class Node;
 		friend class Association;
+		friend class MultiInstanceAssociation;
 
 	//-----------------------------------------------------------------------------
 	// Construction
@@ -62,6 +68,7 @@ namespace OpenZWave
 	public:
 		string const& GetLabel()const{ return m_label; }
 		uint32 GetAssociations( uint8** o_associations );
+		uint32 GetAssociations( InstanceAssociation** o_associations );
 		uint8 GetMaxAssociations()const{ return m_maxAssociations; }
 		uint8 GetIdx()const{ return m_groupIdx; }
 		bool Contains( uint8 const _nodeId );
@@ -71,8 +78,11 @@ namespace OpenZWave
 		void SetAuto( bool const _state ){ m_auto = _state; }
 
 		void AddAssociation( uint8 const _nodeId );
+		void AddAssociation( uint8 const _nodeId, uint8 const _instance );
 		void RemoveAssociation( uint8 const _nodeId );
+		void RemoveAssociation( uint8 const _nodeId, uint8 const _instance );
 		void OnGroupChanged( vector<uint8> const& _associations );
+		void OnGroupChanged( vector<InstanceAssociation> const& _associations );
 
 	//-----------------------------------------------------------------------------
 	// Command methods (COMMAND_CLASS_ASSOCIATION_COMMAND_CONFIGURATION)
@@ -94,6 +104,10 @@ namespace OpenZWave
 		};
 
 		typedef vector<AssociationCommand>	AssociationCommandVec;
+		struct classcomp {
+			bool operator() (const InstanceAssociation& lhs, const InstanceAssociation& rhs) const
+			{return (lhs.m_nodeId < rhs.m_nodeId) and (lhs.m_instance < rhs.m_instance );}
+		};
 
 	//-----------------------------------------------------------------------------
 	// Member variables
@@ -105,7 +119,7 @@ namespace OpenZWave
 		uint8								m_groupIdx;
 		uint8								m_maxAssociations;
 		bool								m_auto;				// If true, the controller will automatically be associated with the group
-		map<uint8,AssociationCommandVec>	m_associations;
+		map<InstanceAssociation,AssociationCommandVec,classcomp>	m_associations;
 	};
 
 } //namespace OpenZWave

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -104,7 +104,7 @@ namespace OpenZWave
 		typedef vector<AssociationCommand>	AssociationCommandVec;
 		struct classcomp {
 			bool operator() (const InstanceAssociation& lhs, const InstanceAssociation& rhs) const
-			{return (lhs.m_nodeId < rhs.m_nodeId) and (lhs.m_instance < rhs.m_instance );}
+			{return lhs.m_nodeId == rhs.m_nodeId ? lhs.m_instance < rhs.m_instance : lhs.m_nodeId < rhs.m_nodeId;}
 		};
 
 	//-----------------------------------------------------------------------------

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -71,16 +71,14 @@ namespace OpenZWave
 		uint32 GetAssociations( InstanceAssociation** o_associations );
 		uint8 GetMaxAssociations()const{ return m_maxAssociations; }
 		uint8 GetIdx()const{ return m_groupIdx; }
-		bool Contains( uint8 const _nodeId );
+		bool Contains( uint8 const _nodeId, uint8 const _instance = 0x00 );
 
 	private:
 		bool IsAuto()const{ return m_auto; }
 		void SetAuto( bool const _state ){ m_auto = _state; }
 
-		void AddAssociation( uint8 const _nodeId );
-		void AddAssociation( uint8 const _nodeId, uint8 const _instance );
-		void RemoveAssociation( uint8 const _nodeId );
-		void RemoveAssociation( uint8 const _nodeId, uint8 const _instance );
+		void AddAssociation( uint8 const _nodeId, uint8 const _instance = 0x00 );
+		void RemoveAssociation( uint8 const _nodeId, uint8 const _instance = 0x00 );
 		void OnGroupChanged( vector<uint8> const& _associations );
 		void OnGroupChanged( vector<InstanceAssociation> const& _associations );
 

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -86,8 +86,8 @@ namespace OpenZWave
 	// Command methods (COMMAND_CLASS_ASSOCIATION_COMMAND_CONFIGURATION)
 	//-----------------------------------------------------------------------------
 	public:
-		bool ClearCommands( uint8 const _nodeId );
-		bool AddCommand( uint8 const _nodeId, uint8 const _length, uint8 const* _data );
+		bool ClearCommands( uint8 const _nodeId, uint8 const _instance = 0x00 );
+		bool AddCommand( uint8 const _nodeId, uint8 const _length, uint8 const* _data, uint8 const _instance = 0x00 );
 
 	private:
 		class AssociationCommand

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3207,24 +3207,6 @@ void Manager::AddAssociation
 		uint32 const _homeId,
 		uint8 const _nodeId,
 		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	if( Driver* driver = GetDriver( _homeId ) )
-	{
-		driver->AddAssociation( _nodeId, _groupIdx, _targetNodeId );
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Manager::AddAssociation>
-// Adds a node to an association group
-//-----------------------------------------------------------------------------
-void Manager::AddAssociation
-(
-		uint32 const _homeId,
-		uint8 const _nodeId,
-		uint8 const _groupIdx,
 		uint8 const _targetNodeId,
 		uint8 const _instance
 )
@@ -3232,25 +3214,6 @@ void Manager::AddAssociation
 	if( Driver* driver = GetDriver( _homeId ) )
 	{
 		driver->AddAssociation( _nodeId, _groupIdx, _targetNodeId, _instance );
-	}
-}
-
-
-//-----------------------------------------------------------------------------
-// <Manager::RemoveAssociation>
-// Removes a node from an association group
-//-----------------------------------------------------------------------------
-void Manager::RemoveAssociation
-(
-		uint32 const _homeId,
-		uint8 const _nodeId,
-		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	if( Driver* driver = GetDriver( _homeId ) )
-	{
-		driver->RemoveAssociation( _nodeId, _groupIdx, _targetNodeId );
 	}
 }
 

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3161,6 +3161,26 @@ uint32 Manager::GetAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::GetAssociations>
+// Gets the associations for a group
+//-----------------------------------------------------------------------------
+uint32 Manager::GetAssociations
+(
+		uint32 const _homeId,
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		InstanceAssociation** o_associations
+)
+{
+	if( Driver* driver = GetDriver( _homeId ) )
+	{
+		return driver->GetAssociations( _nodeId, _groupIdx, o_associations );
+	}
+
+	return 0;
+}
+
+//-----------------------------------------------------------------------------
 // <Manager::GetMaxAssociations>
 // Gets the maximum number of associations for a group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3217,6 +3217,26 @@ void Manager::AddAssociation
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::AddAssociation>
+// Adds a node to an association group
+//-----------------------------------------------------------------------------
+void Manager::AddAssociation
+(
+		uint32 const _homeId,
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	if( Driver* driver = GetDriver( _homeId ) )
+	{
+		driver->AddAssociation( _nodeId, _groupIdx, _targetNodeId, _instance );
+	}
+}
+
+
+//-----------------------------------------------------------------------------
 // <Manager::RemoveAssociation>
 // Removes a node from an association group
 //-----------------------------------------------------------------------------
@@ -3231,6 +3251,25 @@ void Manager::RemoveAssociation
 	if( Driver* driver = GetDriver( _homeId ) )
 	{
 		driver->RemoveAssociation( _nodeId, _groupIdx, _targetNodeId );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <Manager::RemoveAssociation>
+// Removes a node from an association group
+//-----------------------------------------------------------------------------
+void Manager::RemoveAssociation
+(
+		uint32 const _homeId,
+		uint8 const _nodeId,
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	if( Driver* driver = GetDriver( _homeId ) )
+	{
+		driver->RemoveAssociation( _nodeId, _groupIdx, _targetNodeId, _instance );
 	}
 }
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1478,36 +1478,10 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 * \param _nodeId The ID of the node whose associations are to be changed.
 		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
 		 * \param _targetNodeId Identifier for the node that will be added to the association group.
-		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, RemoveAssociation
-		 */
-		void AddAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
-
-		/**
-		 * \brief Adds a node to an association group.
-		 * Due to the possibility of a device being asleep, the command is assumed to suceed, and the association data
-		 * held in this class is updated directly.  This will be reverted by a future Association message from the device
-		 * if the Z-Wave message actually failed to get through.  Notification callbacks will be sent in both cases.
-		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
-		 * \param _nodeId The ID of the node whose associations are to be changed.
-		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
-		 * \param _targetNodeId Identifier for the node that will be added to the association group.
 		 * \param _instance Identifier for the instance that will be added to the association group.
 		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, RemoveAssociation
 		 */
-		void AddAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
-
-		/**
-		 * \brief Removes a node from an association group.
-		 * Due to the possibility of a device being asleep, the command is assumed to suceed, and the association data
-		 * held in this class is updated directly.  This will be reverted by a future Association message from the device
-		 * if the Z-Wave message actually failed to get through.   Notification callbacks will be sent in both cases.
-		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
-		 * \param _nodeId The ID of the node whose associations are to be changed.
-		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
-		 * \param _targetNodeId Identifier for the node that will be removed from the association group.
-		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, AddAssociation
-		 */
-		void RemoveAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
+		void AddAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 
 		/**
 		 * \brief Removes a node from an association group.
@@ -1521,7 +1495,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 * \param _instance Identifier for the instance that will be removed to the association group.
 		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, AddAssociation
 		 */
-		void RemoveAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
+		void RemoveAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 
 	/*@}*/
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1483,6 +1483,20 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		void AddAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
 
 		/**
+		 * \brief Adds a node to an association group.
+		 * Due to the possibility of a device being asleep, the command is assumed to suceed, and the association data
+		 * held in this class is updated directly.  This will be reverted by a future Association message from the device
+		 * if the Z-Wave message actually failed to get through.  Notification callbacks will be sent in both cases.
+		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		 * \param _nodeId The ID of the node whose associations are to be changed.
+		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
+		 * \param _targetNodeId Identifier for the node that will be added to the association group.
+		 * \param _instance Identifier for the instance that will be added to the association group.
+		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, RemoveAssociation
+		 */
+		void AddAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
+
+		/**
 		 * \brief Removes a node from an association group.
 		 * Due to the possibility of a device being asleep, the command is assumed to suceed, and the association data
 		 * held in this class is updated directly.  This will be reverted by a future Association message from the device
@@ -1494,6 +1508,20 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, AddAssociation
 		 */
 		void RemoveAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId );
+
+		/**
+		 * \brief Removes a node from an association group.
+		 * Due to the possibility of a device being asleep, the command is assumed to suceed, and the association data
+		 * held in this class is updated directly.  This will be reverted by a future Association message from the device
+		 * if the Z-Wave message actually failed to get through.   Notification callbacks will be sent in both cases.
+		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		 * \param _nodeId The ID of the node whose associations are to be changed.
+		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
+		 * \param _targetNodeId Identifier for the node that will be removed from the association group.
+		 * \param _instance Identifier for the instance that will be removed to the association group.
+		 * \see GetNumGroups, GetAssociations, GetMaxAssociations, AddAssociation
+		 */
+		void RemoveAssociation( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
 
 	/*@}*/
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -37,6 +37,7 @@
 
 #include "Defs.h"
 #include "Driver.h"
+#include "Group.h"
 #include "value_classes/ValueID.h"
 
 namespace OpenZWave
@@ -1449,6 +1450,19 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 */
 		uint32 GetAssociations( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8** o_associations );
 
+		/**
+		 * \brief Gets the associations for a group.
+		 * Makes a copy of the list of associated nodes in the group, and returns it in an array of InstanceAssociation's.
+		 * The caller is responsible for freeing the array memory with a call to delete [].
+		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		 * \param _nodeId The ID of the node whose associations we are interested in.
+		 * \param _groupIdx One-based index of the group (because Z-Wave product manuals use one-based group numbering).
+		 * \param o_associations If the number of associations returned is greater than zero, o_associations will be set to point to an array containing the IDs and instances of the associated nodes.
+		 * \return The number of items in the associations array.  If zero, the array will point to NULL, and does not need to be deleted.
+		 * \see GetNumGroups, AddAssociation, RemoveAssociation, GetMaxAssociations
+		 */
+		uint32 GetAssociations( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, InstanceAssociation** o_associations );
+			 
 		/**
 		 * \brief Gets the maximum number of associations for a group.
 		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -2631,22 +2631,6 @@ string Node::GetGroupLabel
 void Node::AddAssociation
 (
 		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	if( Group* group = GetGroup( _groupIdx ) )
-	{
-		group->AddAssociation( _targetNodeId );
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Node::AddAssociation>
-// Adds a node to an association group
-//-----------------------------------------------------------------------------
-void Node::AddAssociation
-(
-		uint8 const _groupIdx,
 		uint8 const _targetNodeId,
 		uint8 const _instance
 )
@@ -2654,22 +2638,6 @@ void Node::AddAssociation
 	if( Group* group = GetGroup( _groupIdx ) )
 	{
 		group->AddAssociation( _targetNodeId, _instance  );
-	}
-}
-
-//-----------------------------------------------------------------------------
-// <Node::RemoveAssociation>
-// Removes a node from an association group
-//-----------------------------------------------------------------------------
-void Node::RemoveAssociation
-(
-		uint8 const _groupIdx,
-		uint8 const _targetNodeId
-)
-{
-	if( Group* group = GetGroup( _groupIdx ) )
-	{
-		group->RemoveAssociation( _targetNodeId );
 	}
 }
 

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -48,6 +48,7 @@
 #include "command_classes/ControllerReplication.h"
 #include "command_classes/ManufacturerSpecific.h"
 #include "command_classes/MultiInstance.h"
+#include "command_classes/MultiInstanceAssociation.h"
 #include "command_classes/Security.h"
 #include "command_classes/WakeUp.h"
 #include "command_classes/NodeNaming.h"
@@ -551,18 +552,28 @@ void Node::AdvanceQueries
 			{
 				// if this device supports COMMAND_CLASS_ASSOCIATION, determine to which groups this node belong
 				Log::Write( LogLevel_Detail, m_nodeId, "QueryStage_Associations" );
-				Association* acc = static_cast<Association*>( GetCommandClass( Association::StaticGetCommandClassId() ) );
-				if( acc )
+				MultiInstanceAssociation* macc = static_cast<MultiInstanceAssociation*>( GetCommandClass( MultiInstanceAssociation::StaticGetCommandClassId() ) );
+				if( macc )
 				{
-					acc->RequestAllGroups( 0 );
+					macc->RequestAllGroups( 0 );
 					m_queryPending = true;
 					addQSC = true;
 				}
 				else
 				{
-					// if this device doesn't support Associations, move to retrieve Session information
-					m_queryStage = QueryStage_Neighbors;
-					m_queryRetries = 0;
+					Association* acc = static_cast<Association*>( GetCommandClass( Association::StaticGetCommandClassId() ) );
+					if( acc )
+					{
+						acc->RequestAllGroups( 0 );
+						m_queryPending = true;
+						addQSC = true;
+					}
+					else
+					{
+						// if this device doesn't support Associations, move to retrieve Session information
+						m_queryStage = QueryStage_Neighbors;
+						m_queryRetries = 0;
+					}
 				}
 				break;
 			}
@@ -2630,6 +2641,23 @@ void Node::AddAssociation
 }
 
 //-----------------------------------------------------------------------------
+// <Node::AddAssociation>
+// Adds a node to an association group
+//-----------------------------------------------------------------------------
+void Node::AddAssociation
+(
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	if( Group* group = GetGroup( _groupIdx ) )
+	{
+		group->AddAssociation( _targetNodeId, _instance  );
+	}
+}
+
+//-----------------------------------------------------------------------------
 // <Node::RemoveAssociation>
 // Removes a node from an association group
 //-----------------------------------------------------------------------------
@@ -2642,6 +2670,23 @@ void Node::RemoveAssociation
 	if( Group* group = GetGroup( _groupIdx ) )
 	{
 		group->RemoveAssociation( _targetNodeId );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <Node::RemoveAssociation>
+// Removes a node from an association group
+//-----------------------------------------------------------------------------
+void Node::RemoveAssociation
+(
+		uint8 const _groupIdx,
+		uint8 const _targetNodeId,
+		uint8 const _instance
+)
+{
+	if( Group* group = GetGroup( _groupIdx ) )
+	{
+		group->RemoveAssociation( _targetNodeId, _instance );
 	}
 }
 

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -2589,6 +2589,25 @@ uint32 Node::GetAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Node::GetAssociations>
+// Gets the associations for a group
+//-----------------------------------------------------------------------------
+uint32 Node::GetAssociations
+(
+		uint8 const _groupIdx,
+		InstanceAssociation** o_associations
+)
+{
+	uint32 numAssociations = 0;
+	if( Group* group = GetGroup( _groupIdx ) )
+	{
+		numAssociations = group->GetAssociations( o_associations );
+	}
+
+	return numAssociations;
+}
+
+//-----------------------------------------------------------------------------
 // <Node::GetMaxAssociations>
 // Gets the maximum number of associations for a group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -478,10 +478,8 @@ namespace OpenZWave
 			uint32 GetAssociations( uint8 const _groupIdx, uint8** o_associations );
 			uint8 GetMaxAssociations( uint8 const _groupIdx );
 			string GetGroupLabel( uint8 const _groupIdx );
-			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId );
-			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
-			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId );
-			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
+			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
+			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 			void AutoAssociate();
 
 			// The following methods are not exposed

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -37,6 +37,7 @@
 #include "value_classes/ValueList.h"
 #include "Msg.h"
 #include "platform/TimeStamp.h"
+#include "Group.h"
 
 class TiXmlElement;
 
@@ -476,6 +477,7 @@ namespace OpenZWave
 			// The public interface is provided via the wrappers in the Manager class
 			uint8 GetNumGroups();
 			uint32 GetAssociations( uint8 const _groupIdx, uint8** o_associations );
+			uint32 GetAssociations( uint8 const _groupIdx, InstanceAssociation** o_associations );
 			uint8 GetMaxAssociations( uint8 const _groupIdx );
 			string GetGroupLabel( uint8 const _groupIdx );
 			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -85,6 +85,7 @@ namespace OpenZWave
 			friend class Meter;
 			friend class MeterPulse;
 			friend class MultiInstance;
+			friend class MultiInstanceAssociation;
 			friend class NodeNaming;
 			friend class Protection;
 			friend class Security;
@@ -478,7 +479,9 @@ namespace OpenZWave
 			uint8 GetMaxAssociations( uint8 const _groupIdx );
 			string GetGroupLabel( uint8 const _groupIdx );
 			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId );
+			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
 			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId );
+			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance );
 			void AutoAssociate();
 
 			// The following methods are not exposed

--- a/cpp/src/command_classes/MultiInstanceAssociation.cpp
+++ b/cpp/src/command_classes/MultiInstanceAssociation.cpp
@@ -223,18 +223,6 @@ bool MultiInstanceAssociation::HandleMsg
 			{
 				if( _length >= 5 )
 				{
-//					uint8 numAssociations = _length - 5;
-
-//					Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association report from node %d, group %d, containing %d associations", GetNodeId(), groupIdx, numAssociations );
-//					if( numAssociations )
-//					{
-//						Log::Write( LogLevel_Info, GetNodeId(), "  The group contains:" );
-//						for( i=0; i<numAssociations; ++i )
-//						{
-//							Log::Write( LogLevel_Info, GetNodeId(), "    Node %d",  _data[i+4] );
-//							m_pendingMembers.push_back( _data[i+4] );
-//						}
-//					}
 					// format:
 					//   node A
 					//   node B

--- a/cpp/src/command_classes/MultiInstanceAssociation.cpp
+++ b/cpp/src/command_classes/MultiInstanceAssociation.cpp
@@ -25,11 +25,14 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "tinyxml.h"
 #include "command_classes/CommandClasses.h"
 #include "command_classes/MultiInstanceAssociation.h"
 #include "Defs.h"
 #include "Msg.h"
 #include "Driver.h"
+#include "Node.h"
+#include "Group.h"
 #include "platform/Log.h"
 
 using namespace OpenZWave;
@@ -44,6 +47,145 @@ enum MultiInstanceAssociationCmd
 	MultiInstanceAssociationCmd_GroupingsReport	= 0x06
 };
 
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::ReadXML>
+// Read the saved association data
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::ReadXML
+(
+	TiXmlElement const* _ccElement
+)
+{
+	CommandClass::ReadXML( _ccElement );
+
+	TiXmlElement const* associationsElement = _ccElement->FirstChildElement();
+	while( associationsElement )
+	{
+		char const* str = associationsElement->Value();
+		if( str && !strcmp( str, "Associations" ) )
+		{
+			int intVal;
+			if( TIXML_SUCCESS == associationsElement->QueryIntAttribute( "num_groups", &intVal ) )
+			{
+				m_numGroups = (uint8)intVal;
+			}
+
+			TiXmlElement const* groupElement = associationsElement->FirstChildElement();
+			while( groupElement )
+			{
+				if( Node* node = GetNodeUnsafe() )
+				{
+					Group* group = new Group( GetHomeId(), GetNodeId(), groupElement );
+					node->AddGroup( group );
+				}
+
+				groupElement = groupElement->NextSiblingElement();
+			}
+
+			break;
+		}
+
+		associationsElement = associationsElement->NextSiblingElement();
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::WriteXML>
+// Save the association data
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::WriteXML
+(
+	TiXmlElement* _ccElement
+)
+{
+	CommandClass::WriteXML( _ccElement );
+
+	if( Node* node = GetNodeUnsafe() )
+	{
+		TiXmlElement* associationsElement = new TiXmlElement( "Associations" );
+
+		char str[8];
+		snprintf( str, 8, "%d", m_numGroups );
+		associationsElement->SetAttribute( "num_groups", str );
+
+		_ccElement->LinkEndChild( associationsElement );
+		node->WriteGroups( associationsElement );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::RequestState>
+// Nothing to do for Association
+//-----------------------------------------------------------------------------
+bool MultiInstanceAssociation::RequestState
+(
+	uint32 const _requestFlags,
+	uint8 const _instance,
+	Driver::MsgQueue const _queue
+)
+{
+	if( ( _requestFlags & RequestFlag_Static ) && HasStaticRequest( StaticRequest_Values ) )
+	{
+		// Request the supported group info
+		return RequestValue( _requestFlags, 0, _instance, _queue );
+	}
+
+	return false;
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::RequestValue>
+// Nothing to do for Association
+//-----------------------------------------------------------------------------
+bool MultiInstanceAssociation::RequestValue
+(
+	uint32 const _requestFlags,
+	uint8 const _dummy1,	// = 0 (not used)
+	uint8 const _instance,
+	Driver::MsgQueue const _queue
+)
+{
+	if( _instance != 1 )
+	{
+		// This command class doesn't work with multiple instances
+		return false;
+	}
+	// Request the supported group info
+	Msg* msg = new Msg( "MultiInstanceAssociationCmd_GroupingsGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
+	msg->Append( GetNodeId() );
+	msg->Append( 2 );
+	msg->Append( GetCommandClassId() );
+	msg->Append( MultiInstanceAssociationCmd_GroupingsGet );
+	msg->Append( GetDriver()->GetTransmitOptions() );
+	GetDriver()->SendMsg( msg, _queue );
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+// <Association::RequestAllGroups>
+// Request the contents of each group in turn
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::RequestAllGroups
+(
+	uint32 const _requestFlags
+)
+{
+	m_queryAll = true;
+
+	// Request the contents of the individual groups in turn.
+	if( m_numGroups == 0xff )
+	{
+		// We start with group 255, and will then move to group 1, 2 etc and stop when we find a group with a maxAssociations of zero.
+		Log::Write( LogLevel_Info, GetNodeId(), "Number of association groups reported for node %d is 255, which requires special case handling.", GetNodeId() );
+		QueryGroup( 0xff, _requestFlags );
+	}
+	else
+	{
+		// We start with group 1, and will then move to group 2, 3 etc and stop when the group index is greater than m_numGroups.
+		Log::Write( LogLevel_Info, GetNodeId(), "Number of association groups reported for node %d is %d.", GetNodeId(), m_numGroups );
+		QueryGroup( 1, _requestFlags );
+	}
+}
 
 //-----------------------------------------------------------------------------
 // <MultiInstanceAssociation::HandleMsg>
@@ -56,6 +198,253 @@ bool MultiInstanceAssociation::HandleMsg
 	uint32 const _instance	// = 1
 )
 {
-	return false;
+	bool handled = false;
+	uint32 i;
+
+	if( Node* node = GetNodeUnsafe() )
+	{
+		if( MultiInstanceAssociationCmd_GroupingsReport == (MultiInstanceAssociationCmd)_data[0] )
+		{
+			// Retrieve the number of groups this device supports.
+			// The groups will be queried with the session data.
+			m_numGroups = _data[1];
+			Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association Groupings report from node %d. Number of groups is %d", GetNodeId(), m_numGroups );
+			ClearStaticRequest( StaticRequest_Values );
+			handled = true;
+		}
+		else if( MultiInstanceAssociationCmd_Report == (MultiInstanceAssociationCmd)_data[0] )
+		{
+			// Get the group info
+			uint8 groupIdx = _data[1];
+			uint8 maxAssociations = _data[2];		// If the maxAssociations is zero, this is not a supported group.
+			uint8 numReportsToFollow = _data[3];	// If a device supports a lot of associations, they may come in more than one message.
+
+			if( maxAssociations )
+			{
+				if( _length >= 5 )
+				{
+//					uint8 numAssociations = _length - 5;
+
+//					Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association report from node %d, group %d, containing %d associations", GetNodeId(), groupIdx, numAssociations );
+//					if( numAssociations )
+//					{
+//						Log::Write( LogLevel_Info, GetNodeId(), "  The group contains:" );
+//						for( i=0; i<numAssociations; ++i )
+//						{
+//							Log::Write( LogLevel_Info, GetNodeId(), "    Node %d",  _data[i+4] );
+//							m_pendingMembers.push_back( _data[i+4] );
+//						}
+//					}
+					// format:
+					//   node A
+					//   node B
+					//   0x00 Marker
+					//   node C 
+					//   instance #
+					//   node D
+					//   instance #
+					Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association report from node %d, group %d", GetNodeId(), groupIdx );
+					Log::Write( LogLevel_Info, GetNodeId(), "  The group contains:" );
+					bool pastMarker = false;
+					for( i=0; i < _length-5; ++i )
+					{	
+						if (_data[i+4] == 0x00)
+						{
+							pastMarker = true;
+						} 
+						else 
+						{
+							if (!pastMarker)
+							{
+								Log::Write( LogLevel_Info, GetNodeId(), "    Node %d",  _data[i+4] );
+								InstanceAssociation association;
+								association.m_nodeId=_data[i+4];
+								association.m_instance=0x00;
+								m_pendingMembers.push_back( association );
+							} 
+							else 
+							{
+								Log::Write( LogLevel_Info, GetNodeId(), "    Node %d instance %d",  _data[i+4], _data[i+5] );
+								InstanceAssociation association;
+								association.m_nodeId=_data[i+4];
+								association.m_instance=_data[i+5];								
+								m_pendingMembers.push_back( association );
+								i++;
+							}
+						}
+					}
+				}
+
+				if( numReportsToFollow )
+				{
+					// We're expecting more reports for this group
+					Log::Write( LogLevel_Info, GetNodeId(), "%d more association reports expected for node %d, group %d", numReportsToFollow, GetNodeId(), groupIdx );
+					return true;
+				}
+				else
+				{
+					// No more reports to come for this group, so we can apply the pending list
+					Group* group = node->GetGroup( groupIdx );
+					if( NULL == group )
+					{
+						// Group has not been created yet
+						group = new Group( GetHomeId(), GetNodeId(), groupIdx, maxAssociations );
+						node->AddGroup( group );
+					}
+
+					// Update the group with its new contents
+					group->OnGroupChanged( m_pendingMembers );
+					m_pendingMembers.clear();
+				}
+			}
+			else
+			{
+				// maxAssociations is zero, so we've reached the end of the query process
+				Log::Write( LogLevel_Info, GetNodeId(), "Max associations for node %d, group %d is zero.  Querying associations for this node is complete.", GetNodeId(), groupIdx );
+				node->AutoAssociate();
+				m_queryAll = false;
+			}
+
+			if( m_queryAll )
+			{
+				// Work out which is the next group we will query.
+				// If we are currently on group 255, the next group will be 1.
+				uint8 nextGroup = groupIdx + 1;
+				if( !nextGroup )
+				{
+					nextGroup = 1;
+				}
+
+				if( nextGroup <= m_numGroups )
+				{
+					// Query the next group
+					QueryGroup( nextGroup, 0 );
+				}
+				else
+				{
+					// We're all done
+					Log::Write( LogLevel_Info, GetNodeId(), "Querying associations for node %d is complete.", GetNodeId() );
+					node->AutoAssociate();
+					m_queryAll = false;
+				}
+			}
+
+			handled = true;
+		}
+	}
+
+	return handled;
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::QueryGroup>
+// Request details of an association group
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::QueryGroup
+(
+	uint8 _groupIdx,
+	uint32 const _requestFlags
+)
+{
+	if ( IsGetSupported() )
+	{
+		Log::Write( LogLevel_Info, GetNodeId(), "Get MultiInstanceAssociation for group %d of node %d", _groupIdx, GetNodeId() );
+		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
+		msg->Append( GetNodeId() );
+		msg->Append( 3 );
+		msg->Append( GetCommandClassId() );
+		msg->Append( MultiInstanceAssociationCmd_Get );
+		msg->Append( _groupIdx );
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+		return;
+	} else {
+		Log::Write(  LogLevel_Info, GetNodeId(), "MultiInstanceAssociationCmd_Get Not Supported on this node");
+	}
+	return;
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::Set>
+// Add an association between devices
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::Set
+(
+	uint8 _groupIdx,
+	uint8 _targetNodeId,
+ 	uint8 _instance
+)
+{
+	Log::Write( LogLevel_Info, GetNodeId(), "MultiInstanceAssociation::Set - Adding instance %d on node %d to group %d of node %d", 
+	           _instance, _targetNodeId, _groupIdx, GetNodeId() );
+
+	if ( _instance == 0x00 )
+	{
+		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
+		msg->Append( GetNodeId() );
+		msg->Append( 4 );
+		msg->Append( GetCommandClassId() );
+		msg->Append( MultiInstanceAssociationCmd_Set );
+		msg->Append( _groupIdx );
+		msg->Append( _targetNodeId );
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+	}
+	else 
+	{		
+		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
+		msg->Append( GetNodeId() );
+		msg->Append( 6 );
+		msg->Append( GetCommandClassId() );
+		msg->Append( MultiInstanceAssociationCmd_Set );
+		msg->Append( _groupIdx );
+		msg->Append( 0x00 ); // marker
+		msg->Append( _targetNodeId );
+		msg->Append( _instance );	
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <MultiInstanceAssociation::Remove>
+// Remove an association between devices
+//-----------------------------------------------------------------------------
+void MultiInstanceAssociation::Remove
+(
+	uint8 _groupIdx,
+	uint8 _targetNodeId,
+ 	uint8 _instance
+)
+{
+	Log::Write( LogLevel_Info, GetNodeId(), "MultiInstanceAssociation::Remove - Removing instance %d on node %d from group %d of node %d",
+	           _instance, _targetNodeId, _groupIdx, GetNodeId());
+
+	if ( _instance == 0x00 )
+	{
+		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Remove", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
+		msg->Append( GetNodeId() );
+		msg->Append( 4 );
+		msg->Append( GetCommandClassId() );
+		msg->Append( MultiInstanceAssociationCmd_Remove );
+		msg->Append( _groupIdx );
+		msg->Append( _targetNodeId );
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+	}
+	else
+	{
+		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Remove", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
+		msg->Append( GetNodeId() );
+		msg->Append( 6 );
+		msg->Append( GetCommandClassId() );
+		msg->Append( MultiInstanceAssociationCmd_Remove );
+		msg->Append( _groupIdx );
+		msg->Append( 0x00 ); // marker
+		msg->Append( _targetNodeId );
+		msg->Append( _instance );	
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+	}
 }
 

--- a/cpp/src/command_classes/MultiInstanceAssociation.h
+++ b/cpp/src/command_classes/MultiInstanceAssociation.h
@@ -29,6 +29,7 @@
 #define _MultiInstanceAssociation_H
 
 #include <vector>
+#include "Group.h"
 #include "command_classes/CommandClass.h"
 
 namespace OpenZWave
@@ -37,6 +38,8 @@ namespace OpenZWave
 	 */
 	class MultiInstanceAssociation: public CommandClass
 	{
+		friend class Group;
+		
 	public:
 		static CommandClass* Create( uint32 const _homeId, uint8 const _nodeId ){ return new MultiInstanceAssociation( _homeId, _nodeId ); }
 		virtual ~MultiInstanceAssociation(){}
@@ -45,12 +48,27 @@ namespace OpenZWave
 		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_MULTI_INSTANCE_ASSOCIATION"; }
 
 		// From CommandClass
+		virtual void ReadXML( TiXmlElement const* _ccElement );
+		virtual void WriteXML( TiXmlElement* _ccElement );
+		virtual bool RequestState( uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue );
+		virtual bool RequestValue( uint32 const _requestFlags, uint8 const _index, uint8 const _instance, Driver::MsgQueue const _queue );			
 		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }		
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
 
+		void RequestAllGroups( uint32 const _requestFlags );
+		void Set( uint8 const _group, uint8 const _nodeId, uint8 const _instance );
+		void Remove( uint8 const _group, uint8 const _nodeId, uint8 const _instance );
+			
 	private:
 		MultiInstanceAssociation( uint32 const _homeId, uint8 const _nodeId ): CommandClass( _homeId, _nodeId ){}
+		void QueryGroup( uint8 _groupIdx, uint32 const _requestFlags );
+		void AutoAssociate();
+
+		bool			m_queryAll;			// When true, once a group has been queried, we request the next one.
+		uint8			m_numGroups;		// Number of groups supported by the device.  255 is reported by certain manufacturers and requires special handling.
+		vector<InstanceAssociation>	m_pendingMembers;	// Used to build a list of group members from multiple reports
+			
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
This is an initial attempt to add MultiInstanceAssociation support, and not intended to actually be pulled. 
Since there is some impact on the manager and driver classes I would like some feedback on what the best approach is to continue this work.
Thus far adding a instance association works. 

Some questions:
- do we want both version of 
```
		void AddAssociation( uint8 const _nodeId );
		void AddAssociation( uint8 const _nodeId, uint8 const _instance );
```
or only the last where passing 0x00 as instance would give you the original behavior?

- do we want method signature like this: 
```
		void AddAssociation( uint8 const _nodeId, uint8 const _instance );
```
or
```
		void AddAssociation( InstanceAssociation const _association);
```

On my todo list is:
- testing removing
- restoring COMMAND_CLASS_ASSOCIATION_COMMAND_CONFIGURATION support
- reporting association with instances in manager/driver 
- check why zwcfg_0xxxxx.xml does not contain instances associations
- ???
