### PR TITLE
Fix CPPFLAGS in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ PREFIX ?= /usr/local
 export PREFIX
 
 all: 
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) 
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) 
+	CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) 
+	CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) 
 
 install:
 	$(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) $(MAKECMDGOALS)
@@ -29,7 +29,7 @@ clean:
 	$(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) $(MAKECMDGOALS)
 
 cpp/src/vers.cpp:
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) cpp/src/vers.cpp
+	CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) cpp/src/vers.cpp
 
 check: xmltest
 

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -61,7 +61,7 @@ else
 LDFLAGS += -shared -Wl,-soname,libopenzwave.so.$(VERSION)
 LIBS 	+= -ludev
 endif
-CFLAGS  += $(CPPFLAGS)
+CFLAGS  += "$(CPPFLAGS)"
 
 #where to put the temporary library
 LIBDIR	?= $(top_builddir)

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -10,8 +10,8 @@
 .PHONY:	default clean
 
 
-DEBUG_CFLAGS    := -Wall -Wno-format -ggdb -DDEBUG $(CPPFLAGS)
-RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -Wno-format -O3 $(CPPFLAGS)
+DEBUG_CFLAGS    := -Wall -Wno-format -ggdb -DDEBUG "$(CPPFLAGS)"
+RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -Wno-format -O3 "$(CPPFLAGS)"
 
 DEBUG_LDFLAGS	:= -g
 

--- a/cpp/hidapi/linux/hid.c
+++ b/cpp/hidapi/linux/hid.c
@@ -21,6 +21,8 @@
         http://github.com/signal11/hidapi .
 ********************************************************/
 
+#define _GNU_SOURCE /* needed for wcsdup() before glibc 2.10 */
+
 /* C */
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Put $(CPPFLAGS) between double quote otherwise compilation will fail if CPPFLAGS
are defined by the buildsystem with more than one variable such as "-DX -DY"