### PR TITLE
Fix libopenzwave.pc when using custom values

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -160,8 +160,8 @@ $(top_builddir)/libopenzwave.pc: $(top_srcdir)/cpp/build/libopenzwave.pc.in $(PK
 		-e 's|[@]prefix@|$(PREFIX)|g' \
 		-e 's|[@]exec_prefix@|$(PREFIX)/bin|g' \
 		-e 's|[@]libdir@|$(instlibdir)|g' \
-		-e 's|[@]includedir@|$(PREFIX)/include/openzwave/|g' \
-                -e 's|[@]sysconfdir@|$(PREFIX)/etc/openzwave/|g' \
+		-e 's|[@]includedir@|$(includedir)/|g' \
+                -e 's|[@]sysconfdir@|$(sysconfdir)/|g' \
                 -e 's|[@]gitversion@|$(GITVERSION)|g' \
                 -e 's|[@]docdir@|$(docdir)/|g' \
 		-e 's|[@]VERSION@|$(VERSION)|g' \


### PR DESCRIPTION
sysconfdir and includedir can be overriden by the build system however those values weren't used when building libopenzwave.pc

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>