### PR TITLE
Multi-platform compatible FreeBSD build fix for iconv

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -39,12 +39,23 @@ TARCH	+= -arch i386 -arch x86_64
 LDFLAGS += -dynamiclib
 LIBS	+= -framework IOKit -framework CoreFoundation -arch i386 -arch x86_64
 else ifeq ($(UNAME),FreeBSD)
-
-# FreeBSD 10 has native iconv.h; for older, we look in /usr/local, and libiconv must be installed from ports.
-ifeq (,$(wildcard /usr/include/iconv.h))
-CFLAGS += -I/usr/local/include
-endif
 LDFLAGS+= -shared -lusb
+
+# Pre FreeBSD 10.2 we have no native, or "old" native iconv.h (non-posix compliant
+# const modifiers)
+# For these, require libiconv pkg to be installed.
+ifeq ($(shell test $$(uname -U) -ge 1002000; echo $$?),1)
+# <10.2
+ifeq (,$(wildcard /usr/local/include/iconv.h))
+$(error FreeBSD pre 10.2: Please install libiconv from ports)
+else
+# Installed, use it
+CFLAGS += -I/usr/local/include
+# User application *must* use -liconv; we don't do any linking from this file since we only
+# build a library.
+endif
+endif
+# For 10.2 and later, use iconv from base, no extra include path required.
 
 else
 LDFLAGS += -shared -Wl,-soname,libopenzwave.so.$(VERSION)

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -40,11 +40,17 @@ endif
 
 # Dup from main makefile, but that is not included when building here..
 ifeq ($(UNAME),FreeBSD)
-ifeq (,$(wildcard /usr/include/iconv.h))
+LDFLAGS+= -lusb
+
+ifeq ($(shell test $$(uname -U) -ge 1002000; echo $$?),1)
+ifeq (,$(wildcard /usr/local/include/iconv.h))
+$(error FreeBSD pre 10.2: Please install libiconv from ports)
+else
 CFLAGS += -I/usr/local/include
 LDFLAGS+= -L/usr/local/lib -liconv
 endif
-LDFLAGS+= -lusb
+endif
+
 endif
 
 $(OBJDIR)/MinOZW:	$(patsubst %.cpp,$(OBJDIR)/%.o,$(minozwsrc))

--- a/cpp/hidapi/libusb/hid.c
+++ b/cpp/hidapi/libusb/hid.c
@@ -335,7 +335,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-	const char *inptr;
+	char *inptr;
 	char *outptr;
 
 	/* Determine which language to use. */


### PR DESCRIPTION
Revert hid.c change in d78c7d0, and enforce older FreeBSD versions to
use libiconv from ports instead of old non-posix from base.

Fixes #748, tested on both 10.1 and 10.2. Should work on 9.3 too.