### PR TITLE
constify Notification::GetAsString() 

### DIFF
--- a/cpp/src/Notification.cpp
+++ b/cpp/src/Notification.cpp
@@ -37,7 +37,7 @@ using namespace OpenZWave;
 // Return a string representation of OZW
 //-----------------------------------------------------------------------------
 
-string Notification::GetAsString() {
+string Notification::GetAsString() const {
 	string str;
 	switch (m_type) {
 		case Type_ValueAdded:

--- a/cpp/src/Notification.h
+++ b/cpp/src/Notification.h
@@ -179,7 +179,7 @@ namespace OpenZWave
 		 * Helper Function to return the Notification as a String
 		 * \return A string representation of this Notification
 		 */
-		string GetAsString();
+		string GetAsString()const;
 
 
 	private:


### PR DESCRIPTION
`const` needs to be added to the function signature (it returns a one-use message string anyway: no mutations whatsoever), otherwise I cannot call it from the callback handler, as I'm getting a [passing const discards qualifiers](http://stackoverflow.com/questions/5973427/error-passing-xxx-as-this-argument-of-xxx-discards-qualifiers?rq=1)

this is because the callback handler signature defines `_pNotification` as `const`
```
 typedef void(* 	pfnOnNotification_t) (Notification const *_pNotification, void *_context)
```