### PR TITLE
Corrected description for Aeotec Heavy Duty Smart Switch Gen5: LED Status

### DIFF
--- a/config/aeotec/hdss_gen5.xml
+++ b/config/aeotec/hdss_gen5.xml
@@ -16,7 +16,7 @@
       <Item label="Enable" value="1" />
     </Value>
     <Value type="list" index="20" genre="config" label="LED Mode" size="1" value="0">
-      <Help>LED status after power on</Help>
+      <Help>Switch status after power on</Help>
       <Item label="Last Status" value="0"/>
       <Item label="On" value="1"/>
       <Item label="Off" value="2"/>


### PR DESCRIPTION
Corrected description for Aeotec Heavy Duty Smart Switch Gen5: Configuration value 20 is not just LED status after power on, but even the switch status setting after power on (power loss).