### PR TITLE
add database support for the Cooper all load dimmer and configuration for Cooper outlet

### DIFF
--- a/config/cooper/RF9505-T.xml
+++ b/config/cooper/RF9505-T.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="byte" index="2" genre="config" label="Panic ON time" units="seconds" min="1" max="255" value="0">
+		  <Help>
+		  The amount of time in seconds the switch will turn on for when panic mode is trigered.  The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="byte" index="3" genre="config" label="Panic OFF time" units="seconds" min="1" max="255" value="0">
+		  <Help>
+		  The amount of time in seconds the switch will turn off for when panic mode is triggered.  The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="list" index="5" genre="config" label="Power Up State" units="" min="1" max="3" value="3">
+		  <Help>
+		    Power up state of the device
+		  </Help>
+		  <Item label="OFF" value="1"/>
+		  <Item label="ON" value="2"/>
+		  <Item label="Last state" value="3"/>
+		</Value>
+		<Value type="list" index="6" genre="config" label="Panic mode enable" units="" min="0" max="1" value="0">
+		  <Help>
+		    Enables this device to participate in panic mode
+		  </Help>
+		  <Item label="OFF" value="0"/>
+		  <Item label="ON" value="1"/>
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="2">
+        		<Group index="1" max_associations="5" label="Group #1" auto="true"/>
+			<Group index="255" max_associations="1" label="Group #255" />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/cooper/RF9540-N.xml
+++ b/config/cooper/RF9540-N.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="byte" index="1" genre="config" label="Delayed OFF time" units="seconds" min="0" max="255" value="0">
+		  <Help>
+			The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="byte" index="2" genre="config" label="Panic ON time" units="seconds" min="1" max="255" value="0">
+		  <Help>
+		  The amount of time in seconds the switch will turn on for when panic mode is trigered.  The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="byte" index="3" genre="config" label="Panic OFF time" units="seconds" min="1" max="255" value="0">
+		  <Help>
+		  The amount of time in seconds the switch will turn off for when panic mode is triggered.  The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="byte" index="4" genre="config" label="Basic set value" units="" min="1" max="255" value="0">
+		  <Help>
+		  Setting this to anything other than 0 will cause the value to be transmitted to devices in the association group when the switch is triggered. A setting other than 0 will likely result in undesired operation
+		  </Help>
+		</Value>
+		<Value type="list" index="5" genre="config" label="Power Up State" units="" min="1" max="3" value="3">
+		  <Help>
+		    Power up state of the device
+		  </Help>
+		  <Item label="OFF" value="1"/>
+		  <Item label="ON" value="2"/>
+		  <Item label="Last state" value="3"/>
+		</Value>
+		<Value type="list" index="6" genre="config" label="Panic mode enable" units="" min="1" max="2" value="1">
+		  <Help>
+		    Enables this switch to participate in panic mode
+		  </Help>
+		  <Item label="OFF" value="1"/>
+		  <Item label="ON" value="2"/>
+		</Value>
+		<Value type="byte" index="7" genre="config" label="Dimmer Ramp Time" units="seconds" min="0" max="255" value="0">
+		  <Help>
+		  The amount of time in seconds the switch will take to reach the desired dim level.  The configuration value is a signed single byte number. This value may represent a value with no units or may represent a value such as time. 0 to 127 (decimal) represents 0 to 127 seconds of time. -128 to -1 (negative decimal numbers) represents 128 to 255 seconds as calculated by this formula.  Config value = desired time in seconds (or desired value) -256 For an example of 172 seconds: config value = 172 - 256 = -84 (decimal) or 0xAC (hex) 
+		  </Help>
+		</Value>
+		<Value type="list" index="8" genre="config" label="Kickstart / Rapid Start" units="" min="0" max="1" value="0">
+		  <Help>
+		  	Ensures that LED / CFL bulbs turn on when the preset dim level is low.  Enabling this feature may cause the lights brightness to momentarily be bright when the switch is turned on before reducing in brightness to desired level
+		  </Help>
+		  <Item label="disable" value="0"/>
+		  <Item label="enable" value="1"/>
+		</Value>
+		<Value type="byte" index="11" genre="config" label="Minimum Dimmer Level" units="" min="4" max="99" value="4">
+		  <Help>
+		  The minimum dim level the switch will allow.  The minimum level must always be at least 13 below the maximum level.
+		  </Help>
+		</Value>
+		<Value type="byte" index="12" genre="config" label="Maximum Dimmer Level" units="" min="4" max="99" value="99">
+		  <Help>
+		  The maximum dim level the switch will allow.  The maximum level must always be at least 13 above the minimum level.
+		  </Help>
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="2">
+        		<Group index="1" max_associations="5" label="Group #1" auto="true"/>
+			<Group index="255" max_associations="1" label="Group #255" />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -131,7 +131,8 @@
 	</Manufacturer>
 	<Manufacturer id="001a" name="Cooper">
 		<Product type="4449" id="0002" name="RF9534DS Wall Dimmer Module"/>
-		<Product type="5244" id="0000" name="RF9505-TWS Split Control Duplex Receptacle"/>
+		<Product type="4449" id="0101" name="RF9540-N All Load Dimmer Light Switch" config="cooper/RF9540-N.xml"/>
+		<Product type="5244" id="0000" name="RF9505-T Split Control Duplex Receptacle" config="cooper/RF9505-T.xml"/>
 	</Manufacturer>
 	<Manufacturer id="009d" name="Coventive">
 	</Manufacturer>


### PR DESCRIPTION
This relates to issues #563.  It adds database support for the Cooper Aspire RF 9540 all load dimmer as well as add configuration support for the Cooper Aspire RF 9505 split duplex outlet