### PR TITLE
config ZMNHBA2: correct instance/endpoint mapping

### DIFF
--- a/config/qubino/ZMNHBA2.xml
+++ b/config/qubino/ZMNHBA2.xml
@@ -68,5 +68,8 @@
 
 	<!-- Remove COMMAND_CLASS_BASIC -->
 	<CommandClass id="32" action="remove" />
+	
+	<!-- Map endpoints to instances -->
+	<CommandClass id="96" mapping="endpoints" />
 
 </Product>


### PR DESCRIPTION
without the mapping the device reports tree in stead of two switches due to a incorrect endpoint mapping. 