### PR TITLE
ZME_064281 Wall Plug switch Schuko (IP44) - Gen 5

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -778,6 +778,7 @@
 		<Product type="1000" id="0002" name="ZME_06433/05433 Wall Flush-Mountable Dimmer" config="zwave.me/ZME_06433.xml"/>
 		<Product type="1000" id="0003" name="ZME_06436 Motor Control" config="zwave.me/ZME_06436.xml" />
 		<Product type="1000" id="0004" name="ZME_064435 Wall Controller" config="zwave.me/ZME_064435.xml"/>
+		<Product type="1000" id="0200" name="ZME_064281 Wall Plug switch Schuko (IP44) - Gen 5" config="zwave.me/ZME_064381.xml"/>
 		<Product type="1100" id="0002" name="PLDE Plug-in Dimmer"/>
 	</Manufacturer>
 	<Manufacturer id="0147" name="Z-Wave.Me">

--- a/config/zwave.me/ZME_064381.xml
+++ b/config/zwave.me/ZME_064381.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+
+<!-- Z-Wave.Me ZME_064381 Wall Plug switch Schuko (IP44) - Gen 5 -->
+
+	<!-- Configuration  -->
+	<CommandClass id="112">
+		<Value type="list" genre="config" instance="1" index="1" label="Led mode" size="1" value="1">
+			<Help>Set LED indication mode</Help>
+			<Item label="Disable" value="0" />
+			<Item label="Show switch (Default)" value="1" />
+			<Item label="Operated by Indicator Command Class" value="2" />
+		</Value>
+	
+		<Value type="short" genre="config" instance="1" index="2" label="Automatically switch off after" size="2" min="0" max="65535" value="0">
+			<Help>If not zero, automatically switch device off after an user defined time. Unit: Sec, Min: 0, Max: 65535, Default: 0</Help>
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="3" label="What to do on RF Off-Command" size="1" value="0">
+			<Help>Defines how to interpret RF Off-Command. Can be used in conjunction with Auto Off function: Ignore - to switch on the light by motion detectors and switch it off after some amount of time: in case of multiple motion detectors each would try to switch the light off that would break logics; Switch on - to switch on the light on both ON and OFF paddle press on the remote and switch it off after some amount of time. Button OFF click will still work (if button operations are not disabled).</Help>
+			<Item label="Switch off (Default)" value="0" />
+			<Item label="Ignore" value="1" />
+			<Item label="Switch on" value="2" />
+			<Item label="Switch on if load is off else switch off" value="3" />
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="5" label="Restore switch state after power cycle" size="1" value="1">
+			<Help>Defines if the switch should restore switch state to the last prior to device power off (power cycle).</Help>
+			<Item label="No, turn off" value="0" />
+			<Item label="Yes (Default)" value="1" />
+		</Value>
+		
+		<Value type="short" genre="config" instance="1" index="20" label="Energy consumption" size="2" min="0" max="3500" value="0">
+			<Help>Specify the consumption of the load in watts, for the calculation of power consumption. Maximum load 1800 W. Unit: Watts, Min: 0, Max: 3500, Default: 0</Help>
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="21" label="Off color" size="1" value="0">
+			<Help>Color to OFF state</Help>
+			<Item label="Off (Default)" value="0" />
+			<Item label="Red" value="1" />
+			<Item label="Green" value="2" />
+			<Item label="Blue" value="3" />
+			<Item label="Yellow" value="4" />
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="22" label="On color" size="1" value="3">
+			<Help>Color to ON state</Help>
+			<Item label="Off" value="0" />
+			<Item label="Red" value="1" />
+			<Item label="Green" value="2" />
+			<Item label="Blue (Default)" value="3" />
+			<Item label="Yellow" value="4" />
+		</Value>
+	</CommandClass>
+
+	<!-- Association Groups -->
+	
+	<CommandClass id="133">
+		<Associations num_groups="2">
+			<Group index="1" max_associations="5" label="Send reports on switch state change" auto="true"/>
+			<Group index="2" max_associations="5" label="Controlled by buttons" auto="true" />
+		</Associations>
+	</CommandClass>
+
+</Product>


### PR DESCRIPTION
Add support for the ZME_064281 Wall Plug switch Schuko (IP44) - Gen 5 based on hellqvist PPOP device. (Same device, different manufacturer)