### PR TITLE
Sync DotNet ZWLogLevel Enum with the CPP enum

### DIFF
--- a/dotnet/src/ZWManager.h
+++ b/dotnet/src/ZWManager.h
@@ -59,6 +59,7 @@ namespace OpenZWaveDotNet
 	// Logging levels
 	public enum class ZWLogLevel
 	{
+		Invalid		= LogLevel_Invalid,
 		None		= LogLevel_None,
 		Always		= LogLevel_Always,
 		Fatal		= LogLevel_Fatal,


### PR DESCRIPTION
Added Invalid value in the ZWLogLevel Enum in DotNet to keep Enum in sync with the CPP enum