### PR TITLE
Fix vers.cpp target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	$(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) $(MAKECMDGOALS)
 
 cpp/src/vers.cpp:
-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) cpp/src/vers.cpp
+	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) $(top_srcdir)/cpp/src/vers.cpp
 
 check: xmltest
 


### PR DESCRIPTION
Fix "cpp/src/vers.cpp" target in main Makefile
Now it is possible to generate vers.cpp without building whole project by executing "make cpp/src/vers.cpp"
Fixes #881