### PR TITLE
Add start/stop level change report event handling to SwitchMultilevel

### DIFF
--- a/cpp/src/command_classes/SwitchMultilevel.cpp
+++ b/cpp/src/command_classes/SwitchMultilevel.cpp
@@ -182,31 +182,6 @@ bool SwitchMultilevel::HandleMsg
 			return true;
 		}
 
-		case SwitchMultilevelCmd_Set:
-		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchMultiLevel Set: level=%d", _data[1] );
-
-			if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Level ) ) )
-			{
-				value->OnValueRefreshed( _data[1] );
-				value->Release();
-			}
-
-			if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, SwitchMultilevelIndex_BrightReceived ) ) ) 
-			{
-				value->OnValueRefreshed(false);
-				value->Release();
-			}
-
-			if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, SwitchMultilevelIndex_DimReceived ) ) ) 
-			{
-				value->OnValueRefreshed(false);
-				value->Release();
-			}
-
-			return true;
-		}
-
 		case SwitchMultilevelCmd_StartLevelChange:
 		{
 			Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchMultiLevel StartLevelChange: data[1]=%d", _data[1] );


### PR DESCRIPTION
(Re-submission of previous pull-request)

This change allows reception of dim up/down events from dimmer controller paddles. Unfortunately, I also changed the message type handling from an if/else ladder to a switch which makes the diff difficult to parse. Let me know if I can help clarify.

This request also removes the dead set handler code from the previous request.
