### PR TITLE
Fixed sending color command, Disable other colors when sending value

### DIFF
--- a/cpp/src/command_classes/Color.cpp
+++ b/cpp/src/command_classes/Color.cpp
@@ -25,10 +25,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <iostream>
-#include <iomanip>
-
-
 #include "command_classes/CommandClasses.h"
 #include "command_classes/Color.h"
 #include "Defs.h"
@@ -41,7 +37,7 @@
 #include "value_classes/ValueString.h"
 
 #include "tinyxml.h"
-
+#include <iomanip>
 
 using namespace OpenZWave;
 
@@ -50,7 +46,7 @@ enum ColorCmd
 	ColorCmd_Capability_Get = 0x01,
 	ColorCmd_Capability_Report = 0x02,
 	ColorCmd_Get = 0x03,
-	ColorCmd_Report = 0x04,
+	ColorCmd_Get_Report = 0x04,
 	ColorCmd_Set = 0x05,
 };
 
@@ -65,7 +61,6 @@ enum ColorCmd
 //7=Purple (for 6ch Color mixing)  (0x00 - 0xFF: 0 100%)
 //8=Indexed Color (0x00 0x0FF: Color Index 0 - 255
 
-
 enum ColorIDX {
 	COLORIDX_WARMWHITE,
 	COLORIDX_COLDWHITE,
@@ -78,22 +73,20 @@ enum ColorIDX {
 	COLORIDX_INDEXCOLOR
 };
 
-
 Color::Color
 (
-		uint32 const _homeId,
-		uint8 const _nodeId
-):
-CommandClass( _homeId, _nodeId ),
-m_capabilities ( 0 ),
-m_coloridxbug ( false ),
-m_coloridxcount ( 0 )
+uint32 const _homeId,
+uint8 const _nodeId
+) :
+CommandClass(_homeId, _nodeId),
+m_capabilities(0),
+m_coloridxbug(false),
+m_coloridxcount(0)
 {
 	for (uint8 i = 0; i < 9; i++)
 		m_colorvalues[i] = 0;
-	SetStaticRequest( StaticRequest_Values );
+	SetStaticRequest(StaticRequest_Values);
 }
-
 
 //-----------------------------------------------------------------------------
 // <Color::ReadXML>
@@ -101,22 +94,22 @@ m_coloridxcount ( 0 )
 //-----------------------------------------------------------------------------
 void Color::ReadXML
 (
-		TiXmlElement const* _ccElement
+TiXmlElement const* _ccElement
 )
 {
-	CommandClass::ReadXML( _ccElement );
+	CommandClass::ReadXML(_ccElement);
 
 	int32 intVal;
-	if( TIXML_SUCCESS == _ccElement->QueryIntAttribute( "colorchannels", &intVal ) )
+	if (TIXML_SUCCESS == _ccElement->QueryIntAttribute("colorchannels", &intVal))
 	{
 		if (intVal <= 0x100) {
 			m_capabilities = (uint16)intVal;
 		}
 	}
 	char const* str = _ccElement->Attribute("coloridxbug");
-	if( str )
+	if (str)
 	{
-		m_coloridxbug = !strcmp( str, "true");
+		m_coloridxbug = !strcmp(str, "true");
 	}
 }
 
@@ -126,24 +119,22 @@ void Color::ReadXML
 //-----------------------------------------------------------------------------
 void Color::WriteXML
 (
-		TiXmlElement* _ccElement
+TiXmlElement* _ccElement
 )
 {
-	CommandClass::WriteXML( _ccElement );
+	CommandClass::WriteXML(_ccElement);
 
 	char str[32];
-	if( m_capabilities != 0 )
+	if (m_capabilities != 0)
 	{
-		snprintf( str, sizeof(str), "%d", m_capabilities );
-		_ccElement->SetAttribute( "colorchannels", str );
+		snprintf(str, sizeof(str), "%d", m_capabilities);
+		_ccElement->SetAttribute("colorchannels", str);
 	}
-	if( m_coloridxbug )
+	if (m_coloridxbug)
 	{
-		_ccElement->SetAttribute( "coloridxbug", "true" );
+		_ccElement->SetAttribute("coloridxbug", "true");
 	}
 }
