### PR TITLE
Add Devolo Home Control Radiator Thermostat

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -192,6 +192,7 @@
 		<Product type="0002" id="000e" name="DCH-Z110 Door/Window 3 in 1 sensor" config="dlink/dch-z110.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0002" name="Danfoss">
+		<Product type="0005" id="0175" name="Devolo Home Control Radiator Thermostat" config="danfoss/z.xml"/>
 		<Product type="0005" id="0003" name="Z Thermostat" config="danfoss/z.xml"/>
 		<Product type="0005" id="0004" name="Z Thermostat 014G0013" config="danfoss/z.xml"/>
 		<Product type="0064" id="0001" name="RA Plus-W Radiator Thermostat"/>


### PR DESCRIPTION
The Devolo Home Control Radiator Thermostat is identical to the Danfoss Z Thermostat. There are some firmware differences, but it is functionally 100% identical to the Danfoss model, works fine with the danfoss/z.xml and has even the Danfoss manufacturer ID.
So it would be nice to add the configuration to the config file, it's just the one line with the different product id.