### PR TITLE
hid.c: make inptr in get_usb_string const

### DIFF
--- a/cpp/hidapi/libusb/hid.c
+++ b/cpp/hidapi/libusb/hid.c
@@ -335,7 +335,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-	char *inptr;
+	const char *inptr;
 	char *outptr;
 
 	/* Determine which language to use. */


### PR DESCRIPTION
Without this fix, I get:
openzwave/cpp/hidapi/libusb/hid.c:372:18: error: passing
      'char **' to parameter of type 'const char **' discards qualifiers in nested
      pointer types [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
        res = iconv(ic, &inptr, &inbytes, &outptr, &outbytes);
                        ^~~~~~
/usr/include/iconv.h:56:47: note: passing argument to parameter here
size_t  iconv(iconv_t, const char ** __restrict,

from FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512