### PR TITLE
Update ValueList.cpp

### DIFF
--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -224,8 +224,9 @@ bool ValueList::SetByValue
 )
 {
 	// create a temporary copy of this value to be submitted to the Set() call and set its value to the function param
+	// param is an index
   	ValueList* tempValue = new ValueList( *this );
-	tempValue->m_valueIdx = GetItemIdxByValue(_value);
+	tempValue->m_valueIdx = _value;
 
 	// Set the value in the device.
 	bool ret = ((Value*)tempValue)->Set();


### PR DESCRIPTION
Lists doesn't work if value is different of index, so if mode[1] = 1 it works, but if mode[1] = 3 then it doesn't work. It confuses index with value.
In this function we see
 tempValue->m_valueIdx = GetItemIdxByValue(_value); 
but _value (argument of the function) is not a value, it's an index, see setByLabel function where this function is called with an index as param, not a value.
Perhaps should the name be changed?