### PR TITLE
Fix includes to not assume the base include directory

### DIFF
--- a/cpp/src/platform/Controller.cpp
+++ b/cpp/src/platform/Controller.cpp
@@ -24,9 +24,9 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
-#include "Defs.h"
+#include "../Defs.h"
 #include "Driver.h"
-#include "platform/Controller.h"
+#include "Controller.h"
 
 using namespace OpenZWave;
 

--- a/cpp/src/platform/Controller.h
+++ b/cpp/src/platform/Controller.h
@@ -30,9 +30,9 @@
 
 #include <string>
 #include <list>
-#include "Defs.h"
+#include "../Defs.h"
 #include "Driver.h"
-#include "platform/Stream.h"
+#include "Stream.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/Event.cpp
+++ b/cpp/src/platform/Event.cpp
@@ -25,13 +25,13 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
-#include "Defs.h"
-#include "platform/Event.h"
+#include "../Defs.h"
+#include "Event.h"
 
 #ifdef WIN32
-#include "platform/windows/EventImpl.h"	// Platform-specific implementation of an event
+#include "windows/EventImpl.h"	// Platform-specific implementation of an event
 #else
-#include "platform/unix/EventImpl.h"	// Platform-specific implementation of an event
+#include "unix/EventImpl.h"	// Platform-specific implementation of an event
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/Event.h
+++ b/cpp/src/platform/Event.h
@@ -28,7 +28,7 @@
 #ifndef _Event_H
 #define _Event_H
 
-#include "platform/Wait.h"
+#include "Wait.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/FileOps.cpp
+++ b/cpp/src/platform/FileOps.cpp
@@ -26,12 +26,12 @@
 //
 //-----------------------------------------------------------------------------
 #include <string>
-#include "platform/FileOps.h"
+#include "FileOps.h"
 
 #ifdef WIN32
-#include "platform/windows/FileOpsImpl.h"	// Platform-specific implementation of a File Operations
+#include "windows/FileOpsImpl.h"	// Platform-specific implementation of a File Operations
 #else
-#include "platform/unix/FileOpsImpl.h"	// Platform-specific implementation of a File Operations
+#include "unix/FileOpsImpl.h"	// Platform-specific implementation of a File Operations
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/FileOps.h
+++ b/cpp/src/platform/FileOps.h
@@ -30,7 +30,7 @@
 
 #include <stdarg.h>
 #include <string>
-#include "Defs.h"
+#include "../Defs.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/HidController.cpp
+++ b/cpp/src/platform/HidController.cpp
@@ -26,11 +26,11 @@
 //-----------------------------------------------------------------------------
 
 #include "Msg.h"
-#include "platform/Thread.h"
-#include "platform/Event.h"
-#include "platform/Log.h"
-#include "platform/TimeStamp.h"
-#include "platform/HidController.h"
+#include "Thread.h"
+#include "Event.h"
+#include "Log.h"
+#include "TimeStamp.h"
+#include "HidController.h"
 #include "hidapi.h"
 
 

--- a/cpp/src/platform/HidController.h
+++ b/cpp/src/platform/HidController.h
@@ -29,8 +29,8 @@
 #define _HidController_H
 
 #include <string>
-#include "Defs.h"
-#include "platform/Controller.h"
+#include "../Defs.h"
+#include "Controller.h"
 
 
 struct hid_device_;

--- a/cpp/src/platform/Log.cpp
+++ b/cpp/src/platform/Log.cpp
@@ -27,14 +27,14 @@
 //-----------------------------------------------------------------------------
 #include <stdarg.h>
 
-#include "Defs.h"
-#include "platform/Mutex.h"
-#include "platform/Log.h"
+#include "../Defs.h"
+#include "Mutex.h"
+#include "Log.h"
 
 #ifdef WIN32
-#include "platform/windows/LogImpl.h"	// Platform-specific implementation of a log
+#include "windows/LogImpl.h"	// Platform-specific implementation of a log
 #else
-#include "platform/unix/LogImpl.h"	// Platform-specific implementation of a log
+#include "unix/LogImpl.h"	// Platform-specific implementation of a log
 #endif
 
 

