### PR TITLE
Fix FreeBSD soname

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -39,7 +39,7 @@ TARCH	+= -arch i386 -arch x86_64
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
 LIBS	+= -framework IOKit -framework CoreFoundation -arch i386 -arch x86_64
 else ifeq ($(UNAME),FreeBSD)
-LDFLAGS+= -shared -lusb
+LDFLAGS+= -shared -lusb -Wl,-soname,libopenzwave.so.$(VERSION)
 
 # Pre FreeBSD 10.2 we have no native, or "old" native iconv.h (non-posix compliant
 # const modifiers)


### PR DESCRIPTION
Hi,
a previous FreeBSD related change lost the -soname linker flag. This patch re-introduces it.

An unrelated question: What is the current version number / release plan?
The changelog has a V1.5 title which seems to get continually updated. But there is a V1.5 git tag pointing to 2 commits after V1.4 (a lot of commits ago).

I'm working on the FreeBSD package, it would be good to know what's to expect :)

Thanks!