### PR TITLE
Issue #446 - Visual Studio 2015 Breakage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -207,6 +207,7 @@ Version 1.3
  - Issue #501 - Fix ThermostatFanMode when checking for Valid Modes (Justin)
  - Pull Request #659 - Added configuration file for D-Link Corp and DCH-Z110 Door/Window 3in1 sensor
    from psixilambda (Justin)
+ - Issue #446 - Fix Visual Studio 2015 breakage. (Justin)
 
 Version 1.2 
  - Released on 15/10/14

--- a/dotnet/src/ZWManager.cpp
+++ b/dotnet/src/ZWManager.cpp
@@ -240,13 +240,13 @@ bool ZWManager::GetValueListSelection
 bool ZWManager::GetValueListItems
 ( 
 	ZWValueID^ id, 
-	[Out] array<String^>^ %o_value
+	[Out] cli::array<String^>^ %o_value
 )
 {
 	vector<string> items;
 	if( Manager::Get()->GetValueListItems(id->CreateUnmanagedValueID(), &items ) )
 	{
-		o_value = gcnew array<String^>(items.size());
+		o_value = gcnew cli::array<String^>(items.size());
 		for( uint32 i=0; i<items.size(); ++i )
 		{
 			o_value[i] = gcnew String( items[i].c_str() );		
@@ -264,14 +264,14 @@ uint32 ZWManager::GetNodeNeighbors
 ( 
 	uint32 homeId,
 	uint8 nodeId,
-	[Out] array<Byte>^ %o_neighbors
+	[Out] cli::array<Byte>^ %o_neighbors
 )
 {
 	uint8* neighbors;
 	uint32 numNeighbors = Manager::Get()->GetNodeNeighbors( homeId, nodeId, &neighbors );
 	if( numNeighbors )
 	{
-		o_neighbors = gcnew array<Byte>(numNeighbors);
+		o_neighbors = gcnew cli::array<Byte>(numNeighbors);
 		for( uint32 i=0; i<numNeighbors; ++i )
 		{
 			o_neighbors[i] = neighbors[i];		
@@ -318,14 +318,14 @@ uint32 ZWManager::GetAssociations
 	uint32 homeId,
 	uint8 nodeId,
 	uint8 groupIdx,
-	[Out] array<Byte>^ %o_associations
+	[Out] cli::array<Byte>^ %o_associations
 )
 {
 	uint8* associations;
 	uint32 numAssociations = Manager::Get()->GetAssociations( homeId, nodeId, groupIdx, &associations );
 	if( numAssociations )
 	{
-		o_associations = gcnew array<Byte>(numAssociations);
+		o_associations = gcnew cli::array<Byte>(numAssociations);
 		for( uint32 i=0; i<numAssociations; ++i )
 		{
 			o_associations[i] = associations[i];		
@@ -379,14 +379,14 @@ bool ZWManager::GetNodeClassInformation
 //-----------------------------------------------------------------------------
 uint8 ZWManager::GetAllScenes
 (
-	[Out] array<Byte>^ o_sceneIds
+	[Out] cli::array<Byte>^ o_sceneIds
 )
 {
 	uint8* sceneIds;
 	uint32 numScenes = Manager::Get()->GetAllScenes( &sceneIds );
 	if( numScenes )
 	{
-		o_sceneIds = gcnew array<Byte>(numScenes);
+		o_sceneIds = gcnew cli::array<Byte>(numScenes);
 		for( uint32 i=0; i<numScenes; ++i )
 		{
 			o_sceneIds[i] = sceneIds[i];		
@@ -404,14 +404,14 @@ uint8 ZWManager::GetAllScenes
 int ZWManager::SceneGetValues
 (
 	uint8 sceneId,
-	[Out] array<ZWValueID ^>^ %o_values
+	[Out] cli::array<ZWValueID ^>^ %o_values
 )
 {
 	vector<ValueID> values;
 	uint32 numValues = Manager::Get()->SceneGetValues( sceneId, &values );
 	if( numValues )
 	{
-		o_values = gcnew array<ZWValueID ^>(numValues);
+		o_values = gcnew cli::array<ZWValueID ^>(numValues);
 		for( uint32 i=0; i<numValues; ++i )
 		{
 			o_values[i] = gcnew ZWValueID(values[i]);		

--- a/dotnet/src/ZWManager.h
+++ b/dotnet/src/ZWManager.h
@@ -659,7 +659,7 @@ namespace OpenZWaveDotNet
 		 * \param nodeId The ID of the node to query.
 		 * \param o_associations An array of 29 uint8s to hold the neighbor bitmap
 		 */
-		uint32 GetNodeNeighbors( uint32 const homeId, uint8 const nodeId, [Out] array<Byte>^ %o_associations );
+		uint32 GetNodeNeighbors( uint32 const homeId, uint8 const nodeId, [Out] cli::array<Byte>^ %o_associations );
 
 		/**
 		 * \brief Get the manufacturer name of a device.
@@ -1078,7 +1078,7 @@ namespace OpenZWaveDotNet
 		 * \return true if the list items were obtained.  Returns false if the value is not a ZWValueID::ValueType_List. The type can be tested with a call to ZWValueID::GetType
 		 * \see ValueID::GetType, GetValueAsBool, GetValueAsByte, GetValueAsDecimal, GetValueAsInt, GetValueAsShort, GetValueAsString, GetValueListSelection 
 		 */
-		bool GetValueListItems( ZWValueID^ id, [Out] array<String^>^ %o_value );
+		bool GetValueListItems( ZWValueID^ id, [Out] cli::array<String^>^ %o_value );
 
 		/**
 		 * \brief Sets the state of a bool.
@@ -1400,7 +1400,7 @@ namespace OpenZWaveDotNet
 		 * \return The number of nodes in the associations array.  If zero, the array will point to NULL, and does not need to be deleted.
 		 * \see GetNumGroups, AddAssociation, RemoveAssociation
 		 */
-		uint32 GetAssociations( uint32 const homeId, uint8 const nodeId, uint8 const groupIdx, [Out] array<Byte>^ %o_associations );
+		uint32 GetAssociations( uint32 const homeId, uint8 const nodeId, uint8 const groupIdx, [Out] cli::array<Byte>^ %o_associations );
 
 		/**
 		 * \brief Gets the maximum number of associations for a group.
@@ -1885,7 +1885,7 @@ namespace OpenZWaveDotNet
 		 * \return The number of scenes.
 		 * \see GetNumScenes, CreateScene, RemoveScene, AddSceneValue, RemoveSceneValue, SceneGetValues, SceneGetValueAsBool, SceneGetValueAsByte, SceneGetValueAsFloat, SceneGetValueAsInt, SceneGetValueAsShort, SceneGetValueAsString, SetSceneValue, GetSceneLabel, SetSceneLabel, SceneExists, ActivateScene
 		 */
-		uint8 GetAllScenes( [Out] array<Byte>^ sceneIds );
+		uint8 GetAllScenes( [Out] cli::array<Byte>^ sceneIds );
 
 		/**
 		 * \brief Create a new Scene passing in Scene ID
@@ -1999,7 +1999,7 @@ namespace OpenZWaveDotNet
 		 * \return The number of nodes in the o_value array. If zero, the array will point to NULL and does not need to be deleted.
 		 * \see GetNumScenes, GetAllScenes, CreateScene, RemoveScene, AddSceneValue, RemoveSceneValue, SceneGetValueAsBool, SceneGetValueAsByte, SceneGetValueAsFloat, SceneGetValueAsInt, SceneGetValueAsShort, SceneGetValueAsString, SetSceneValue, GetSceneLabel, SetSceneLabel, SceneExists, ActivateScene
 		 */
-		int SceneGetValues( uint8 sceneId, [Out] array<ZWValueID ^>^ %o_values );
+		int SceneGetValues( uint8 sceneId, [Out] cli::array<ZWValueID ^>^ %o_values );
 
 		/**
 		 * \brief Retrieves a scene's value as a bool.


### PR DESCRIPTION
Make sure we use a fully qualified namespace for arrays, so VS2015 doesn't get confused. 