### PR TITLE
replace fixed value initialization vector (for encryption key) 

### DIFF
--- a/cpp/src/ZWSecurity.cpp
+++ b/cpp/src/ZWSecurity.cpp
@@ -167,8 +167,7 @@ namespace OpenZWave {
 		 * and we add it also to the start of the payload
 		 */
 		for (int i = 0; i < 8; i++) {
-			//initializationVector[i] = (rand()%0xFF)+1;
-			initializationVector[i] = 0xAA;
+			initializationVector[i] = (uint8) (255.0 * rand() / (RAND_MAX + 1.0));
 			e_buffer[len++] = initializationVector[i];
 		}
 		/* the remaining 8 bytes are the NONCE we got from the device */
@@ -176,6 +175,11 @@ namespace OpenZWave {
 			initializationVector[8+i] = m_nonce[i];
 		}
 
+		/* we need a copy b/c aes_ofb_encrypt will overwrite it */
+		uint8 iv_dup[16];
+		for (int i = 0; i < 16; i++) {
+			iv_dup[i] = initializationVector[i];
+		}
 
 		uint8 plaintextmsg[32];
 		/* add the Sequence Flag
@@ -209,19 +213,9 @@ namespace OpenZWave {
 		e_buffer[len++] = m_nonce[0];
 
 
-		/* regenerate the IV */
-		for (int i = 0; i < 8; i++) {
-			//initializationVector[i] = (rand()%0xFF)+1;
-			initializationVector[i] = 0xAA;
-		}
-		/* the remaining 8 bytes are the NONCE we got from the device */
-		for (int i = 0; i < 8; i++) {
-			initializationVector[8+i] = m_nonce[i];
-		}
-
 		/* now calculate the MAC and append it */
 		uint8 mac[8];
-		GenerateAuthentication(&e_buffer[7], e_buffer[5], driver, _sendingNode, _receivingNode, initializationVector, mac);
+		GenerateAuthentication(&e_buffer[7], e_buffer[5], driver, _sendingNode, _receivingNode, iv_dup, mac);
 		for(int i=0; i<8; ++i )
 		{
 			e_buffer[len++] = mac[i];
@@ -284,7 +278,7 @@ namespace OpenZWave {
 		PrintHex("Raw", e_buffer, e_length);
 
 		if (e_length < 19) {
-			Log::Write(LogLevel_Warning, _sendingNode, "Recieved a Encrypted Message that is too Short. Dropping it");
+			Log::Write(LogLevel_Warning, _sendingNode, "Received a Encrypted Message that is too Short. Dropping it");
 			return false;
 		}
 


### PR DESCRIPTION

Code filled the sender portion of the intialization vector with 0xaa (with a random seed commented out).  It needs to be random bytes.  Because the IV is used twice and overwritten in-between by the aes_mode_reset() call, we need to create a copy for generating the MAC.

There's also a spelling typo in an unrelated comment that got fixed.
