### PR TITLE
drive.cpp UPDATE_STATE_NEW_ID_ASSIGNED fix

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -3737,9 +3737,13 @@ bool Driver::HandleApplicationUpdateRequest
 		case UPDATE_STATE_NEW_ID_ASSIGNED:
 		{
 			Log::Write( LogLevel_Info, nodeId, "** Network change **: ID %d was assigned to a new Z-Wave node", nodeId );
-
-			// Request the node protocol info (also removes any existing node and creates a new one)
-			InitNode( nodeId );
+                        // Check if the new node id is equal to the current one.... if so no operation is needed, thus no remove and add is necessary
+                        if ( _data[3] != _data[6] )
+                        {
+                        	// Request the node protocol info (also removes any existing node and creates a new one)
+			        InitNode( nodeId );	
+                        }
+			
 			break;
 		}
 		case UPDATE_STATE_ROUTING_PENDING:


### PR DESCRIPTION
I detected a device that from times to times send a UPDATE_STATE_NEW_ID_ASSIGNED when it didn't happen, This device sends a request where the old id is equal to the current id so, IMHO there is no need to add and remove the device with initnode since it may generate a lot of remove and add events on a consumer application.

This situation may happen in order to a faulty device firmware, but since it comes from a commercial product that any other person has bought I guess that this small fix wont hurt no one