### PR TITLE
Device Support: Nexia DB100Z Z-Wave Doorbell Sensor configuration params

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -537,6 +537,10 @@
 	</Manufacturer>
 	<Manufacturer id="0083" name="MTC Maintronic">
 	</Manufacturer>
+	<Manufacturer id="0178" name="Nexia">
+		<!-- full name in Z-wave database: Ingersoll Rand - Nexia Home Intelligence -->
+		<Product type="4442" id="3130" name="DB100Z Doorbell Sensor" config="nexia/db100z.xml"/>
+	</Manufacturer>
 	<Manufacturer id="0165" name="NodOn">
     		<Product type="0001" id="0001" name="ASP-3-1-00 Smart Plug" config="nodon/asp3100SmartPlug.xml"/>
     		<Product type="0002" id="0001" name="CRC-3-1-00 Octan Remote" config="nodon/crc3100OctanRemote.xml"/>

--- a/config/nexia/db100z.xml
+++ b/config/nexia/db100z.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Ingersoll Rand - Nexia Home Intelligence; DB100Z Z-Wave Doorbell Sensor -->
+<!-- If the device isn't being discovered by OZW, tap the install button 3 times in a second (LED will turn on for 10 seconds) -->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="list" index="1" genre="config" label="Send Battery Report with Notification Report" min="0" max="1" value="0" size="1">
+			<Help>Send a battery report in addition to the alarm report when the alarm report is triggered</Help>
+			<Item label="No (default)" value="0" />
+			<Item label="Yes (recommended)" value="1" />
+		</Value>
+	</CommandClass>
+</Product>

--- a/config/nexia/db100z.xml
+++ b/config/nexia/db100z.xml
@@ -10,4 +10,10 @@
 			<Item label="Yes (recommended)" value="1" />
 		</Value>
 	</CommandClass>
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<!-- Z-Wave Plus Lifeline Battery Report, Notification Report, Device Reset Locally Notification -->
+			<Group index="1" max_associations="5" label="Lifeline" />
+		</Associations>
+	</CommandClass>
 </Product>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -141,6 +141,7 @@ DISTFILES =	.gitignore \
 	config/mcohome/mhs513.xml \
 	config/merten/507801.xml \
 	config/merten/50x5xx.xml \
+	config/nexia/db100z.xml \
 	config/nodon/asp3100SmartPlug.xml \
 	config/nodon/crc3100OctanRemote.xml \
 	config/nodon/cws3101wallswitch.xml \


### PR DESCRIPTION
Add configuration support for the Nexia DB100Z Z-Wave Doorbell Sensor.

It's only got one config param according to http://products.z-wavealliance.org/products/1349/configs, pretty simple/boring. Device works well otherwise - alarm class notifications (class 113, index 11, value of 0/1) for the doorbell state, and battery class for the battery reports, works great after discovery.