--- a/cpp/src/platform/Log.h
+++ b/cpp/src/platform/Log.h
@@ -30,7 +30,7 @@
 
 #include <stdarg.h>
 #include <string>
-#include "Defs.h"
+#include "../Defs.h"
 
 
 

--- a/cpp/src/platform/Mutex.cpp
+++ b/cpp/src/platform/Mutex.cpp
@@ -25,13 +25,13 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
-#include "Defs.h"
-#include "platform/Mutex.h"
+#include "../Defs.h"
+#include "Mutex.h"
 
 #ifdef WIN32
-#include "platform/windows/MutexImpl.h"	// Platform-specific implementation of a mutex
+#include "windows/MutexImpl.h"	// Platform-specific implementation of a mutex
 #else
-#include "platform/unix/MutexImpl.h"	// Platform-specific implementation of a mutex
+#include "unix/MutexImpl.h"	// Platform-specific implementation of a mutex
 #endif
 
 

--- a/cpp/src/platform/Mutex.h
+++ b/cpp/src/platform/Mutex.h
@@ -28,7 +28,7 @@
 #ifndef _Mutex_H
 #define _Mutex_H
 
-#include "platform/Wait.h"
+#include "Wait.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/Ref.h
+++ b/cpp/src/platform/Ref.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "Defs.h"
+#include "../Defs.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/SerialController.cpp
+++ b/cpp/src/platform/SerialController.cpp
@@ -26,15 +26,15 @@
 //-----------------------------------------------------------------------------
 
 #include "Msg.h"
-#include "platform/Event.h"
-#include "platform/Thread.h" 
-#include "platform/SerialController.h"
-#include "platform/Log.h"
+#include "Event.h"
+#include "Thread.h" 
+#include "SerialController.h"
+#include "Log.h"
 
 #ifdef WIN32
-#include "platform/windows/SerialControllerImpl.h"	// Platform-specific implementation of a serial port
+#include "windows/SerialControllerImpl.h"	// Platform-specific implementation of a serial port
 #else
-#include "platform/unix/SerialControllerImpl.h"	// Platform-specific implementation of a serial port
+#include "unix/SerialControllerImpl.h"	// Platform-specific implementation of a serial port
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/SerialController.h
+++ b/cpp/src/platform/SerialController.h
@@ -29,8 +29,8 @@
 #define _SerialController_H
 
 #include <string>
-#include "Defs.h"
-#include "platform/Controller.h"
+#include "../Defs.h"
+#include "Controller.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/Stream.cpp
+++ b/cpp/src/platform/Stream.cpp
@@ -25,9 +25,9 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
-#include "platform/Stream.h"
-#include "platform/Mutex.h"
-#include "platform/Log.h"
+#include "Stream.h"
+#include "Mutex.h"
+#include "Log.h"
 
 #include <string.h>
 

--- a/cpp/src/platform/Stream.h
+++ b/cpp/src/platform/Stream.h
@@ -28,8 +28,8 @@
 #ifndef _Stream_H
 #define _Stream_H
 
-#include "Defs.h"
-#include "platform/Wait.h"
+#include "../Defs.h"
+#include "Wait.h"
 
 #include <string>
 

--- a/cpp/src/platform/Thread.cpp
+++ b/cpp/src/platform/Thread.cpp
@@ -25,14 +25,14 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
-#include "Defs.h"
-#include "platform/Event.h"
-#include "platform/Thread.h"
+#include "../Defs.h"
+#include "Event.h"
+#include "Thread.h"
 
 #ifdef WIN32
-#include "platform/windows/ThreadImpl.h"	// Platform-specific implementation of a thread
+#include "windows/ThreadImpl.h"	// Platform-specific implementation of a thread
 #else
-#include "platform/unix/ThreadImpl.h"	// Platform-specific implementation of a thread
+#include "unix/ThreadImpl.h"	// Platform-specific implementation of a thread
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/Thread.h
+++ b/cpp/src/platform/Thread.h
@@ -29,8 +29,8 @@
 #define _Thread_H
 
 #include <string>
