### PR TITLE
Ensure we send a WakeUpNoMoreInfo at end of QueryStages

### DIFF
--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -689,6 +689,12 @@ void Node::AdvanceQueries
 				notification->SetHomeAndNodeIds( m_homeId, m_nodeId );
 				GetDriver()->QueueNotification( notification );
 
+				/* if its a sleeping node, this will send a NoMoreInformation Packet to the device */
+				WakeUp* cc = static_cast<WakeUp*>( GetCommandClass( WakeUp::StaticGetCommandClassId() ) );
+				if( cc )
+				{
+					cc->SendPending();
+				}
 				// Check whether all nodes are now complete
 				GetDriver()->CheckCompletedNodeQueries();
 				return;

--- a/cpp/src/command_classes/WakeUp.h
+++ b/cpp/src/command_classes/WakeUp.h
@@ -77,7 +77,6 @@ namespace OpenZWave
 		list<Driver::MsgQueueItem>	m_pendingQueue;		// Messages waiting to be sent when the device wakes up
 		bool						m_awake;
 		bool						m_pollRequired;
-		bool						m_notification;
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
This fixes some devices that don't automatically goto sleep after the inclusion process has completed and our QueryStages is complete. 