### PR TITLE
fix to Nonce generation

### DIFF
--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -3427,9 +3427,31 @@ Node::DeviceClass* Node::GenericDeviceClass::GetSpecificDeviceClass
 //-----------------------------------------------------------------------------
 uint8 *Node::GenerateNonceKey() {
 	uint8 idx = this->m_lastnonce;
-	for (int i = 0; i < 8; i++) {
-		this->m_nonces[idx][i] = (rand()%0xFF)+1;
+
+	/* The first byte must be unique and non-zero.  The others are random.
+	   Per Numerical Recipes in C its best to use the high-order byte.  The
+	   floating point calculation here doesn't assume the size of the random
+	   integer, otherwise we could just shift the high byte over.
+	*/
+	uint8 match = 0;
+	do {
+		this->m_nonces[idx][0] = 1 + (uint8) (255.0 * rand() / (RAND_MAX + 1.0));
+		match = 0;
+		for (int i = 0; i < 8; i++) {
+			if (i == idx) {
+				continue;
+			}
+			if (this->m_nonces[idx][0] == this->m_nonces[i][0]) {
+				match = 1;
+			}
+		}
+	} while (match);
+
+	/* The other bytes have no restrictions. */
+	for (int i = 1; i < 8; i++) {
+		this->m_nonces[idx][i] = (int) (256.0 * rand() / (RAND_MAX + 1.0));
 	}
+
 	this->m_lastnonce++;
 	if (this->m_lastnonce >= 8)
 		this->m_lastnonce = 0;


### PR DESCRIPTION
Nonce handling has a bug.  If one is generated with the same first byte as an earlier in the cache (ie. m_nonces[i][0] == m_nonces[j][0] where i<j) and is used to encrypt a packet, then GetNonceKey() will pick the first (i) for decryption.  This causes the decryption to generate garbage, the MAC comparison to fail, and the packet to be dropped.

The fix is to require the first byte of each nonce be unique during generation.  This is actually required by the security protocol.

There are two other tweaks in this patch.  First, it also requires the first byte be non-zero.  This requirement is coming from a long-time ZWave developer; I haven't been able to find it documented anywhere.  (To not require this use the equation for the other bytes for the first, ie. 256*rand()/(RAND_MAX+1.0).)  Second, this uses the high-order bits from rand(), which are supposed to better.

This change has been stress-tested locally.
