### PR TITLE
Fix ValueList::SetByValue for values not starting at 0

### DIFF
--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -225,7 +225,7 @@ bool ValueList::SetByValue
 {
 	// create a temporary copy of this value to be submitted to the Set() call and set its value to the function param
   	ValueList* tempValue = new ValueList( *this );
-	tempValue->m_valueIdx = _value;
+	tempValue->m_valueIdx = GetItemIdxByValue(_value);
 
 	// Set the value in the device.
 	bool ret = ((Value*)tempValue)->Set();


### PR DESCRIPTION
When setting a configuration parameter List with a value not starting at 0 i got an "invalid Index" error (or something like that).

This was because the `ValueList::SetByValue()` got (in my case) the value 2 and used that as index, which did not exist.
By using `GetItemIdxByValue()` this was fixed.

```				
<Value type="list" genre="config" instance="1" index="5" label="Command Options" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="1" max="2" vindex="0" size="1">
					<Help>Which commands to send when PIR motion sensor triggered</Help>
					<Item label="Basic Set (default)" value="1" />
					<Item label="Binary Sensor Report" value="2" />
				</Value>
```