### PR TITLE
Fixed crash on Windows systems. Timestamp (m_stamp)not parsed as pointer (Used in the Control Panel)

### DIFF
--- a/cpp/hidapi/hidapi/hidapi.h
+++ b/cpp/hidapi/hidapi/hidapi.h
@@ -29,8 +29,13 @@
 
 #include <wchar.h>
 
-#define HID_API_EXPORT /**< API export macro */
-#define HID_API_CALL /**< API call macro */
+#ifdef _WIN32
+      #define HID_API_EXPORT __declspec(dllexport)
+      #define HID_API_CALL
+#else
+      #define HID_API_EXPORT /**< API export macro */
+      #define HID_API_CALL /**< API call macro */
+#endif
 
 #define HID_API_EXPORT_CALL HID_API_EXPORT HID_API_CALL /**< API export and call macro*/
 

--- a/cpp/hidapi/hidapi/hidapi.h
+++ b/cpp/hidapi/hidapi/hidapi.h
@@ -29,13 +29,8 @@
 
 #include <wchar.h>
 
-#ifdef _WIN32
-      #define HID_API_EXPORT __declspec(dllexport)
-      #define HID_API_CALL
-#else
-      #define HID_API_EXPORT /**< API export macro */
-      #define HID_API_CALL /**< API call macro */
-#endif
+#define HID_API_EXPORT /**< API export macro */
+#define HID_API_CALL /**< API call macro */
 
 #define HID_API_EXPORT_CALL HID_API_EXPORT HID_API_CALL /**< API export and call macro*/
 

--- a/cpp/src/platform/windows/TimeStampImpl.cpp
+++ b/cpp/src/platform/windows/TimeStampImpl.cpp
@@ -92,7 +92,7 @@ string TimeStampImpl::GetAsString
 {
 	// Convert m_stamp (FILETIME) to SYSTEMTIME for ease of use
 	SYSTEMTIME time;
-	::FileTimeToSystemTime( (FILETIME*)m_stamp, &time );
+	::FileTimeToSystemTime( (FILETIME*)&m_stamp, &time );
 
 	char buf[100];
 	sprintf_s( buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d:%03d ", time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute, time.wSecond, time.wMilliseconds );


### PR DESCRIPTION
Also fixed the hidapi dll export, causing the final windows application to contain hid exports.
This was already merged some time ago, but somehow reverted back ?