### PR TITLE
update dotnet wrapper

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -2422,7 +2422,7 @@ bool Manager::GetValueListItems
 
 //-----------------------------------------------------------------------------
 // <Manager::GetValueListValues>
-// Gets the list of items from a list value
+// Gets the list of values from a list value
 //-----------------------------------------------------------------------------
 bool Manager::GetValueListValues
 (

--- a/dotnet/src/ZWManager.cpp
+++ b/dotnet/src/ZWManager.cpp
@@ -257,6 +257,29 @@ bool ZWManager::GetValueListItems
 }
 
 //-----------------------------------------------------------------------------
+// <ZWManager::GetValueListValues>
+// Gets the list of values from a list value
+//-----------------------------------------------------------------------------
+bool ZWManager::GetValueListValues
+( 
+	ZWValueID^ id, 
+	[Out] cli::array<int>^ %o_value
+)
+{
+	vector<int32> items;
+	if( Manager::Get()->GetValueListValues(id->CreateUnmanagedValueID(), &items ) )
+	{
+		o_value = gcnew cli::array<int>(items.size());
+		for( uint32 i=0; i<items.size(); ++i )
+		{
+			o_value[i] = items[i];
+		}
+		return true;
+	}
+	return false;
+}
+
+//-----------------------------------------------------------------------------
 // <ZWManager::GetNeighbors>
 // Gets the neighbors for a node
 //-----------------------------------------------------------------------------

--- a/dotnet/src/ZWManager.h
+++ b/dotnet/src/ZWManager.h
@@ -1082,6 +1082,16 @@ namespace OpenZWaveDotNet
 		bool GetValueListItems( ZWValueID^ id, [Out] cli::array<String^>^ %o_value );
 
 		/**
+		 * \brief Gets the list of values from a list value.
+		 *
+		 * \param _id The unique identifier of the value.
+		 * \param o_value Pointer to a vector of integers that will be filled with list items. The vector will be cleared before the items are added.
+		 * \return true if the list values were obtained.  Returns false if the value is not a ValueID::ValueType_List. The type can be tested with a call to ValueID::GetType.
+		 * \see ValueID::GetType, GetValueAsBool, GetValueAsByte, GetValueAsFloat, GetValueAsInt, GetValueAsShort, GetValueAsString, GetValueListSelection, GetValueAsRaw
+		 */
+		bool GetValueListValues( ZWValueID^ id, [Out] cli::array<int>^ %o_value );
+
+		/**
 		 * \brief Sets the state of a bool.
 		 *
 		 * Due to the possibility of a device being asleep, the command is assumed to suceeed, and the value


### PR DESCRIPTION
Hi Justin, 

can you accept this patch. It keeps the dotnet wrapper sync with the c++ codebase.
I've added the Manager::GetValueListValues() function introduced by the commit 8cc839a8a08acf7d723241f779d8a72c221382f7.

Thanks.