### PR TITLE
Ensure correct git repository path

### DIFF
--- a/cpp/build/support.mk
+++ b/cpp/build/support.mk
@@ -29,7 +29,7 @@ GIT		:= $(shell which git)
 ifeq ($(GIT),)
 VERSION_REV ?= 0
 else
-GITVERSION	:= $(shell $(GIT) describe --long --tags --dirty 2>/dev/null | sed s/^v//)
+GITVERSION	:= $(shell $(GIT) --git-dir ./.git describe --long --tags --dirty 2>/dev/null | sed s/^v//)
 ifeq ($(GITVERSION),)
 GITVERSION	:= $(VERSION_MAJ).$(VERSION_MIN).-1
 VERSION_REV	:= 0


### PR DESCRIPTION
Add "--git-dir ./.git" to ensure the correct git repository path is used (this
fix a bug when trying to add openzwave to buildroot build system)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>