### PR TITLE
Add brk smoke C02 Detector

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -147,6 +147,9 @@
 	</Manufacturer>
 	<Manufacturer id="0023" name="Boca Devices">
 	</Manufacturer>
+	<Manufacturer id="0138" name="BRK">
+		<Product type="0001" id="0002" name="Smoke and Carbon and Monoxide Alarm"/>
+	</Manufacturer>
 	<Manufacturer id="002d" name="Broadband Energy">
 	</Manufacturer>
 	<Manufacturer id="0123" name="Iwatsu Electric Co">


### PR DESCRIPTION
This is my first try of adding devices to openzwave, so I am sorry if I did anything incorrectly. I will be more than happy to fix it up. That being said in my `zwcfg_*.xml` file I am seeing the following... 

```xml
<Node id="7" name="" location="" basic="4" generic="161" specific="0" type="Alarm Sensor" listening="false" frequentListening="false" beaming="true" routing="true" max_baud_rate="40000" version="4" query_stage="Probe">
                <Manufacturer id="" name="">
                        <Product type="" id="" name="" />
                </Manufacturer>
                <CommandClasses>
                        <CommandClass id="32" name="COMMAND_CLASS_BASIC" version="1" after_mark="true" mapping="113">
                                <Instance index="1" />
                        </CommandClass>
                        <CommandClass id="132" name="COMMAND_CLASS_WAKE_UP" version="1" request_flags="2">
                                <Instance index="1" />
                                <Value type="int" genre="system" instance="1" index="0" label="Wake-up Interval" units="Seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="3600" />
                        </CommandClass>
                </CommandClasses>
        </Node>
```

So I followed the instructions and found the device at http://www.pepper1.net/zwavedb/device/458 and created this PR. The device is still not autodetecting. I am not sure if its because its asleep or if I made a mistake adding the device. Any guidance is greatly appreciated.  