### PR TITLE
DeviceResetLocally Command Class

### DIFF
--- a/cpp/src/command_classes/CommandClasses.cpp
+++ b/cpp/src/command_classes/CommandClasses.cpp
@@ -45,6 +45,7 @@ using namespace OpenZWave;
 #include "command_classes/Configuration.h"
 #include "command_classes/ControllerReplication.h"
 #include "command_classes/CRC16Encap.h"
+#include "command_classes/DeviceResetLocally.h"
 #include "command_classes/DoorLock.h"
 #include "command_classes/DoorLockLogging.h"
 #include "command_classes/EnergyProduction.h"
@@ -195,6 +196,7 @@ void CommandClasses::RegisterCommandClasses
 	cc.Register( Configuration::StaticGetCommandClassId(), Configuration::StaticGetCommandClassName(), Configuration::Create );
 	cc.Register( ControllerReplication::StaticGetCommandClassId(), ControllerReplication::StaticGetCommandClassName(), ControllerReplication::Create );
 	cc.Register( CRC16Encap::StaticGetCommandClassId(), CRC16Encap::StaticGetCommandClassName(), CRC16Encap::Create );
+	cc.Register( DeviceResetLocally::StaticGetCommandClassId(), DeviceResetLocally::StaticGetCommandClassName(), DeviceResetLocally::Create );
 	cc.Register( DoorLock::StaticGetCommandClassId(), DoorLock::StaticGetCommandClassName(), DoorLock::Create );
 	cc.Register( DoorLockLogging::StaticGetCommandClassId(), DoorLockLogging::StaticGetCommandClassName(), DoorLockLogging::Create);
 	cc.Register( EnergyProduction::StaticGetCommandClassId(), EnergyProduction::StaticGetCommandClassName(), EnergyProduction::Create );

--- a/cpp/src/command_classes/DeviceResetLocally.cpp
+++ b/cpp/src/command_classes/DeviceResetLocally.cpp
@@ -1,0 +1,63 @@
+//-----------------------------------------------------------------------------
+//
+//	DeviceResetLocally.cpp
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_DEVICE_RESET_LOCALLY
+//
+//	Copyright (c) 2015
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#include "command_classes/CommandClasses.h"
+#include "command_classes/DeviceResetLocally.h"
+#include "Defs.h"
+#include "platform/Log.h"
+
+using namespace OpenZWave;
+
+enum DeviceResetLocallyCmd
+{
+	DeviceResetLocallyCmd_Notification = 1
+};
+
+
+//-----------------------------------------------------------------------------
+// <DeviceResetLocally::HandleMsg>
+// Handle a message from the Z-Wave network
+//-----------------------------------------------------------------------------
+bool DeviceResetLocally::HandleMsg
+(
+	uint8 const* _data,
+	uint32 const _length,
+	uint32 const _instance	// = 1
+)
+{
+	if( DeviceResetLocallyCmd_Notification == _data[0] )
+	{
+		// device has been reset
+		Log::Write( LogLevel_Info, GetNodeId(), "Received Device Reset Locally from node %d", GetNodeId() );
+
+		// TODO tell the controller the node has gone away.
+		// Manager::Get()->RemoveFailedNode(GetHomeId(), GetNodeId());
+		return true;
+	}
+	return false;
+}
+

--- a/cpp/src/command_classes/DeviceResetLocally.h
+++ b/cpp/src/command_classes/DeviceResetLocally.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+//
+//	DeviceResetLocally.h
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_DEVICE_RESET_LOCALLY
+//
+//	Copyright (c) 2015
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#ifndef _DeviceResetLocally_H
+#define _DeviceResetLocally_H
+
+#include "command_classes/CommandClass.h"
+
+namespace OpenZWave
+{
+	/** \brief Implements COMMAND_CLASS_DEVICE_RESET_LOCALLY (0x5a), a Z-Wave device command class.
+	 */
+	class DeviceResetLocally: public CommandClass
+	{
+	public:
+		static CommandClass* Create( uint32 const _homeId, uint8 const _nodeId ){ return new DeviceResetLocally( _homeId, _nodeId ); }
+		virtual ~DeviceResetLocally(){}
+
+		static uint8 const StaticGetCommandClassId(){ return 0x5a; }
+		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_DEVICE_RESET_LOCALLY"; }
+
+		// From CommandClass
+		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
+		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
+		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
+
+	private:
+		DeviceResetLocally( uint32 const _homeId, uint8 const _nodeId ): CommandClass( _homeId, _nodeId ){}
+	};
+
+} // namespace OpenZWave
+
+#endif
+


### PR DESCRIPTION
Initial version for the DeviceResetLocally CommandClass.

When a node is reset is will send out a DeviceResetLocally message telling the controller the node has been reset and left the network.
Upon receiving this goodbye message we will try to send a NoOp message so the controller knows the node has gone. Next we ask the controller to remove the failed node. 
When the node answers the NoOp the removal will fail. 
