### PR TITLE
Fix ThermostatSetpoint Command Class detecting wrong setpoint types

### DIFF
--- a/config/horstmann/scsc17.xml
+++ b/config/horstmann/scsc17.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- SCSC17 (Secure / Horstmann) -->
 <Product xmlns='http://code.google.com/p/open-zwave/'>
-  <!-- The thermostat does not properly report its operating modes -->
-  <CommandClass id="64" getsupported="false">
-    <SupportedModes>
-      <Mode index="0" label="Off"/>
-      <Mode index="1" label="Heat"/>
-    </SupportedModes>
-  </CommandClass>
-  <!-- This thermostat's setpoint descriptions are 0 based, not 1 -->
+
   <CommandClass id="67" base="0" override_precision="0"/>
 
   <!-- Configuration Parameters -->
@@ -26,7 +19,7 @@
     </Value>
     <Value type="byte" instance="1" index="4" genre="config" label="Delta T: Temperature change" min="1" max="50" value="5">
       <Help>Change between temperatures to trigger a temperature report (step 0.1)
-        1 to 50, 1 or 0.1 (Default 5 = 0,5C) -> (1C = 10)
+        1 to 50 (Default 5 = 0,5C)
       </Help>
     </Value>
   </CommandClass>

--- a/config/qubino/ZMNHIDxS2.xml
+++ b/config/qubino/ZMNHIDxS2.xml
@@ -11,20 +11,7 @@ ref: http://qubino.com/download/1061/
 -->
 <Product xmlns='http://code.google.com/p/open-zwave/'>
 
-     <!-- The thermostat does not properly report its operating modes -->
-	<CommandClass id="64">
-		<Value type="list" genre="user" instance="1" index="0" label="Mode" units="" read_only="false" write_only="false" min="0" max="0" value="0">
-            <Item label="Off" value="0" />
-            <Item label="Heat" value="1" />
-        </Value>
-   		<SupportedModes>
-     		<Mode index="0" label="Off" />
-     		<Mode index="1" label="Heat" />
-   		</SupportedModes>
-	</CommandClass>
-
-    <!-- This thermostat's setpoint descriptions are 0 based, not 1 -->
-    <CommandClass id="67"  base="0" override_precision="2"  />
+    <CommandClass id="67" base="0" override_precision="2"  />
     
     <!-- Configuration -->
     <CommandClass id="112">
@@ -121,6 +108,12 @@ ref: http://qubino.com/download/1061/
                 255 - Antifreeze functionality disabled.
                 Default value 50 (5.0 C).
             </Help>
+        </Value>
+        <Value type="list" genre="config" instance="1" index="59" label="Thermostat mode" size="1" min="0" max="1" value="0">
+            <Help>Set thermostat in heating or cooling mode.
+                After parameter change, first exclude module (without setting parameters to default value) and then re include the module.</Help>
+            <Item label="Heat mode" value="0" />
+            <Item label="Cool mode" value="1" />
         </Value>
         <Value type="short" genre="config" instance="1" index="60" label="Too low temperature limit" size="2" min="1" max="1150" value="50">
             <Help>


### PR DESCRIPTION
In response to a ThermostatSetpointCmd_SupportedGet, the ThermostatSetpoint command class considers each bit number is a setpoint type Id. However, the ThermostatSetpoint specification makes a distinction between both. This makes OpenZwave reporting wrong setpoint types (eg "Moist Air" instead of "Away heating"), so I added a mapping between bits and their corresponding setpoint types.

I also removed the ThermostatMode command class in the Horstmann/scsc17.xml config file because the thermostat does not handle it (it doesn't report it in its NIF, and doesn't mention it in its documentation either). This led to a unusable Mode value being shown in applications. However, the thermostat can _control_ a device using this command class.

Also renamed "Heating 1" and "Cooling 1" setpoint types into "Heating" and "Cooling" to get closer to the command class specification and because I don't see the reason of this "1". Of course, if I missed a point, let me know.