### PR TITLE
Added support for Merten Plug-in Roller Shutter Module.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 Version 1.3
+ - Added support for Merten Plug-in Roller Shutter Module (Marco)
  - Fixed Issue 383 - Update Remotec ZXT-120 Config file thanks to yy.bendavid & gizmocuz (Alex)
  - Fixed Issue 392 - Add Qubino ZMNHJA2 Config file thanks to nicoserveur (Alex)
  - Fixed Issue 394 - Add 2GIG CT100 USA version device thanks to mldkfa (Alex)

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -499,6 +499,7 @@
 	<Manufacturer id="007a" name="Merten">
 		<Product type="8001" id="0001" name="Plug-in Appliance Module"/>
 		<Product type="8002" id="0001" name="Plug-in Dimmer Module"/>
+		<Product type="8003" id="0001" name="Plug-in Roller Shutter Module" config="merten/507801.xml"/>
 		<Product type="4003" id="0001" name="Wall Dimmer Module"/>
 		<Product type="4002" id="0001" name="Wall Appliance Module"/>
 		<Product type="4004" id="0001" name="Wall Roller Shutter Module" config="merten/50x5xx.xml"/>

--- a/config/merten/507801.xml
+++ b/config/merten/507801.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--http://www.pepper1.net/zwavedb/device/72-->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+  <!-- Configuration -->
+  <CommandClass id="112">
+
+    <Value type="byte" genre="config" instance="1" index="176" label="Changeover delay (motor protection)" value="100">
+      <Help>To configure the time (value * 0.1 sec) the motor waits before switching direction.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="177" label="Raising time input 1" value="100">
+      <Help>To configure input 1 of the raising time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="178" label="Raising time input 2" value="100">
+      <Help>To configure input 1 of the raising time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="179" label="Lowering time input 1" value="100">
+      <Help>To configure input 1 of the lowering time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="180" label="Lowering time input 2" value="100">
+      <Help>To configure input 1 of the lowering time calculation (256 * Input 1 + Input 2) * 0.1 sec</Help>
+    </Value>
+
+  </CommandClass>
+  
+  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+  <CommandClass id="113" getsupported="false" />
+
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="1">
+      <Group index="1" max_associations="12" label="Group 1" auto="true"/>
+    </Associations>
+  </CommandClass>
+
+</Product>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -132,6 +132,7 @@ DISTFILES =	.gitignore \
 	config/mcohome/mhs411.xml \
 	config/mcohome/mhs412.xml \
 	config/mcohome/mhs513.xml \
+	config/merten/507801.xml \
 	config/merten/50x5xx.xml \
 	config/nodon/asp3100SmartPlug.xml \
 	config/nodon/crc3100OctanRemote.xml \


### PR DESCRIPTION
I have added support for the Plug-in Roller Shutter Module (507801) from Merten. 
Some documentation of this module can be found at http://www.merten.com/uploads/tx_seqdownload/V5078_581_00_web_01.pdf

The functionality is similar to the Merten 50x5xx, which is already supported. 


