### PR TITLE
Add function 'getVersionLongAsString' which returns the full version:…

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -64,6 +64,7 @@ Manager* Manager::s_instance = NULL;
 extern uint16_t ozw_vers_major;
 extern uint16_t ozw_vers_minor;
 extern uint16_t ozw_vers_revision;
+extern char ozw_version_string[];
 
 //-----------------------------------------------------------------------------
 //	Construction
@@ -114,6 +115,15 @@ std::string Manager::getVersionAsString() {
 	std::ostringstream versionstream;
 	versionstream << ozw_vers_major << "." << ozw_vers_minor << "." << ozw_vers_revision;
 	return versionstream.str();
+}
+//-----------------------------------------------------------------------------
+//      <Manager::getVersionLong>
+//      Static method to get the long Version of OZW as a string.
+//-----------------------------------------------------------------------------
+std::string Manager::getVersionLongAsString() {
+        std::ostringstream versionstream;
+        versionstream << ozw_version_string;
+        return versionstream.str();
 }
 //-----------------------------------------------------------------------------
 //	<Manager::getVersion>

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -161,6 +161,12 @@ namespace OpenZWave
 		static std::string getVersionAsString();
 
 		/**
+                 * \brief Get the Version Number including Git commit of OZW as a string
+                 * \return a String representing the version number as MAJOR.MINOR.REVISION-gCOMMIT
+                 */
+                static std::string getVersionLongAsString();
+
+                /**
 		 * \brief Get the Version Number as the Version Struct (Only Major/Minor returned)
 		 * \return the version struct representing the version
 		 */


### PR DESCRIPTION
… including the Git commit hash OZW was build from.