### PR TITLE
Device Support: Leviton VRMX1-1LZ - additional hardware id

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -466,6 +466,7 @@
 		<Product type="0501" id="0206" name="VRI10-1LX Multilevel Scene Switch" config="leviton/vri10.xml"/>
 		<Product type="0501" id="0209" name="VRI10-1LZ Scene Capable Dimmer" config="leviton/vri10.xml"/>
 		<Product type="0602" id="0209" name="VRMX1-1LZ Multilevel Scene Switch" config="leviton/vri10.xml"/>
+		<Product type="0602" id="0334" name="VRMX1-1LZ Multilevel Scene Switch" config="leviton/vri10.xml"/>
 		<Product type="0901" id="0215" name="VRC51-1LX One Scene Controller"/>
 		<Product type="0702" id="0261" name="VRCZ4-M0Z 4-Button Zone Controller"/>
 		<Product type="0b02" id="030b" name="VRC0P-1LW Plug-in Serial Interface Module"/>


### PR DESCRIPTION
Attach the right name and config to the version of the VRMX1-1LZ that I got (newer rev maybe? Ordered at http://smile.amazon.com/Leviton-VRMX1-1LZ-Universal-Magnetic-Voltage/dp/B005Y8JC6Q).