### PR TITLE
FreeBSD fixes

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -35,7 +35,7 @@ endif
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS	+= -c -DDARWIN
-ARCH	+= -arch i386 -arch x86_64
+TARCH	+= -arch i386 -arch x86_64
 LDFLAGS += -dynamiclib
 LIBS	+= -framework IOKit -framework CoreFoundation -arch i386 -arch x86_64
 else ifeq ($(UNAME),FreeBSD)
@@ -140,7 +140,7 @@ $(LIBDIR)/$(SHARED_LIB_NAME):	$(patsubst %.cpp,$(OBJDIR)/%.o,$(tinyxml)) \
 			$(patsubst %.cpp,$(OBJDIR)/%.o,$(indep)) \
 			$(OBJDIR)/vers.o
 	@echo "Linking Shared Library"
-	@$(LD) $(LDFLAGS) $(ARCH) -o $@ $+ $(LIBS)
+	@$(LD) $(LDFLAGS) $(TARCH) -o $@ $+ $(LIBS)
 	@ln -sf $(SHARED_LIB_NAME) $(LIBDIR)/$(SHARED_LIB_UNVERSIONED)
 
 $(top_builddir)/libopenzwave.pc: $(top_srcdir)/cpp/build/libopenzwave.pc.in $(PKGCONFIG)

--- a/cpp/build/support.mk
+++ b/cpp/build/support.mk
@@ -117,7 +117,7 @@ $(OBJDIR)/%.o : %.cpp
 	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | fmt -1 | \
 	  $(SED) -e 's/^ *//' -e 's/$$/:/' >> $(DEPDIR)/.$*.d;
 	@rm -f $(DEPDIR)/$*.d.tmp
-	@$(CXX) $(CFLAGS) $(ARCH) $(INCLUDES) -o $@ $<
+	@$(CXX) $(CFLAGS) $(TARCH) $(INCLUDES) -o $@ $<
 
 
 $(OBJDIR)/%.o : %.c
@@ -128,7 +128,7 @@ $(OBJDIR)/%.o : %.c
 	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | fmt -1 | \
 	  $(SED) -e 's/^ *//' -e 's/$$/:/' >> $(DEPDIR)/.$*.d;
 	@rm -f $(DEPDIR)/$*.d.tmp
-	@$(CC) $(CFLAGS) $(ARCH) $(INCLUDES) -o $@ $<
+	@$(CC) $(CFLAGS) $(TARCH) $(INCLUDES) -o $@ $<
 
 
 dummy := $(shell test -d $(OBJDIR) || mkdir -p $(OBJDIR))

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -35,7 +35,7 @@ include $(top_srcdir)/cpp/build/support.mk
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS += -DDARWIN
-ARCH += -arch i386 -arch x86_64
+TARCH += -arch i386 -arch x86_64
 endif
 
 # Dup from main makefile, but that is not included when building here..
@@ -49,7 +49,7 @@ endif
 
 $(OBJDIR)/MinOZW:	$(patsubst %.cpp,$(OBJDIR)/%.o,$(minozwsrc))
 	@echo "Linking $(OBJDIR)/MinOZW"
-	$(LD) $(LDFLAGS) $(ARCH) -o $@ $< $(LIBS) -pthread
+	$(LD) $(LDFLAGS) $(TARCH) -o $@ $< $(LIBS) -pthread
 
 $(top_builddir)/MinOZW: $(top_srcdir)/cpp/examples/MinOZW/MinOZW.in $(OBJDIR)/MinOZW
 	@echo "Creating Temporary Shell Launch Script"

--- a/cpp/hidapi/libusb/hid.c
+++ b/cpp/hidapi/libusb/hid.c
@@ -335,11 +335,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-#ifdef __FreeBSD__
-	const char *inptr;
-#else
 	char *inptr;
-#endif
 	char *outptr;
 
 	/* Determine which language to use. */


### PR DESCRIPTION
Some minor fixes to make build work on FreeBSD again.

Not sure on backwards compatibility on the iconv thing, but other FreeBSD ports seems to have been fully changed (i.e no conditionals): https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=199099, so I'd say openzwave should do the same?