### PR TITLE
add manager interface and value list method to retrieve list of integer values from value list

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -2421,6 +2421,43 @@ bool Manager::GetValueListItems
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::GetValueListValues>
+// Gets the list of items from a list value
+//-----------------------------------------------------------------------------
+bool Manager::GetValueListValues
+(
+		ValueID const& _id,
+		vector<int32>* o_value
+)
+{
+	bool res = false;
+
+	if( o_value )
+	{
+		if( ValueID::ValueType_List == _id.GetType() )
+		{
+			if( Driver* driver = GetDriver( _id.GetHomeId() ) )
+			{
+				LockGuard LG(driver->m_nodeMutex);
+				if( ValueList* value = static_cast<ValueList*>( driver->GetValue( _id ) ) )
+				{
+					o_value->clear();
+					res = value->GetItemValues( o_value );
+					value->Release();
+				} else {
+					OZW_ERROR(OZWException::OZWEXCEPTION_INVALID_VALUEID, "Invalid ValueID passed to GetValueListValues");
+				}
+			}
+		} else {
+			OZW_ERROR(OZWException::OZWEXCEPTION_CANNOT_CONVERT_VALUEID, "ValueID passed to GetValueListValues is not a List Value");
+		}
+	}
+
+	return res;
+}
+
+
+//-----------------------------------------------------------------------------
 // <Manager::GetValueFloatPrecision>
 // Gets a value's scale as a uint8
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1124,6 +1124,18 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		bool GetValueListItems( ValueID const& _id, vector<string>* o_value );
 
 		/**
+		 * \brief Gets the list of values from a list value.
+		 * \param _id The unique identifier of the value.
+		 * \param o_value Pointer to a vector of integers that will be filled with list items. The vector will be cleared before the items are added.
+		 * \return true if the list values were obtained.  Returns false if the value is not a ValueID::ValueType_List. The type can be tested with a call to ValueID::GetType.
+		 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+		 * \throws OZWException with Type OZWException::OZWEXCEPTION_CANNOT_CONVERT_VALUEID if the Actual Value is off a different type
+		 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+		 * \see ValueID::GetType, GetValueAsBool, GetValueAsByte, GetValueAsFloat, GetValueAsInt, GetValueAsShort, GetValueAsString, GetValueListSelection, GetValueAsRaw
+		 */
+		bool GetValueListValues( ValueID const& _id, vector<int32>* o_value );
+
+		/**
 		 * \brief Gets a float value's precision.
 		 * \param _id The unique identifier of the value.
 		 * \param o_value Pointer to a uint8 that will be filled with the precision value.

--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -351,6 +351,28 @@ bool ValueList::GetItemLabels
 }
 
 //-----------------------------------------------------------------------------
+// <ValueList::GetItemValues>
+// Fill a vector with the item values
+//-----------------------------------------------------------------------------
+bool ValueList::GetItemValues
+(
+	vector<int32>* o_values
+)
+{
+	if( o_values )
+	{
+		for( vector<Item>::iterator it = m_items.begin(); it != m_items.end(); ++it )
+		{
+			o_values->push_back( (*it).m_value );
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+//-----------------------------------------------------------------------------
 // <ValueList::GetItem>
 // Get the Item at the Currently selected Index
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueList.h
+++ b/cpp/src/value_classes/ValueList.h
@@ -74,6 +74,7 @@ namespace OpenZWave
 		int32 const GetItemIdxByValue( int32 const _value );
 
 		bool GetItemLabels( vector<string>* o_items );
+		bool GetItemValues( vector<int32>* o_values );
 
 		uint8 const GetSize()const{ return m_size; }
 


### PR DESCRIPTION
This may be useful to upper SW stack or bindings to retrieve the list of integer values from list type values. This could make it more convenient for subsequent ozw.setValue() call, instead of getting string labels of the value list.