### PR TITLE
Fixed default values and param types for Aeotec Multisensor 6 & domitech Z-wave Smart LED Light Bulb support added

### DIFF
--- a/config/aeotec/multisensor6.xml
+++ b/config/aeotec/multisensor6.xml
@@ -38,7 +38,7 @@
 			<Item label="Disabled" value="0" />
 			<Item label="Enabled" value="1" /> 			
 		</Value>
-		<Value type="short" index="41" genre="config" label="Temperature Reporting Threshold" units="%" min="0" max="39321" value="1" size="2">
+		<Value type="short" index="41" genre="config" label="Temperature Reporting Threshold" units="%" min="0" max="39321" value="20" size="2">
 			<Help>Threshold change in temperature to induce an automatic report.  
 			Note: 
 			1. When the unit is Celsius, threshold=Value. 
@@ -46,7 +46,7 @@
 			3. The high byte is the part of integer, the low byte is the fractional part. 
 			</Help>
 		</Value>
-		<Value type="short" index="42" genre="config" label="Humidity Reporting Threshold" units="%" min="0" max="39321" value="5" size="2">
+		<Value type="byte" index="42" genre="config" label="Humidity Reporting Threshold" units="%" min="0" max="100" value="10" size="2">
 			<Help>Threshold change in humidity to induce an automatic report. 
 			Note: 
 			The accuracy is 0.1. 
@@ -56,7 +56,7 @@
 		<Value type="short" index="43" genre="config" label="Luminance Reporting Threshold" units="LUX" min="0" max="65535" value="100" size="2">
 			<Help>Threshold change in luminance to induce an automatic report. </Help>
 		</Value>
-		<Value type="short" index="44" genre="config" label="Battery Reporting Threshold" units="%" min="0" max="39321" value="5" size="2">
+		<Value type="byte" index="44" genre="config" label="Battery Reporting Threshold" units="%" min="0" max="100" value="10" size="2">
 			<Help>Threshold change in battery level to induce an  automatic report. 
 			Note: 
 			The accuracy is 0.1. 

--- a/config/domitech/z-wave_smart_led_ligth_bulb.xml
+++ b/config/domitech/z-wave_smart_led_ligth_bulb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="byte" index="1" genre="config" label="Status on turn on the bulb after turning off" units="" min="0" max="1" value="0">
+		  <Help>
+		     0=back to 100 % (Default) 1=back to last dimming level
+		  </Help>
+		</Value>
+		<Value type="byte" index="9" genre="config" label="Dimming Step Level" units="" min="1" max="99" value="1">
+		  <Help>
+		    You may change the dimming step level when you adjust the brightness by your controller. Low -> gradual, High -> Rapid
+		  </Help>
+		</Value>
+		<Value type="byte" index="10" genre="config" label="Dimming Step Timing" units="" min="1" max="10" value="3">
+		  <Help>
+		    You may change the dimming speed quicker or slower by changin this parameter. Low -> quick, High -> slow
+		  </Help>
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+        		<Group index="1" max_associations="5" label="Group #1 for lifeline communications. Max associations=5.  Lifeline association only supports the manual reset event." />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -205,6 +205,9 @@
 	</Manufacturer>
 	<Manufacturer id="0050" name="Digital 5">
 	</Manufacturer>
+	<Manufacturer id="020e" name="domitech">
+		<Product type="4c42" id="3134" name="Z-wave Smart LED Light Bulb" config="domitech/z-wave_smart_led_ligth_bulb.xml" />
+	</Manufacturer>
 	<Manufacturer id="0184" name="Dragon Tech">
 		<Product type="4447" id="3034" name="In Wall Dimmer" config="dragontech/wd-100.xml" />
 	</Manufacturer>


### PR DESCRIPTION
Fixed bug in Aeotec Multisensor 6 Z-Wave definition files (and one default value),

<pre>
#3031 Humidity Reporting Threshold -> OpenZWave set it always to 0 when trying to change

Hi Juho Ylikorpi,

I'll have our engineers change the engineering sheet on the Multisensor 6 for param 42 and 44, the only difference right now would be the size setting change

Instead of Size = 2 byte

Size = 1 byte

Cheers,
Chris Cheng
Field Application Engineer
Aeon Labs
ccheng@aeon-labs.com
</pre>