### PR TITLE
Use errno variable instead of _set_errno function, fixes MINGW build …

### DIFF
--- a/cpp/src/platform/windows/LogImpl.cpp
+++ b/cpp/src/platform/windows/LogImpl.cpp
@@ -41,7 +41,11 @@ errno_t fopen_s(FILE** pFile, const char *filename, const char *mode)
 {
     if (!pFile)
     {
-        _set_errno(EINVAL);
+#ifdef __MINGW64__
+	_set_errno(EINVAL);
+#else
+        errno = EINVAL;
+#endif
         return EINVAL;
     }
 


### PR DESCRIPTION
Use errno variable instead of _set_errno function, fixes MINGW build with old msvcr lib