### PR TITLE
Fix compilation of MinOZW

### DIFF
--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -17,9 +17,11 @@ DEBUG_LDFLAGS	:= -g
 
 top_srcdir := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../../)
 
+#where is put the temporary library
+LIBDIR  	?= $(top_builddir)
 
 INCLUDES	:= -I $(top_srcdir)/cpp/src -I $(top_srcdir)/cpp/tinyxml/ -I $(top_srcdir)/cpp/hidapi/hidapi/
-LIBS =  $(wildcard $(LIBDIR)/*.so $(LIBDIR)/*.dylib $(top_builddir)/*.so $(top_builddir)/*.dylib $(top_builddir)/cpp/build/*.so $(top_builddir)/cpp/build/*.dylib )
+LIBS =  $(wildcard $(LIBDIR)/*.so $(LIBDIR)/*.dylib $(top_builddir)/cpp/build/*.so $(top_builddir)/cpp/build/*.dylib )
 LIBSDIR = $(abspath $(dir $(firstword $(LIBS))))
 minozwsrc := $(notdir $(wildcard $(top_srcdir)/cpp/examples/MinOZW/*.cpp))
 VPATH := $(top_srcdir)/cpp/examples/MinOZW


### PR DESCRIPTION
LIBDIR was used in cpp/examples/MinOZW/Makefile to add dynamic
libraries. However, as it was unset by default, the cross-compilation
could fail if the host had a library such as libnss3.so in /.
To fix this issue, this patch sets LIBDIR to top_buildir if it is unset

Fixes:
  http://autobuild.buildroot.net/results/68719fdf1320a69310bada6d3c47654dacdb5898

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>