### PR TITLE
fix how CPPFLAGS are passed to Makefile in all: target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ PREFIX ?= /usr/local
 export PREFIX
 
 all: 
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) 
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) 
+	CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS)
+	CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS)
 
 install:
 	$(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) $(MAKECMDGOALS)


### PR DESCRIPTION
$ export CPPFLAGS="-I/something -I/somethingelse"
$ make

Will bail like:

CPPFLAGS=-I/home/ubuntu/snappy-sensor-examples/parts/openzwave/install/include -I/home/ubuntu/snappy-sensor-examples/parts/openzwave/install/usr/include -I/home/ubuntu/snappy-sensor-examples/parts/openzwave/install/include/arm-linux-gnueabihf -I/home/ubuntu/snappy-sensor-examples/parts/openzwave/install/usr/include/arm-linux-gnueabihf  make -C /home/ubuntu/snappy-sensor-examples/parts/openzwave/build/cpp/build/ - 
/bin/sh: 1: -I/home/ubuntu/snappy-sensor-examples/parts/openzwave/install/usr/include: not found


This patch fixes that.