### PR TITLE
Added Ecolink door/window sensor and fixed Ecolink PIR Motion sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -243,7 +243,8 @@
 		<Product type="0001" id="0001" name="Switchkeeper Plug-in Appliance Module"/>
 	</Manufacturer>
         <Manufacturer id="014a" name="Ecolink">
-                <Product type="0001" id="0001" name="Door/Window Sensor"/>
+                <Product type="0001" id="0001" name="PIR Motion Sensor"/>
+                <Product type="0001" id="0002" name="Door/Window Sensor"/>
                 <Product type="0001" id="0003" name="Garage Door Sensor"/>
         </Manufacturer>
 	<Manufacturer id="0087" name="Eka Systems">


### PR DESCRIPTION
I noticed that Ecolink Motion Sensor (https://www.amazon.com/Ecolink-Z-Wave-Motion-Detector-PIRZWAVE2-ECO/dp/B00FB1TBKS) was appearing with the wrong name. It was appearing as "Door/Window Sensor". I happen to also have several Ecolink Door/Window Sensors (https://www.amazon.com/Ecolink-Z-Wave-Window-Sensor-DWZWAVE2-ECO/dp/B00HPIYJWU) and they were not being recognized.

This PR fixes both problems. The PIR Motion Sensor now appears with proper name and Door/Sensor were added to the database.