### PR TITLE
Add RaZBerry Pi board ID=0002 (Same as ID=0001)

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -764,6 +764,7 @@
 	</Manufacturer>
 	<Manufacturer id="0118" name="Wenzhou TKB Control System">
 		<Product type="0001" id="0001" name="TZ88 Smart Energy Plug-in Switch" config="wenzhou/tz88.xml"/>
+ 		<Product type="0001" id="0011" name="TZ88E Smart Energy Plug-in Switch" config="wenzhou/tz88.xml"/>
 		<Product type="0002" id="0001" name="SM103 Door/Window Sensor" config="wenzhou/sm103.xml"/>
 		<Product type="0002" id="0002" name="TSP01 3 in 1 PIR Motion Sensor" config="wenzhou/tsp01.xml" />
 		<Product type="0003" id="0002" name="TZ68 On/Off Switch Socket" config="wenzhou/tz68.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -848,6 +848,7 @@
 	<Manufacturer id="0147" name="Z-Wave.Me">
 		<Product type="0002" id="0003" name="RaZberry Controller"/>
 		<Product type="0400" id="0001" name="RaZberry Controller ZWave+"/>
+		<Product type="0400" id="0002" name="RaZberry Controller 2016 ZWave+"/>
 	</Manufacturer>
 	<Manufacturer id="004f" name="Z-Wave Technologia">
 	</Manufacturer>


### PR DESCRIPTION
New RaZBerry board has an updated ID. No differences known between this one and the older ID=0001, but I've added 2016 into the name to differentiate.