### PR TITLE
Fixed crash in CommandClass::ReadValueRefreshXML and corrected 3 type castings

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -3871,7 +3871,7 @@ void Driver::CommonAddNodeStatusRequestHandler
 			state = ControllerState_Completed;
 			if( m_currentControllerCommand != NULL && m_currentControllerCommand->m_controllerCommandNode != 0xff )
 			{
-				InitNode( m_currentControllerCommand->m_controllerCommandNode, true, m_currentControllerCommand->m_controllerCommandArg, m_currentControllerCommand->m_controllerDeviceProtocolInfo, m_currentControllerCommand->m_controllerDeviceProtocolInfoLength );
+				InitNode( m_currentControllerCommand->m_controllerCommandNode, true, m_currentControllerCommand->m_controllerCommandArg != 0, m_currentControllerCommand->m_controllerDeviceProtocolInfo, m_currentControllerCommand->m_controllerDeviceProtocolInfoLength );
 			}
 
 			// Not sure about the new controller function here.

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -998,7 +998,7 @@ bool Manager::IsNodeZWavePlus
 		version = driver->IsNodeZWavePlus( _nodeId );
 	}
 
-	return version;
+	return (version != 0);
 }
 
 
@@ -1290,7 +1290,7 @@ uint8 Manager::GetNodeDeviceType
 {
 	if( Driver* driver = GetDriver( _homeId ) )
 	{
-		return driver->GetNodeDeviceType( _nodeId );
+		return (uint8)driver->GetNodeDeviceType( _nodeId );
 	}
 
 	return 0x00; // unknown

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -3207,7 +3207,7 @@ void Node::ReadDeviceClasses
 			if( keyStr )
 			{
 				char* pStop;
-				uint16 key = (uint16)strtol( keyStr, &pStop, 16 );
+				uint8 key = (uint8)strtol( keyStr, &pStop, 16 );
 
 				if( !strcmp( str, "Generic" ) )
 				{

--- a/cpp/src/command_classes/CommandClass.cpp
+++ b/cpp/src/command_classes/CommandClass.cpp
@@ -329,12 +329,15 @@ void CommandClass::ReadValueRefreshXML
 	char const* str;
 	bool ok = false;
 	const char *genre;
+	int32 intVal;
 	RefreshValue *rcc = new RefreshValue();
 	rcc->cc = GetCommandClassId();
 	genre = _ccElement->Attribute( "Genre" );
 	rcc->genre = Value::GetGenreEnumFromName(genre);
-	_ccElement->QueryIntAttribute( "Instance", (int*)&rcc->instance);
-	_ccElement->QueryIntAttribute( "Index", (int*)&rcc->index);
+	_ccElement->QueryIntAttribute( "Instance", &intVal);
+	rcc->instance = intVal;
+	_ccElement->QueryIntAttribute( "Index", &intVal);
+	rcc->index = intVal;
 	Log::Write(LogLevel_Info, GetNodeId(), "Value Refresh triggered by CommandClass: %s, Genre: %d, Instance: %d, Index: %d for:", GetCommandClassName().c_str(), rcc->genre, rcc->instance, rcc->index);
 	TiXmlElement const* child = _ccElement->FirstChildElement();
 	while( child )
@@ -345,22 +348,26 @@ void CommandClass::ReadValueRefreshXML
 			if ( !strcmp(str, "RefreshClassValue"))
 			{
 				RefreshValue *arcc = new RefreshValue();
-				if (child->QueryIntAttribute( "CommandClass", (int*)&arcc->cc) != TIXML_SUCCESS) {
+				if (child->QueryIntAttribute( "CommandClass", &intVal) != TIXML_SUCCESS) {
 					Log::Write(LogLevel_Warning, GetNodeId(), "    Invalid XML - CommandClass Attribute is wrong type or missing");
 					continue;
 				}
-				if (child->QueryIntAttribute( "RequestFlags", (int*)&arcc->genre) != TIXML_SUCCESS) {
+				arcc->cc = intVal;
+				if (child->QueryIntAttribute( "RequestFlags", &intVal) != TIXML_SUCCESS) {
 					Log::Write(LogLevel_Warning, GetNodeId(), "    Invalid XML - RequestFlags Attribute is wrong type or missing");
 					continue;
 				}
-				if (child->QueryIntAttribute( "Instance", (int*)&arcc->instance) != TIXML_SUCCESS) {
+				arcc->genre = intVal;
+				if (child->QueryIntAttribute( "Instance", &intVal) != TIXML_SUCCESS) {
 					Log::Write(LogLevel_Warning, GetNodeId(), "    Invalid XML - Instance Attribute is wrong type or missing");
 					continue;
 				}
-				if (child->QueryIntAttribute( "Index", (int*)&arcc->index) != TIXML_SUCCESS) {
+				arcc->instance = intVal;
+				if (child->QueryIntAttribute( "Index", &intVal) != TIXML_SUCCESS) {
 					Log::Write(LogLevel_Warning, GetNodeId(), "    Invalid XML - Index Attribute is wrong type or missing");
 					continue;
 				}
+				arcc->index = intVal;
 				Log::Write(LogLevel_Info, GetNodeId(), "    CommandClass: %s, RequestFlags: %d, Instance: %d, Index: %d", CommandClasses::GetName(arcc->cc).c_str(), arcc->genre, arcc->instance, arcc->index);
 				rcc->RefreshClasses.push_back(arcc);
 				ok = true;

--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -74,7 +74,7 @@ ValueList::ValueList
 ):
 	Value(),
 	m_items( ),
-	m_valueIdx(),
+	m_valueIdx(0),
 	m_valueIdxCheck( 0 ),
 	m_newValueIdx( 0 ),
 	m_size(0)
@@ -355,12 +355,12 @@ bool ValueList::GetItemLabels
 // Get the Item at the Currently selected Index
 //-----------------------------------------------------------------------------
 ValueList::Item const *ValueList::GetItem() const {
-	try {
-		return &m_items.at(m_valueIdx);
-	} catch (const std::out_of_range& oor) {
+	if ((m_valueIdx < 0) || (m_valueIdx >= (int32)m_items.size()))
+	{
 		Log::Write(LogLevel_Warning, "Invalid Index Set on ValueList");
 		return NULL;
 	}
+	return &m_items.at(m_valueIdx);
 }
 
 


### PR DESCRIPTION
Fixed crash in CommandClass::ReadValueRefreshXML that was caused by QueryIntAttribute which takes an int pointer as argument and a uint8 pointer was provided

Corrected 3 type castings that where causing a compile warning