-#include "Defs.h"
-#include "platform/Wait.h"
+#include "../Defs.h"
+#include "Wait.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/TimeStamp.cpp
+++ b/cpp/src/platform/TimeStamp.cpp
@@ -26,13 +26,13 @@
 //
 //-----------------------------------------------------------------------------
 #include <string>
-#include "Defs.h"
-#include "platform/TimeStamp.h"
+#include "../Defs.h"
+#include "TimeStamp.h"
 
 #ifdef WIN32
-#include "platform/windows/TimeStampImpl.h"	// Platform-specific implementation of a TimeStamp
+#include "windows/TimeStampImpl.h"	// Platform-specific implementation of a TimeStamp
 #else
-#include "platform/unix/TimeStampImpl.h"	// Platform-specific implementation of a TimeStamp
+#include "unix/TimeStampImpl.h"	// Platform-specific implementation of a TimeStamp
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/TimeStamp.h
+++ b/cpp/src/platform/TimeStamp.h
@@ -28,7 +28,7 @@
 #ifndef _TimeStamp_H
 #define _TimeStamp_H
 
-#include "Defs.h"
+#include "../Defs.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/Wait.cpp
+++ b/cpp/src/platform/Wait.cpp
@@ -26,15 +26,15 @@
 //
 //-----------------------------------------------------------------------------
 #include <stdio.h>
-#include "Defs.h"
-#include "platform/Wait.h"
-#include "platform/Event.h"
-#include "platform/Log.h"
+#include "../Defs.h"
+#include "Wait.h"
+#include "Event.h"
+#include "Log.h"
 
 #ifdef WIN32
-#include "platform/windows/WaitImpl.h"	// Platform-specific implementation of a Wait object
+#include "windows/WaitImpl.h"	// Platform-specific implementation of a Wait object
 #else
-#include "platform/unix/WaitImpl.h"	// Platform-specific implementation of a Wait object
+#include "unix/WaitImpl.h"	// Platform-specific implementation of a Wait object
 #endif
 
 using namespace OpenZWave;

--- a/cpp/src/platform/Wait.h
+++ b/cpp/src/platform/Wait.h
@@ -30,7 +30,7 @@
 #define _Wait_H
 
 #include <list>
-#include "platform/Ref.h"
+#include "Ref.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -31,7 +31,7 @@
 #include "Node.h"
 #include "Notification.h"
 #include "Msg.h"
-#include "value_classes/Value.h"
+#include "Value.h"
 #include "platform/Log.h"
 #include "command_classes/CommandClass.h"
 #include <ctime>

--- a/cpp/src/value_classes/Value.h
+++ b/cpp/src/value_classes/Value.h
@@ -32,9 +32,9 @@
 #ifdef __FreeBSD__
 #include <time.h>
 #endif
-#include "Defs.h"
-#include "platform/Ref.h"
-#include "value_classes/ValueID.h"
+#include "../Defs.h"
+#include "../platform/Ref.h"
+#include "ValueID.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueBool.cpp
+++ b/cpp/src/value_classes/ValueBool.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueBool.h"
+#include "ValueBool.h"
 #include "Driver.h"
 #include "Node.h"
 #include "platform/Log.h"

--- a/cpp/src/value_classes/ValueBool.h
+++ b/cpp/src/value_classes/ValueBool.h
@@ -29,8 +29,8 @@
 #define _ValueBool_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueButton.cpp
+++ b/cpp/src/value_classes/ValueButton.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueButton.h"
+#include "ValueButton.h"
 #include "Manager.h"
 #include "Driver.h"
 #include "Node.h"

--- a/cpp/src/value_classes/ValueButton.h
+++ b/cpp/src/value_classes/ValueButton.h
@@ -29,8 +29,8 @@
 #define _ValueButton_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -27,7 +27,7 @@
 
 #include <sstream>
 #include "tinyxml.h"
-#include "value_classes/ValueByte.h"
+#include "ValueByte.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueByte.h
+++ b/cpp/src/value_classes/ValueByte.h
@@ -29,8 +29,8 @@
 #define _ValueByte_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueDecimal.cpp
