### PR TITLE
Fix null pointer

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -3860,7 +3860,7 @@ void Driver::CommonAddNodeStatusRequestHandler
 			 */
 			if( m_currentControllerCommand != NULL )
 			{
-                Log::Write( LogLevel_Info, nodeId, "Adding node ID %d - %s", _data[4], m_currentControllerCommand->m_controllerCommandArg ? "Secure" : "Non-Secure");
+				Log::Write( LogLevel_Info, nodeId, "Adding node ID %d - %s", _data[4], m_currentControllerCommand->m_controllerCommandArg ? "Secure" : "Non-Secure");
 				m_currentControllerCommand->m_controllerAdded = false;
 				m_currentControllerCommand->m_controllerCommandNode = _data[4];
 				/* make sure we dont overrun our buffer. Its ok to truncate */

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -3848,7 +3848,6 @@ void Driver::CommonAddNodeStatusRequestHandler
 		case ADD_NODE_STATUS_ADDING_SLAVE:
 		{
 			Log::Write( LogLevel_Info, nodeId, "ADD_NODE_STATUS_ADDING_SLAVE" );
-			Log::Write( LogLevel_Info, nodeId, "Adding node ID %d - %s", _data[4], m_currentControllerCommand->m_controllerCommandArg ? "Secure" : "Non-Secure");
 			/* Discovered all the CC's are sent in this packet as well:
 			 * position description
 			 * 4 - Node ID
@@ -3861,6 +3860,7 @@ void Driver::CommonAddNodeStatusRequestHandler
 			 */
 			if( m_currentControllerCommand != NULL )
 			{
+                Log::Write( LogLevel_Info, nodeId, "Adding node ID %d - %s", _data[4], m_currentControllerCommand->m_controllerCommandArg ? "Secure" : "Non-Secure");
 				m_currentControllerCommand->m_controllerAdded = false;
 				m_currentControllerCommand->m_controllerCommandNode = _data[4];
 				/* make sure we dont overrun our buffer. Its ok to truncate */


### PR DESCRIPTION
It was possible for `m_currentControllerCommand` to be NULL, thus accessing it causes a segmentation fault. Moving the log output inside the if where this is checked. 