### PR TITLE
PR: add some useful variables in pkg-config

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -154,7 +154,7 @@ $(top_builddir)/libopenzwave.pc: $(top_srcdir)/cpp/build/libopenzwave.pc.in $(PK
 		-e 's|[@]libdir@|$(instlibdir)|g' \
 		-e 's|[@]includedir@|$(PREFIX)/include/openzwave/|g' \
                 -e 's|[@]sysconfdir@|$(PREFIX)/etc/openzwave/|g' \
-		-e 's|[@]gitversion@|$(GITVERSION)|g' \
+                -e 's|[@]gitversion@|$(GITVERSION)|g' \
                 -e 's|[@]docdir@|$(docdir)/|g' \
 		-e 's|[@]VERSION@|$(VERSION)|g' \
 		< "$<" > "$@"

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -153,6 +153,9 @@ $(top_builddir)/libopenzwave.pc: $(top_srcdir)/cpp/build/libopenzwave.pc.in $(PK
 		-e 's|[@]exec_prefix@|$(PREFIX)/bin|g' \
 		-e 's|[@]libdir@|$(instlibdir)|g' \
 		-e 's|[@]includedir@|$(PREFIX)/include/openzwave/|g' \
+                -e 's|[@]sysconfdir@|$(PREFIX)/etc/openzwave/|g' \
+		-e 's|[@]gitversion@|$(GITVERSION)|g' \
+                -e 's|[@]docdir@|$(docdir)/|g' \
 		-e 's|[@]VERSION@|$(VERSION)|g' \
 		< "$<" > "$@"
 endif

--- a/cpp/build/libopenzwave.pc.in
+++ b/cpp/build/libopenzwave.pc.in
@@ -2,6 +2,9 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+sysconfdir=@sysconfdir@
+gitversion=@gitversion@
+docdir=@docdir@
 
 Name: libopenzwave
 Description: A Open Source implementation of the ZWave Serial API


### PR DESCRIPTION
Precise git version is needed to be able to scan and enable the new security API in openzwave-shared. I've also added the shared conf dir (PREFIX/etc/openzwave) and documentation (PREFIX/share/doc/openzwave-<version>)