### PR TITLE
Add support for AU/NZ Frequency Remotec ZXT120 IR Controller

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -735,6 +735,7 @@
 		<Product type="0001" id="8380" name="ZRC-100"/>
 		<Product type="0101" id="8371" name="ZXT-310EU"/>
 		<Product type="0101" id="8377" name="ZXT-120" config="remotec/zxt-120.xml"/>
+		<Product type="0102" id="8377" name="ZXT-120" config="remotec/zxt-120.xml"/>
 		<Product type="0001" id="8510" name="ZRC-90" config="remotec/zrc-90.xml"/>
 		<Product type="8201" id="8120" name="ZFM-X10EU Dual Mode Insert Module "/>
 		<Product type="8000" id="0002" name="ZFM-80" config="remotec/zfm-80.xml" />


### PR DESCRIPTION
Adds support to OpenZave to recognise the Australian/New Zealand version
of the Remotec ZXT-120 A?C IR Controller.