### PR TITLE
Make the ValueID default constructor public

### DIFF
--- a/cpp/src/value_classes/ValueID.h
+++ b/cpp/src/value_classes/ValueID.h
@@ -250,6 +250,9 @@ namespace OpenZWave
 		        m_id = ((uint32)(id & 0xFFFFFFFF));
 		        m_id1 = (uint32)(id >> 32);
 		}
+
+		// Default constructor
+		ValueID():m_id(0),m_id1(0),m_homeId(0){}
 	private:
 		// Construct a value id for use in notifications
 		ValueID( uint32 const _homeId, uint8 const _nodeId ): m_id1( 0 ),m_homeId( _homeId ){ m_id = ((uint32)_nodeId)<<24; }
@@ -259,9 +262,6 @@ namespace OpenZWave
 				m_id = (((uint32)_nodeId)<<24);
 				m_id1 = (((uint32)_instance)<<24);
 			}
-
-		// Default constructor
-		ValueID():m_id(0),m_id1(0),m_homeId(0){}
 
 		// Not all parts of the ValueID are necessary to uniquely identify the value.  In the case of a 
 		// Node's ValueStore, we can ignore the home ID, node ID, genre and type and still be left with


### PR DESCRIPTION
This is required by python-openzwave when it creates a Map with
ValueIDs as the value.