### PR TITLE
Add ZXT-120 product types for other regions

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -788,6 +788,10 @@
 		<Product type="0100" id="8377" name="ZXT-120US" config="remotec/zxt-120.xml"/>
 		<Product type="0101" id="8377" name="ZXT-120EU" config="remotec/zxt-120.xml"/>
 		<Product type="0102" id="8377" name="ZXT-120AU" config="remotec/zxt-120.xml"/>
+		<Product type="0103" id="8377" name="ZXT-120IN" config="remotec/zxt-120.xml"/>
+		<Product type="0106" id="8377" name="ZXT-120RU" config="remotec/zxt-120.xml"/>
+		<Product type="0107" id="8377" name="ZXT-120IL" config="remotec/zxt-120.xml"/>
+		<Product type="0108" id="8377" name="ZXT-120BR" config="remotec/zxt-120.xml"/>
 		<Product type="0001" id="8510" name="ZRC-90" config="remotec/zrc-90.xml"/>
 		<Product type="8201" id="8120" name="ZFM-X10EU Dual Mode Insert Module "/>
 		<Product type="8000" id="0002" name="ZFM-80" config="remotec/zfm-80.xml" />


### PR DESCRIPTION
Thanks Vincent Ou (Remotec) for providing the list of
product types and confirming that there are no differences
in firmware.

Probably need to change config to work around issue #1063,
but that does not appear to be region-specific.