### PR TITLE
Added configuration for Merten 50x5xx Roller Shutter Module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+-  Added configuration file for Merten 50x5xx Roller Shutter Module (Sascha)
 Version 1.3
  - Fixed Issue 383 - Update Remotec ZXT-120 Config file thanks to yy.bendavid & gizmocuz (Alex)
  - Fixed Issue 392 - Add Qubino ZMNHJA2 Config file thanks to nicoserveur (Alex)

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -462,7 +462,7 @@
 		<Product type="8002" id="0001" name="Plug-in Dimmer Module"/>
 		<Product type="4003" id="0001" name="Wall Dimmer Module"/>
 		<Product type="4002" id="0001" name="Wall Appliance Module"/>
-		<Product type="4004" id="0001" name="Wall Roller Shutter Module"/>
+		<Product type="4004" id="0001" name="Wall Roller Shutter Module" config="merten/50x5xx.xml"/>
 		<Product type="8001" id="8001" name="Receiver Flush-Mounted 1-Gang Switch"/>
 		<Product type="0003" id="0004" name="Transmitter Flush-Mounted 4-Gang Switch"/>
 		<Product type="0001" id="0002" name="Transmitter 1-Gang Switch"/>

--- a/config/merten/50x5xx.xml
+++ b/config/merten/50x5xx.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--http://www.pepper1.net/zwavedb/device/85-->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+
+
+    <commandClasses>
+        <commandClass id="0020" inNIF="false"/>
+        <commandClass id="0060" version="2"/>
+        <commandClass id="0085"/>
+        <commandClass id="0086"/>
+        <commandClass id="0070" version="2"/>
+        <commandClass id="008e"/>
+        <commandClass id="0050" version="2"/>
+        <commandClass id="0031" version="0"/>
+        <commandClass id="0072"/>
+        <commandClass id="0075" version="2"/>
+        <commandClass id="0026"/>
+        <commandClass id="009e" version="0"/>
+      </commandClasses>
+
+
+
+
+  <!-- Configuration -->
+  <CommandClass id="112">
+
+    <Value type="byte" genre="config" instance="1" index="1" label="Switching additional CONNECT radio receivers" value="1">
+      <Help>To configure if other radio recivers from Merten should be switched as well.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="176" label="Changeover delay (motor protection)" value="100">
+      <Help>To configure the time the motor waits before switching direction.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="177" label="Raising time input 1" value="100">
+      <Help>To configure input 1 of the raising time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="178" label="Raising time input 2" value="100">
+      <Help>To configure input 1 of the raising time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="179" label="Lowering time input 1" value="100">
+      <Help>To configure input 1 of the lowering time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="180" label="Lowering time input 2" value="100">
+      <Help>To configure input 1 of the lowering time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="list" genre="config" instance="1" index="181" label="Light sensor" value="0" size="1">
+      <Help>To configure use of light sensor. Default: 0 .</Help>
+      <Item label="0 - Auto" value="0"/>
+      <Item label="1 - On" value="1"/>
+      <Item label="2 - Off" value="1"/>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="182" label="Brightness threshold for light sensor" value="1">
+      <Help>To configure brightness threshold for light sensor.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="183" label="Sensor raising reaction threshold input 1" value="1">
+      <Help>To configure input 1 of reaction threshold for raising shutter time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="184" label="Sensor raising reaction threshold input 1" value="100">
+      <Help>To configure input 2 of reaction threshold for raising shutter time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="185" label="Sensor lowering reaction threshold input 1" value="1">
+      <Help>To configure input 1 of reaction threshold for lowering shutter time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="186" label="Sensor lowering reaction threshold input 1" value="100">
+      <Help>To configure input 2 of reaction threshold for lowering shutter time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+	</CommandClass>
+  
+  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+  <CommandClass id="113" getsupported="false" />
+
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="1">
+      <Group index="1" max_associations="5" label="Group 1" auto="true"/>
+    </Associations>
+  </CommandClass>
+
+</Product>


### PR DESCRIPTION
There was no configuration file for Merten 50x5xx roller shutter
modules. Added those as proposed here:
https://github.com/OpenZWave/open-zwave/wiki/Adding-Devices