### PR TITLE
New device: Everspring AN181 Miniplug with meter function

### DIFF
--- a/config/everspring/an181.xml
+++ b/config/everspring/an181.xml
@@ -1,0 +1,45 @@
+<Product xmlns="http://code.google.com/p/open-zwave/">
+    <!-- Everspring - AN181 - Miniplug On/Off with meter function -->
+    <!-- Configuration Parameters -->
+    <CommandClass id="112">
+        <Value type="short" index="1" genre="config" label="Basic Set Command" units="" min="0" max="255" size="2" value="255">
+            <Help>
+	Set Basic Set Command value to be sent to group 2 when switch is turned on.
+
+	When the physical button on the mini-plug is used to turn OFF the switch the value "0" will always be sent to group 2,
+	however this is not the case when the switch is turned off remotely.
+	    </Help>
+        </Value>
+        <Value type="byte" index="2" genre="config" label="Delay" units="seconds" min="3" max="25" size="1" value="3">
+            <Help>
+                The delaying time to report to Group 1
+            </Help>
+        </Value>
+        <Value type="list" index="3" genre="config" label="Remember Last" units="" min="0" max="1" value="1">
+            <Help>
+                Remember the last status on plug
+            </Help>
+            <Item label="Do not remember" value="0"/>
+            <Item label="Remember" value="1"/>
+        </Value>
+        <Value type="short" index="4" genre="config" label="Wattage Auto Report" units="minutes" min="0" max="32767" size="2" value="1">
+            <Help>Set the interval for wattage auto report (0 = disabled)</Help>
+        </Value>
+        <Value type="short" index="5" genre="config" label="Energy Auto report" units="minutes" min="0" max="32767" size="2" value="60">
+            <Help>Set the interval for kWh auto report (0 = disabled)</Help>
+        </Value>
+        <Value type="short" index="6" genre="config" label="Value of Wattage surpassed" units="watts" min="0" max="2500" size="2" value="0">
+            <Help>Auto report is sent when load surpasses the set value of wattage (0 = disabled)</Help>
+        </Value>
+        <Value type="byte" index="7" genre="config" label="Change of Wattage surpassed" units="%" min="0" max="100" size="2" value="0">
+            <Help>Auto report is sent when the change of wattage surpasses the set percentage (0 = disabled)</Help>
+        </Value>
+    </CommandClass>
+    <!-- Association Groups -->
+    <CommandClass id="133">
+        <Associations num_groups="2">
+            <Group index="1" max_associations="1" label="Lifeline" />
+            <Group index="2" max_associations="4" label="On/Off control (Button on the mini-plug)" />
+        </Associations>
+    </CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -245,12 +245,13 @@
 		<Product type="0001" id="0002" name="SP814 Motion Detector" config="everspring/sp814.xml"/>
 		<Product type="0002" id="0001" name="SM103 Door/Window Sensor" config="everspring/sm103.xml"/>
 		<Product type="0003" id="0001" name="AD142 Plug-in Dimmer Module"/>
-        <Product type="0003" id="0003" name="AD147 Plug-in Dimmer Module" config="everspring/ad147.xml"/>
-        <Product type="0003" id="0002" name="AD146 In wall Dimmer Module" config="everspring/ad146.xml"/>
+        	<Product type="0003" id="0003" name="AD147 Plug-in Dimmer Module" config="everspring/ad147.xml"/>
+        	<Product type="0003" id="0002" name="AD146 In wall Dimmer Module" config="everspring/ad146.xml"/>
 		<Product type="0004" id="0001" name="AN157 Plug-in Appliance Module"/>
 		<Product type="0004" id="0002" name="AN158 Plug-in Meter Appliance Module" config="everspring/an158.xml"/>
-        <Product type="0004" id="0007" name="AN180 Plug-in ON/OFF Module" config="everspring/an180.xml"/>
-        <Product type="0004" id="0008" name="AN179 In wall ON/OFF Module" config="everspring/an179.xml"/>
+                <Product type="0004" id="0006" name="AN181 Miniplug On/Off with meter function" config="everspring/an181.xml"/>
+        	<Product type="0004" id="0007" name="AN180 Plug-in ON/OFF Module" config="everspring/an180.xml"/>
+        	<Product type="0004" id="0008" name="AN179 In wall ON/OFF Module" config="everspring/an179.xml"/>
 		<Product type="0006" id="0001" name="ST814 Temperature and Humidity Sensor" config="everspring/st814.xml"/>
 		<Product type="0007" id="0001" name="ST815 Illumination Sensor" config="everspring/st815.xml"/>
 		<Product type="0009" id="0001" name="TSE03 Door Bell" config="everspring/tse03.xml"/>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -78,6 +78,7 @@ DISTFILES =	.gitignore \
 	config/everspring/an158.xml \
 	config/everspring/an179.xml \
 	config/everspring/an180.xml \
+	config/everspring/an181.xml \
 	config/everspring/hsp02.xml \
 	config/everspring/se812.xml \
 	config/everspring/sf812.xml \


### PR DESCRIPTION
Tested with latest snapshot of Domoticz and works reasonable OK. 

All control seems to work ok, but the meter support does not work for kWh or power factor.
Not sure if the Notification reports (device powered on, or overload situation) works.
If communication is temporarily lost, or device experience power failure: then Domoticz reports the switch as ON when communication is restored even though it may be in OFF position... -> Is the Notification Report (device powered on) misinterpreted as the switch is in ON position?