### PR TITLE
Fix warning on wcsdup implicit declaration

### DIFF
--- a/cpp/hidapi/linux/hid.c
+++ b/cpp/hidapi/linux/hid.c
@@ -21,6 +21,8 @@
         http://github.com/signal11/hidapi .
 ********************************************************/
 
+#define _GNU_SOURCE /* needed for wcsdup() before glibc 2.10 */
+
 /* C */
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Define __GNU_SOURCE in cpp/hidapi/linux/hid.c (like already done in
cpp/hidapi/libusb/hid.c) to fix implicit declaration of wcsdup function