### PR TITLE
Remove endpoint mapping from the Qubino ZMNHBDx.xml defiition for the

### DIFF
--- a/config/qubino/ZMNHBDx.xml
+++ b/config/qubino/ZMNHBDx.xml
@@ -109,7 +109,4 @@
 	<!-- Remove COMMAND_CLASS_BASIC -->
 	<CommandClass id="32" action="remove" />		
 	
-	<!-- Map endpoints to instances -->
-	<CommandClass id="96" mapping="endpoints" /> 
-
 </Product>


### PR DESCRIPTION
Qubino 2x relay switch
This change enables the qubino to be seen as 3 devices. The first instance
is the device itself (Master switch, power and energy). The relays are numbered
by OZW as instance 2 and instance 3 with associated switches, power & energy reporting