### PR TITLE
Fixed windows build event (winversion.cpp generation)

### DIFF
--- a/cpp/build/windows/vs2010/OpenZWave.vcxproj
+++ b/cpp/build/windows/vs2010/OpenZWave.vcxproj
@@ -101,7 +101,7 @@
     </Lib>
     <PreBuildEvent>
       <Command>del ..\winversion.cpp
-CALL $(SolutionDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp" 
+CALL $(ProjectDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp"
 exit 0</Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -134,7 +134,7 @@ exit 0</Command>
     </Link>
     <PreBuildEvent>
       <Command>del ..\winversion.cpp
-CALL $(SolutionDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp" 
+CALL $(ProjectDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp"
 exit 0</Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -167,7 +167,7 @@ exit 0</Command>
     <PreBuildEvent>
       <Message>Export GIT Revision</Message>
       <Command>del ..\winversion.cpp
-CALL $(SolutionDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp" 
+CALL $(ProjectDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp"
 exit 0</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -190,7 +190,7 @@ exit 0</Command>
     </Lib>
     <PreBuildEvent>
       <Command>del ..\winversion.cpp
-CALL $(SolutionDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp" 
+CALL $(ProjectDir)\..\GIT-VS-VERSION-GEN.bat "$(ProjectDir)\" "..\winversion.cpp"
 exit 0</Command>
     </PreBuildEvent>
     <PreBuildEvent>


### PR DESCRIPTION
The MinOZW solution incorporates the OpenZWave project and its build is broken due to the SolutionDir macro.
Changed $(SolutionDir) to $(ProjectDir) to fix