### PR TITLE
fixed minimote default value

### DIFF
--- a/config/aeotec/minimote.xml
+++ b/config/aeotec/minimote.xml
@@ -44,7 +44,7 @@
       <Item label="Learn Mode" value="5" />
     </Value>
 
-    <Value type="list" index="250" genre="config" label="Mode" units="" min="0" max="1" size="1" value="1">
+    <Value type="list" index="250" genre="config" label="Mode" units="" min="0" max="1" size="1" value="0">
       <Help>
         Enable selective Group Mode or Scene Mode when Button is in Use.
         NOTE: Minimote firmware 1.17 or higher is required, firmware 1.19 is highly recommended.</Help>


### PR DESCRIPTION
the default is group mode, but the xml config is inverted and the default is scene mode.. that is incorrect.

with index=250 value=1 it was impossible to update this parameter, see this thread and the posts leading up to it: https://www.domoticz.com/forum/viewtopic.php?f=6&t=2283&start=40#p71143

this very small change has proven to work for numerous people, the previous value gives nothing but headaches.

You can see the default was inverted with this commit, appears to be an accident: https://github.com/nayrnet/open-zwave/commit/a47eda41790c488f60f92e203c8e784f88629652