-
-
 
 //-----------------------------------------------------------------------------
 // <Color::RequestState>
@@ -151,13 +142,13 @@ void Color::WriteXML
 //-----------------------------------------------------------------------------
 bool Color::RequestState
 (
-		uint32 const _requestFlags,
-		uint8 const _instance,
-		Driver::MsgQueue const _queue
+	uint32 const _requestFlags,
+	uint8 const _instance,
+	Driver::MsgQueue const _queue
 )
 {
 	bool requests = false;
-	if( ( _requestFlags & RequestFlag_Static ) && HasStaticRequest( StaticRequest_Values ) )
+	if ((_requestFlags & RequestFlag_Static) && HasStaticRequest(StaticRequest_Values))
 	{
 		Msg* msg = new Msg("ColorCmd_CapabilityGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
 		msg->Append(GetNodeId());
@@ -171,11 +162,11 @@ bool Color::RequestState
 	if (_requestFlags & RequestFlag_Dynamic)
 	{
 		/* do a request for each channel. the RequestValue will filter out channels that are not supported
-		 * by the device
-		 */
+		* by the device
+		*/
 		/* if the device has the ColorIDX bug, then only request the first channel. We will get the rest later */
 		for (int i = 0; i <= 9; i++) {
-			bool tmprequests = RequestValue( _requestFlags, i, _instance, _queue );
+			bool tmprequests = RequestValue(_requestFlags, i, _instance, _queue);
 			requests |= tmprequests;
 			if (m_coloridxbug && tmprequests)
 				break;
@@ -191,25 +182,30 @@ bool Color::RequestState
 //-----------------------------------------------------------------------------
 bool Color::RequestValue
 (
-		uint32 const _requestFlags,
-		uint8 const coloridx,
-		uint8 const _instance,
-		Driver::MsgQueue const _queue
+	uint32 const _requestFlags,
+	uint8 const coloridx,
+	uint8 const _instance,
+	Driver::MsgQueue const _queue
 )
 {
-	if( IsGetSupported() )
+	/* rework this so we split out the coloridx from value index. This will then enable us to either start a
+	* refresh for valueID's based on index, or a call from other methods to get a particular color.
+	*/
+
+
+	if (IsGetSupported())
 	{
 		/* make sure our coloridx is valid */
-		if ((m_capabilities) & (1<<(coloridx))) {
+		if ((m_capabilities)& (1 << (coloridx))) {
 			Msg* msg = new Msg("ColorCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
-			msg->SetInstance( this, _instance );
-			msg->Append( GetNodeId() );
-			msg->Append( 3 );
-			msg->Append( GetCommandClassId() );
-			msg->Append( ColorCmd_Get );
-			msg->Append( coloridx );
-			msg->Append( GetDriver()->GetTransmitOptions() );
-			GetDriver()->SendMsg( msg, _queue );
+			msg->SetInstance(this, _instance);
+			msg->Append(GetNodeId());
+			msg->Append(3);
+			msg->Append(GetCommandClassId());
+			msg->Append(ColorCmd_Get);
+			msg->Append(coloridx);
+			msg->Append(GetDriver()->GetTransmitOptions());
+			GetDriver()->SendMsg(msg, _queue);
 			m_coloridxcount = coloridx;
 			return true;
 		}
@@ -224,9 +220,9 @@ bool Color::RequestValue
 //-----------------------------------------------------------------------------
 bool Color::HandleMsg
 (
-		uint8 const* _data,
-		uint32 const _length,
-		uint32 const _instance	// = 1
+	uint8 const* _data,
+	uint32 const _length,
+	uint32 const _instance	// = 1
 )
 {
 	if (ColorCmd_Capability_Report == (ColorCmd)_data[0])
@@ -251,42 +247,39 @@ bool Color::HandleMsg
 			Log::Write(LogLevel_Info, GetNodeId(), "Purple (0x07)");
 		if (m_capabilities & 0x100)
 			Log::Write(LogLevel_Info, GetNodeId(), "Indexed Color (0x08)");
-		if( ValueInt* colorchannels = static_cast<ValueInt*>( GetValue( _instance, 254 ) ) )
+
+		if (ValueInt* colorchannels = static_cast<ValueInt*>(GetValue(_instance, 254)))
 		{
-			colorchannels->OnValueRefreshed( m_capabilities );
+			colorchannels->OnValueRefreshed(m_capabilities);
 			colorchannels->Release();
 		}
 		if (m_capabilities & 0x100) {
-			if( Node* node = GetNodeUnsafe() )
+			if (Node* node = GetNodeUnsafe())
 			{
-				node->CreateValueInt( ValueID::ValueGenre_User, GetCommandClassId(), _instance, 2, "Color Index", "", false, false, 0, 0 );
+				node->CreateValueInt(ValueID::ValueGenre_User, GetCommandClassId(), _instance, 2, "Color Index", "", false, false, 0, 0);
 			}
 		}
-
-
-
-
 		return true;
 	}
-	if (ColorCmd_Report == (ColorCmd)_data[0])
+	if (ColorCmd_Get_Report == (ColorCmd)_data[0])
 	{
 		/* Fibaro is messed up. It always returns 0x03 as the Coloridx in a report message, but the values are correct for what the request was.
-		 * I read a forum post about it being a bug. If this is a case, its going to make this class messy as hell :(
-		 *
-		 * http://forum.z-wave.me/viewtopic.php?f=3422&t=20042
-		 *
-		 * Received: 0x01, 0x0a, 0x00, 0x04, 0x00, 0x34, 0x04, 0x33, 0x04, 0x03, 0xff, 0x0a
-		 *                                                                 ^^^^
-		 *                                                                 Always 0x03
-		 *                                                                       ^^^^
-		 *                                                                       But this appears to be the right value for the channel we requested
-		 *
-		 */
+		* I read a forum post about it being a bug. If this is the case, its going to make this class messy as hell :(
+		*
+		* http://forum.z-wave.me/viewtopic.php?f=3422&t=20042
+		*
+		* Received: 0x01, 0x0a, 0x00, 0x04, 0x00, 0x34, 0x04, 0x33, 0x04, 0x03, 0xff, 0x0a
+		*                                                                 ^^^^
+		*                                                                 Always 0x03
+		*                                                                       ^^^^
+		*                                                                       But this appears to be the right value for the channel we requested
+		*
+		*/
 		/* request the next color index if we are bugged */
 		uint8 coloridx = _data[1];
 		if (m_coloridxbug) {
 			coloridx = m_coloridxcount;
-			for (uint8 idx = m_coloridxcount + 1; idx < 9; idx++ ) {
+			for (uint8 idx = m_coloridxcount + 1; idx < 9; idx++) {
 				if (RequestValue(0, idx, _instance, Driver::MsgQueue_Send)) {
 					m_coloridxcount = idx;
 					break;
@@ -296,14 +289,14 @@ bool Color::HandleMsg
 		m_colorvalues[coloridx] = _data[2];
 
 		/* test if there are any more valid coloridx */
-		for ( uint8 idx = coloridx+1; idx < 9; idx++ ) {
-			if ((m_capabilities) & (1<<(idx))) {
+		for (uint8 idx = coloridx + 1; idx < 9; idx++) {
+			if ((m_capabilities)& (1 << (idx))) {
 				return true;
 			}
 		}
 
 		/* if we get here, then we can update our ValueID */
-		if( ValueString* color = static_cast<ValueString*>( GetValue( _instance, 1 ) ) )
+		if (ValueString* color = static_cast<ValueString*>(GetValue(_instance, 1)))
 		{
 			/* create a RGB[W] String */
 			std::stringstream ss;
@@ -311,39 +304,42 @@ bool Color::HandleMsg
 			bool usingbuf = false;
 			ss << "#";
 			/* do R */
-			if ((m_capabilities) & (1<<(COLORIDX_RED)))
+			if ((m_capabilities)& (1 << (COLORIDX_RED)))
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_RED];
 			else
 				ss << "00";
 			/* do G */
-			if ((m_capabilities) & (1<<(COLORIDX_GREEN)))
+			if ((m_capabilities)& (1 << (COLORIDX_GREEN)))
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_GREEN];
 			else
 				ss << "00";
 			/* do B */
-			if ((m_capabilities) & (1<<(COLORIDX_BLUE)))
+			if ((m_capabilities)& (1 << (COLORIDX_BLUE)))
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_BLUE];
 			else
 				ss << "00";
 
 			/* if both whites are present.... */
-			if (((m_capabilities) & (1<<(COLORIDX_WARMWHITE)))
-					& ((m_capabilities) & (1<<(COLORIDX_COLDWHITE)))) {
+			if (((m_capabilities)& (1 << (COLORIDX_WARMWHITE)))
+				& ((m_capabilities)& (1 << (COLORIDX_COLDWHITE)))) {
 				/* append them both */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_WARMWHITE];
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_COLDWHITE];
-			} else if ((m_capabilities) & (1<<(COLORIDX_WARMWHITE))) {
+			}
+			else if ((m_capabilities)& (1 << (COLORIDX_WARMWHITE))) {
 				/* else, if the warm white is present, append that */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_WARMWHITE];
-			} else if ((m_capabilities) & (1<<(COLORIDX_COLDWHITE))) {
+			}
+			else if ((m_capabilities)& (1 << (COLORIDX_COLDWHITE))) {
 				/* else, if the cold white is present, append that */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_COLDWHITE];
-			} else {
+			}
+			else {
 				/* we put 0000 into our buffer to represent both Warm and Cold white */
 				ssbuf << "0000";
 				usingbuf = true;
 			}
-			if ((m_capabilities) & (1<<(COLORIDX_AMBER))) {
+			if ((m_capabilities)& (1 << (COLORIDX_AMBER))) {
 				/* if AMBER is present, append our buffer if needed */
 				if (usingbuf) {
 					ss << ssbuf.str();
@@ -353,12 +349,13 @@ bool Color::HandleMsg
 				}
 				/* and then our Color */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_AMBER];
-			} else {
+			}
+			else {
 				/* put 00 into our buffer */
 				ssbuf << "00";
 				usingbuf = true;
 			}
-			if ((m_capabilities) & (1<<(COLORIDX_CYAN))) {
+			if ((m_capabilities)& (1 << (COLORIDX_CYAN))) {
 				/* if CYAN is present, append our buffer if needed */
 				if (usingbuf) {
 					ss << ssbuf.str();
@@ -368,12 +365,13 @@ bool Color::HandleMsg
 				}
 				/* and then our Color */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_CYAN];
-			} else {
+			}
+			else {
 				/* put 00 into our buffer */
 				ssbuf << "00";
 				usingbuf = true;
 			}
-			if ((m_capabilities) & (1<<(COLORIDX_PURPLE))) {
+			if ((m_capabilities)& (1 << (COLORIDX_PURPLE))) {
 				/* if PURPLE is present, append our buffer if needed */
 				if (usingbuf) {
 					ss << ssbuf.str();
@@ -383,22 +381,23 @@ bool Color::HandleMsg
 				}
 				/* and then our Color */
 				ss << std::setw(2) << std::uppercase << std::hex << std::setfill('0') << (int)m_colorvalues[COLORIDX_PURPLE];
-			} else {
+			}
+			else {
 				/* put 00 into our buffer */
 				ssbuf << "00";
 				usingbuf = true;
 			}
 
-			Log::Write(LogLevel_Info, GetNodeId(), "Received a updated Color from Device: %s", ss.str().c_str() );
-			color->OnValueRefreshed( ss.str() );
+			Log::Write(LogLevel_Info, GetNodeId(), "Received a updated Color from Device: %s", ss.str().c_str());
+			color->OnValueRefreshed(ss.str());
 			color->Release();
 
 		}
 		/* if we got a updated Color Index Value - Update our ValueID */
-		if ((m_capabilities) & (1<<(COLORIDX_INDEXCOLOR))) {
-			if( ValueInt* coloridx = static_cast<ValueInt*>( GetValue( _instance, 2 ) ) )
+		if ((m_capabilities)& (1 << (COLORIDX_INDEXCOLOR))) {
+			if (ValueInt* coloridx = static_cast<ValueInt*>(GetValue(_instance, 2)))
 			{
-				coloridx->OnValueRefreshed( m_colorvalues[COLORIDX_INDEXCOLOR] );
+				coloridx->OnValueRefreshed(m_colorvalues[COLORIDX_INDEXCOLOR]);
 				coloridx->Release();
 			}
 		}
@@ -408,40 +407,168 @@ bool Color::HandleMsg
 }
 
 //-----------------------------------------------------------------------------
+// <GetColor>
+// Get a Specific Color Value from a position in a RGB String
+// its assumed the string is formated such as #RRGGBB[WWCWAMCYPR]
+// where the color values in [] are optional.
+// throws a exception when position is out of bounds
+//-----------------------------------------------------------------------------
+uint8 GetColor(string rgbstring, uint8 const position) {
+
+	/* check the length of the string based on position value we passed in including the #*/
+	if (rgbstring.length() < (size_t)(position * 2) + 1) {
+		Log::Write(LogLevel_Warning, "Request for Color Position %d exceeds String Length: %s", position, rgbstring.c_str());
+		throw;
+	}
+	string result = rgbstring.substr(((position - 1) * 2) + 1, 2);
+
+	std::stringstream ss(result);
+	int rawresult;
+	ss >> std::hex >> rawresult;
+	return (uint8)rawresult;
+}
+
+//-----------------------------------------------------------------------------
 // <Color::SetValue>
 // Set the device's Color value
 //-----------------------------------------------------------------------------
 bool Color::SetValue
 (
-		Value const& _value
+	Value const& _value
 )
 {
-#if 0
-	if (ValueID::ValueType_Raw == _value.GetID().GetType())
+	if (ValueID::ValueType_String == _value.GetID().GetType())
 	{
-		ValueRaw const* value = static_cast<ValueRaw const*>(&_value);
-		uint8* s = value->GetValue();
-		uint8 len = value->GetLength();
-		if (len > 10) //sanity check
+		ValueString const* value = static_cast<ValueString const*>(&_value);
+		string s = value->GetValue();
+		/* make sure the first char is # */
+		if (s.at(0) != '#') {
+			Log::Write(LogLevel_Warning, GetNodeId(), "Color::SetValue - String is Malformed. Missing #: %s", s.c_str());
 			return false;
+		}
+		/* length minus the # has to be multiple of 2's */
+		if ((s.length() - 1) % 2 != 0) {
+			Log::Write(LogLevel_Warning, GetNodeId(), "Color::SetValue - Uneven Length string. Each Color should be 2 chars: %s", s.c_str());
+			return false;
+		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Color::SetValue - Setting Color value");
-		Msg* msg = new Msg( "Color Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
-		msg->SetInstance( this, _value.GetID().GetInstance() );
-		msg->Append( GetNodeId() );
-		msg->Append(3 + len); //length
-		msg->Append( GetCommandClassId() );
+		/* the size of the string tells us how many colors are set */
+		uint8 nocols = (s.length() - 1) / 2;
+		uint8 colvals[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		bool colvalset[8] = { false, false, false, false, false, false, false, false };
+
+
+		try {
+			/* we always will have at least RGB */
+			colvals[COLORIDX_RED] = GetColor(s, 1);
+			colvals[COLORIDX_GREEN] = GetColor(s, 2);
+			colvals[COLORIDX_BLUE] = GetColor(s, 3);
+
+			if (nocols == 3) {
+				//RGB value, we have to turn off the supported white colors
+
+				if (((m_capabilities)& (1 << (COLORIDX_WARMWHITE)))	& ((m_capabilities)& (1 << (COLORIDX_COLDWHITE)))) {
+					colvals[COLORIDX_WARMWHITE] = 0;
+					colvals[COLORIDX_COLDWHITE] = 0;
+					colvalset[COLORIDX_WARMWHITE] = true;
+					colvalset[COLORIDX_COLDWHITE] = true;
+					nocols += 2;
+				}
+				else if ((m_capabilities)& (1 << (COLORIDX_WARMWHITE))) {
+					colvals[COLORIDX_WARMWHITE] = 0;
+					colvalset[COLORIDX_WARMWHITE] = true;
+					nocols += 1;
+				}
+				else if ((m_capabilities)& (1 << (COLORIDX_COLDWHITE))) {
+					colvals[COLORIDX_COLDWHITE] = 0;
+					colvalset[COLORIDX_COLDWHITE] = true;
+					nocols += 1;
+				}
+			}
+			else
+			{
+				if (nocols == 4) {
+					/* warm white is set */
+					/* set cold_white to 0 */
+					colvals[COLORIDX_WARMWHITE] = GetColor(s, 4);
+					colvalset[COLORIDX_WARMWHITE] = true;
+					if ((m_capabilities)& (1 << (COLORIDX_COLDWHITE))) {
+						colvals[COLORIDX_COLDWHITE] = 0;
+						colvalset[COLORIDX_COLDWHITE] = true;
+						nocols += 1;
+					}
+				}
+				if (nocols >= 5) {
+					/* warm white and cold white are set */
+					colvals[COLORIDX_WARMWHITE] = GetColor(s, 4);
+					colvals[COLORIDX_COLDWHITE] = GetColor(s, 5);
+					colvalset[COLORIDX_WARMWHITE] = true;
+					colvalset[COLORIDX_COLDWHITE] = true;
+				}
+				if (nocols >= 6) {
+					/* amber is also set */
+					colvals[COLORIDX_AMBER] = GetColor(s, 6);
+					colvalset[COLORIDX_AMBER] = true;
+				}
+				if (nocols >= 7) {
+					/* cyan is also set */
+					colvals[COLORIDX_CYAN] = GetColor(s, 7);
+					colvalset[COLORIDX_CYAN] = true;
+				}
+				if (nocols == 8) {
+					/* purple is also set */
+					colvals[COLORIDX_PURPLE] = GetColor(s, 8);
+					colvalset[COLORIDX_PURPLE] = true;
+				}
+			}
+		}
+		catch (...) {
+			Log::Write(LogLevel_Warning, GetNodeId(), "Color::SetValue - Color String Decoding Failed: %s", s.c_str());
+			return false;
+		}
+		Log::Write(LogLevel_Info, GetNodeId(), "Color::SetValue - Setting Color value");
+
+		Msg* msg = new Msg("Color Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true);
+		msg->SetInstance(this, _value.GetID().GetInstance());
+		msg->Append(GetNodeId());
+		msg->Append(3 + (nocols * 2)); //length
+		msg->Append(GetCommandClassId());
 		msg->Append(ColorCmd_Set); //cmd
-		msg->Append(len); //LEN OF DATA
-		for (int ii = 0; ii < len; ii++)
-		{
-			msg->Append(s[ii]);
+		msg->Append(nocols); //number of color pairs
+		msg->Append(COLORIDX_RED);
+		msg->Append(colvals[COLORIDX_RED]);
+		msg->Append(COLORIDX_GREEN);
+		msg->Append(colvals[COLORIDX_GREEN]);
+		msg->Append(COLORIDX_BLUE);
+		msg->Append(colvals[COLORIDX_BLUE]);
+		if (colvalset[COLORIDX_WARMWHITE] & !colvalset[COLORIDX_COLDWHITE]) {
+			msg->Append(COLORIDX_WARMWHITE);
+			msg->Append(colvals[COLORIDX_WARMWHITE]);
+		}
+		if (colvalset[COLORIDX_WARMWHITE] && colvalset[COLORIDX_COLDWHITE]) {
+			msg->Append(COLORIDX_WARMWHITE);
+			msg->Append(colvals[COLORIDX_WARMWHITE]);
+			msg->Append(COLORIDX_COLDWHITE);
+			msg->Append(colvals[COLORIDX_COLDWHITE]);
+		}
+		if (colvalset[COLORIDX_AMBER]) {
+			msg->Append(COLORIDX_AMBER);
+			msg->Append(colvals[COLORIDX_AMBER]);
+		}
+		if (colvalset[COLORIDX_CYAN]) {
+			msg->Append(COLORIDX_CYAN);
+			msg->Append(colvals[COLORIDX_CYAN]);
+		}
+		if (colvalset[COLORIDX_PURPLE]) {
+			msg->Append(COLORIDX_PURPLE);
+			msg->Append(colvals[COLORIDX_PURPLE]);
 		}
 		msg->Append(GetDriver()->GetTransmitOptions());
-		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+		GetDriver()->SendMsg(msg, Driver::MsgQueue_Send);
 		return true;
 	}
-#endif
+
+
 	return false;
 }
 
@@ -451,19 +578,16 @@ bool Color::SetValue
 //-----------------------------------------------------------------------------
 void Color::CreateVars
 (
-		uint8 const _instance
+	uint8 const _instance
 )
 {
 	if( Node* node = GetNodeUnsafe() )
 	{
-		/* XXX TODO convert this to a bitset when we implement */
-		node->CreateValueInt( ValueID::ValueGenre_System, GetCommandClassId(), _instance, 254, "Color Channels", "", true, false, 0, 0 );
-		node->CreateValueString( ValueID::ValueGenre_User, GetCommandClassId(), _instance, 1, "Color", "#RRGGBB[WWCWAMCYPR]", false, false, "#000000", 0 );
-		node->CreateValueInt( ValueID::ValueGenre_User, GetCommandClassId(), _instance, 2, "Color Index", "", false, false, 0, 0 );
-
+		//Write only for now
+		node->CreateValueInt(ValueID::ValueGenre_System, GetCommandClassId(), _instance, 254, "Color Channels", "", true, false, 0, 0);
+		node->CreateValueString(ValueID::ValueGenre_User, GetCommandClassId(), _instance, 1, "Color", "#RRGGBB[WWCWAMCYPR]", false, false, "#000000", 0);
+		node->CreateValueInt(ValueID::ValueGenre_User, GetCommandClassId(), _instance, 2, "Color Index", "", false, false, 0, 0);
 	}
-
-
 }
 
 //-----------------------------------------------------------------------------
@@ -472,12 +596,12 @@ void Color::CreateVars
 //-----------------------------------------------------------------------------
 void Color::SetValueBasic
 (
-		uint8 const _instance,
-		uint8 const _value
+uint8 const _instance,
+uint8 const _value
 )
 {
 	// Send a request for new value to synchronize it with the BASIC set/report.
 	for (int i = 0; i <= 8; i++) {
-		RequestValue( 0, i, _instance, Driver::MsgQueue_Send );
+		RequestValue(0, i, _instance, Driver::MsgQueue_Send);
 	}
 }

--- a/cpp/src/command_classes/Color.h
+++ b/cpp/src/command_classes/Color.h
@@ -46,22 +46,22 @@ namespace OpenZWave
 		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_COLOR"; }
 
 		// From CommandClass
-		virtual void ReadXML( TiXmlElement const* _ccElement );
-		virtual void WriteXML( TiXmlElement* _ccElement );
-		virtual bool RequestState( uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue );
-		virtual bool RequestValue( uint32 const _requestFlags, uint8 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
+		virtual void ReadXML(TiXmlElement const* _ccElement);
+		virtual void WriteXML(TiXmlElement* _ccElement);
+		virtual bool RequestState(uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue);
+		virtual bool RequestValue(uint32 const _requestFlags, uint8 const _index, uint8 const _instance, Driver::MsgQueue const _queue);
 		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
-		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
-		virtual bool SetValue( Value const& _value );
+		virtual bool HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance = 1);
+		virtual bool SetValue(Value const& _value);
 		virtual uint8 GetMaxVersion(){ return 3; }
-		virtual void SetValueBasic( uint8 const _instance, uint8 const _value );
+		virtual void SetValueBasic(uint8 const _instance, uint8 const _value);
 
 	protected:
 		virtual void CreateVars( uint8 const _instance );
 
 	private:
-		Color( uint32 const _homeId, uint8 const _nodeId );
+		Color(uint32 const _homeId, uint8 const _nodeId);
 		uint16 m_capabilities;
 		bool m_coloridxbug; // Fibaro RGBW before version 25.25 always reported the coloridx as 3 in the Report Message. Work around it
 		uint8 m_coloridxcount;


### PR DESCRIPTION
Fixed sending color command (after ColorCmd_Set we should send the amount of color pairs)

Implemented, disabling other colors (When sending for example a RGB command, then we have to turn of the possible white colors)