+++ b/cpp/src/value_classes/ValueDecimal.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueDecimal.h"
+#include "ValueDecimal.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueDecimal.h
+++ b/cpp/src/value_classes/ValueDecimal.h
@@ -29,8 +29,8 @@
 #define _ValueDecimal_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueID.h
+++ b/cpp/src/value_classes/ValueID.h
@@ -30,7 +30,7 @@
 
 #include <string>
 #include <assert.h>
-#include "Defs.h"
+#include "../Defs.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueInt.cpp
+++ b/cpp/src/value_classes/ValueInt.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <limits.h>
 #include "tinyxml.h"
-#include "value_classes/ValueInt.h"
+#include "ValueInt.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueInt.h
+++ b/cpp/src/value_classes/ValueInt.h
@@ -29,8 +29,8 @@
 #define _ValueInt_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueList.h"
+#include "ValueList.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueList.h
+++ b/cpp/src/value_classes/ValueList.h
@@ -30,8 +30,8 @@
 
 #include <string>
 #include <vector>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueRaw.cpp
+++ b/cpp/src/value_classes/ValueRaw.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueRaw.h"
+#include "ValueRaw.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueRaw.h
+++ b/cpp/src/value_classes/ValueRaw.h
@@ -29,8 +29,8 @@
 #define _ValueRaw_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueSchedule.cpp
+++ b/cpp/src/value_classes/ValueSchedule.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <limits.h>
 #include "tinyxml.h"
-#include "value_classes/ValueSchedule.h"
+#include "ValueSchedule.h"
 #include "Msg.h"
 #include "platform/Log.h"
 

--- a/cpp/src/value_classes/ValueSchedule.h
+++ b/cpp/src/value_classes/ValueSchedule.h
@@ -29,8 +29,8 @@
 #define _ValueSchedule_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueShort.cpp
+++ b/cpp/src/value_classes/ValueShort.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <limits.h>
 #include "tinyxml.h"
-#include "value_classes/ValueShort.h"
+#include "ValueShort.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueShort.h
+++ b/cpp/src/value_classes/ValueShort.h
@@ -29,8 +29,8 @@
 #define _ValueShort_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueStore.cpp
+++ b/cpp/src/value_classes/ValueStore.cpp
@@ -25,8 +25,8 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "value_classes/ValueStore.h"
-#include "value_classes/Value.h"
+#include "ValueStore.h"
+#include "Value.h"
 #include "Manager.h"
 #include "Notification.h"
 

--- a/cpp/src/value_classes/ValueStore.h
+++ b/cpp/src/value_classes/ValueStore.h
@@ -29,8 +29,8 @@
 #define _ValueStore_H
 
 #include <map>
-#include "Defs.h"
-#include "value_classes/ValueID.h"
+#include "../Defs.h"
+#include "ValueID.h"
 
 class TiXmlElement;
 

--- a/cpp/src/value_classes/ValueString.cpp
+++ b/cpp/src/value_classes/ValueString.cpp
@@ -26,7 +26,7 @@
 //-----------------------------------------------------------------------------
 
 #include "tinyxml.h"
-#include "value_classes/ValueString.h"
+#include "ValueString.h"
 #include "Msg.h"
 #include "platform/Log.h"
 #include "Manager.h"

--- a/cpp/src/value_classes/ValueString.h
+++ b/cpp/src/value_classes/ValueString.h
@@ -29,8 +29,8 @@
 #define _ValueString_H
 
 #include <string>
-#include "Defs.h"
-#include "value_classes/Value.h"
+#include "../Defs.h"
+#include "Value.h"
 
 class TiXmlElement;
 


### PR DESCRIPTION
Currently, the headers assume that you are adding the openzwave include directory directly to the compiler's search path (e.g. -I /pathto/include/openzwave & #include "Manager.h").

When this is not the case, includes in the headers like "#include platform/Stream.h" from platform/Controller.h will break, because platform is not in the search path, nor in the directory of the current file.

Making the includes relative to the current file's directory fixes this and gives the flexibility to set up your includes differently (e.g., -I /pathto/include & #include "openzwave/Manager.h")