### PR TITLE
Added support for Fibaro Wall plug Gen5 (FGWPF-102)

### DIFF
--- a/config/fibaro/fgwpfzw5.xml
+++ b/config/fibaro/fgwpfzw5.xml
@@ -20,13 +20,13 @@
 			<Item label="Active" value="1" />
 		</Value>
 
-		<Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="0" size="1">
+		<Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="1" size="1">
 			<Help>This parameter determines how the Wall Plug will react in the event of power supply failure (e.g. taking out from the electrical outlet). After the power supply is back on, the Wall Plug can be restored to previous state or remain switched off. This parameter is ignored in Always On mode - the device automatically turns ON after plugging it into the socket. Default setting: 1</Help>
 			<Item label="Wall Plug does not memorize its state after a power failure" value="0" />
 			<Item label="Wall Plug memorizes its state after a power failure" value="1" />
 		</Value>
 
-		<Value type="short" genre="config" instance="1" index="3" label="Overload safety switch" value="0" size="2">
+		<Value type="short" genre="config" instance="1" index="3" label="Overload safety switch" value="0" min="0" max="30000" size="2">
 			<Help>This function allows for turning off the controlled device in case of exceeding the defined power. Controlled device will be turned off even if "always on" function is active (parameter 1). Controlled device can be turned back on via B-button or sending a control frame. Available settings: 10 - 30000 (1,0W - 3000,0W step 0,1W). Default setting: 0 (function inactive)</Help>
 		</Value>
 
@@ -34,11 +34,11 @@
 			<Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller with the highest priority in the Z-Wave network. By default, the Wall Plug immediately sends the power report if the power load changes by 80%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 80 (80%)</Help>
 		</Value>
 
-		<Value type="byte" genre="config" instance="1" index="11" label="Standard power load reporting" value="15" min="0" max="100" size="1">
+		<Value type="byte" genre="config" instance="1" index="11" label="Standard power load reporting" value="15" min="1" max="100" size="1">
 			<Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller Compared to parameter 10, the maximum number of reports sent is reduced (parameter 12) to 5 in a specified time interval. In addition, the frames are not sent in EXPLORE mode, which prevents overloading the Z-Wave network. By default changes in power load may be reported up to 5 times per 30 seconds, when power load changes by 15%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 15 (15%)</Help>
 		</Value>
 
-		<Value type="short" genre="config" instance="1" index="12" label="Power reporting interval" value="30" min="1" max="600" size="2">
+		<Value type="short" genre="config" instance="1" index="12" label="Power reporting interval" value="30" min="5" max="600" size="2">
 			<Help>This parameter defines how frequently standard power reports (parameter 11) will be sent. By default Wall Plug sends up to 5 reports each 30 seconds, provided the power load changes by 15%.  Available setttings: 5-600 (in seconds). Default setting: 30 (s)</Help>
 		</Value>
 
@@ -50,7 +50,7 @@
 			<Help>This parameter defines time period between reports sent when changes in power load have not been recorded or if changes are insignificant (not exceeding values of parameters 20, 21 and 23). By default reports are sent every hour. Available settings: 5 - 32400 (s). 0 - periodic reports inactive. Reports will be sent only in case of power load / energy consumption changes (parameters 20,21,23) or in case of polling. Default setting: 3600</Help>
 		</Value>
 
-		<Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="1" size="1">
+		<Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="0" size="1">
 			<Help>This parameter determines whether energy metering should include the amount of energy consumed by the Wall Plug itself. Results are being added to energy consumed by controlled device. Default setting: 0</Help>
 			<Item label="Inactive" value="0" />
 			<Item label="Active" value="1" />
@@ -96,7 +96,7 @@
 			<Item label="All alarms" value="63" />
 		</Value>
 
-		<Value type="list" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" size="1">
+		<Value type="short" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" min="0" max="50" size="1">
 			<Help>This parameter defines how the Wall Plug will respond to alarms (device’s status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
 		</Value>
 
@@ -108,7 +108,7 @@
 			<Help>Function is active only when parameter 41 is set to 0 or 1. Available settings: 1000 - 30000 (100,0W - 3000,0W, step 0,1W). Default setting: 25000 (2500W)</Help>
 		</Value>
 
-		<Value type="list" genre="config" instance="1" index="41" label="LED ring illumination colour when controlled device is on" value="5" size="1">
+		<Value type="list" genre="config" instance="1" index="41" label="LED ring illumination colour when controlled device is on" value="1" size="1">
 			<Help>0 - Illumination turned off completely, 1 - LED ring illumination colour changes continuously depending on active power, 2 - LED ring illumination colour changes in steps, depending on active power,  3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 1</Help>
 			<Item label="illumination turned off completely" value="0" />
 			<Item label="Colour changes continuously depending on active power" value="1" />
@@ -136,8 +136,8 @@
 
 		</Value>
 
-		<Value type="list" genre="config" instance="1" index="43" label="LED ring illumination colour at the Z-Wave network alarm detection" value="0" size="1">
-			<Help>0 - illumination turned off completely, 1 - No change in colour. LED ring illumination colour determined by parameters 41 or 42 settings, 2 - LED ring flashes red/blue/white (default), 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
+		<Value type="list" genre="config" instance="1" index="43" label="LED ring illumination colour at the Z-Wave network alarm detection" value="2" size="1">
+			<Help>0 - illumination turned off completely, 1 - No change in colour. LED ring illumination colour determined by parameters 41 or 42 settings, 2 - LED ring flashes red/blue/white (default), 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 2</Help>
 			<Item label="illumination turned off completely" value="0" />
 			<Item label="No change in colour" value="1" />
 			<Item label="LED ring flashes red / blue / white" value="2" />
@@ -163,9 +163,9 @@
 	<!-- Association Groups -->
 	<CommandClass id="133">
 		<Associations num_groups="3">
-			<Group index="1" max_associations="16" label="Lifeline"/>
-			<Group index="2" max_associations="16" label="On/Off (button)"  />
-			<Group index="3" max_associations="1" label="On/Off (power)"/>
+			<Group index="1" max_associations="1" label="Lifeline"/>
+			<Group index="2" max_associations="10" label="On/Off (button)"  />
+			<Group index="3" max_associations="10" label="On/Off (power)"/>
 		</Associations>
 	</CommandClass>
 

--- a/config/fibaro/fgwpfzw5.xml
+++ b/config/fibaro/fgwpfzw5.xml
@@ -16,8 +16,8 @@
 
 		<Value type="list" genre="config" instance="1" index="1" label="Always on function" value="0" size="1">
 			<Help>Once activated, Wall Plug will keep a connected device constantly ON, will stop reacting to alarm frames and B-button push. "Always on" function turns the Plug into a power and energy meter. Also, connected device will not be turned off upon receiving an alarm frame from another Z-Wave device (parameter 31 will be ignored). In "Always on" mode, connected device may be turned off only after user defined power has been exceeded (parameter 3). In such a case, connected device can be turned on again by pushing the B-button or sending a control frame. By default, overload protection is inactive. Default setting: 0</Help>
-			<Item label="function inactive" value="0" />
-			<Item label="function activated" value="1" />
+			<Item label="Inactive" value="0" />
+			<Item label="Active" value="1" />
 		</Value>
 
 		<Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="0" size="1">
@@ -52,8 +52,8 @@
 
 		<Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="1" size="1">
 			<Help>This parameter determines whether energy metering should include the amount of energy consumed by the Wall Plug itself. Results are being added to energy consumed by controlled device. Default setting: 0</Help>
-			<Item label="function inactive" value="0" />
-			<Item label="function activated" value="1" />
+			<Item label="Inactive" value="0" />
+			<Item label="Active" value="1" />
 		</Value>
 
 		<Value type="list" genre="config" instance="1" index="20" label="Control of On/Off (button) association group(2) devices" value="0" size="1">
@@ -163,9 +163,9 @@
 	<!-- Association Groups -->
 	<CommandClass id="133">
 		<Associations num_groups="3">
-			<Group index="1" max_associations="16" label="Lifeline" auto="true"/>
+			<Group index="1" max_associations="16" label="Lifeline"/>
 			<Group index="2" max_associations="16" label="On/Off (button)"  />
-			<Group index="3" max_associations="1" label="On/Off (power)" auto="false"/>
+			<Group index="3" max_associations="1" label="On/Off (power)"/>
 		</Associations>
 	</CommandClass>
 

--- a/config/fibaro/fgwpfzw5.xml
+++ b/config/fibaro/fgwpfzw5.xml
@@ -2,171 +2,171 @@
 
 <Product xmlns='http://code.google.com/p/open-zwave/'>
 
-  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
-  <!-- CommandClass id="113" action="remove" />
+	<!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+	<!-- CommandClass id="113" action="remove" /> -->
 
-  <!-- COMMAND_CLASS_SENSOR_ALARM not supported -->
-  <!-- CommandClass id="156" action="remove" />
+	<!-- COMMAND_CLASS_SENSOR_ALARM not supported -->
+	<!-- CommandClass id="156" action="remove" /> -->
 
-  <!-- COMMAND_CLASS_SWITCH_ALL not supported -->
-  <!-- CommandClass id="39" action="remove" />
+	<!-- COMMAND_CLASS_SWITCH_ALL not supported -->
+	<!-- CommandClass id="39" action="remove" /> -->
 
-  <!-- Configuration -->
-  <CommandClass id="112">
+	<!-- Configuration -->
+	<CommandClass id="112">
 
-    <Value type="list" genre="config" instance="1" index="1" label="Always on function" value="0" size="1">
-      <Help>Once activated, Wall Plug will keep a connected device constantly ON, will stop reacting to alarm frames and B-button push. "Always on" function turns the Plug into a power and energy meter. Also, connected device will not be turned off upon receiving an alarm frame from another Z-Wave device (parameter 31 will be ignored). In "Always on" mode, connected device may be turned off only after user defined power has been exceeded (parameter 3). In such a case, connected device can be turned on again by pushing the B-button or sending a control frame. By default, overload protection is inactive. Default setting: 0</Help>
-      <Item label="function inactive" value="0" />
-      <Item label="function activated" value="1" />
-    </Value>
+		<Value type="list" genre="config" instance="1" index="1" label="Always on function" value="0" size="1">
+			<Help>Once activated, Wall Plug will keep a connected device constantly ON, will stop reacting to alarm frames and B-button push. "Always on" function turns the Plug into a power and energy meter. Also, connected device will not be turned off upon receiving an alarm frame from another Z-Wave device (parameter 31 will be ignored). In "Always on" mode, connected device may be turned off only after user defined power has been exceeded (parameter 3). In such a case, connected device can be turned on again by pushing the B-button or sending a control frame. By default, overload protection is inactive. Default setting: 0</Help>
+			<Item label="function inactive" value="0" />
+			<Item label="function activated" value="1" />
+		</Value>
 
-     <Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="0" size="1">
-      <Help>This parameter determines how the Wall Plug will react in the event of power supply failure (e.g. taking out from the electrical outlet). After the power supply is back on, the Wall Plug can be restored to previous state or remain switched off. This parameter is ignored in Always On mode - the device automatically turns ON after plugging it into the socket. Default setting: 1</Help>
-      <Item label="Wall Plug does not memorize its state after a power failure" value="0" />
-      <Item label="Wall Plug memorizes its state after a power failure" value="1" />
-    </Value>
+		<Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="0" size="1">
+			<Help>This parameter determines how the Wall Plug will react in the event of power supply failure (e.g. taking out from the electrical outlet). After the power supply is back on, the Wall Plug can be restored to previous state or remain switched off. This parameter is ignored in Always On mode - the device automatically turns ON after plugging it into the socket. Default setting: 1</Help>
+			<Item label="Wall Plug does not memorize its state after a power failure" value="0" />
+			<Item label="Wall Plug memorizes its state after a power failure" value="1" />
+		</Value>
 
-   <Value type="short" genre="config" instance="1" index="3" label="Overload safety switch" value="0" size="2">
-      <Help>This function allows for turning off the controlled device in case of exceeding the defined power. Controlled device will be turned off even if "always on" function is active (parameter 1). Controlled device can be turned back on via B-button or sending a control frame. Available settings: 10 - 30000 (1,0W - 3000,0W step 0,1W). Default setting: 0 (function inactive)</Help>
-    </Value>
-   
-    <Value type="byte" genre="config" instance="1" index="10" label="High priority power report" value="80" min="1" max="100" size="1">
-    <Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller with the highest priority in the Z-Wave network. By default, the Wall Plug immediately sends the power report if the power load changes by 80%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 80 (80%)</Help>
-    </Value>
-   
-    <Value type="byte" genre="config" instance="1" index="11" label="Standard power load reporting" value="15" min="0" max="100" size="1">
-    <Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller Compared to parameter 10, the maximum number of reports sent is reduced (parameter 12) to 5 in a specified time interval. In addition, the frames are not sent in EXPLORE mode, which prevents overloading the Z-Wave network. By default changes in power load may be reported up to 5 times per 30 seconds, when power load changes by 15%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 15 (15%)</Help>
-    </Value>
-   
-    <Value type="short" genre="config" instance="1" index="12" label="Power reporting interval" value="30" min="1" max="600" size="2">
-    <Help>This parameter defines how frequently standard power reports (parameter 11) will be sent. By default Wall Plug sends up to 5 reports each 30 seconds, provided the power load changes by 15%.  Available setttings: 5-600 (in seconds). Default setting: 30 (s)</Help>
-    </Value>
-   
-    <Value type="short" genre="config" instance="1" index="13" label="Energy reporting threshold" value="10" min="0" max="500" size="2">
-    <Help>This parameter specifies the minimum change in energy consumption (in relation to the previously reported), that will result in sending a new report. Available settings: 1-500 (0,01kWh - 5kWh).   0 - energy reports inactive. Default Setting: 10 (0,1 kWh)</Help>
-    </Value>
-   
-    <Value type="short" genre="config" instance="1" index="14" label="Power and energy periodic reports" min="0" max="32400" value="3600" size="2">
-    <Help>This parameter defines time period between reports sent when changes in power load have not been recorded or if changes are insignificant (not exceeding values of parameters 20, 21 and 23). By default reports are sent every hour. Available settings: 5 - 32400 (s). 0 - periodic reports inactive. Reports will be sent only in case of power load / energy consumption changes (parameters 20,21,23) or in case of polling. Default setting: 3600</Help>
-    </Value>
-   
-    <Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="1" size="1">
-          <Help>This parameter determines whether energy metering should include the amount of energy consumed by the Wall Plug itself. Results are being added to energy consumed by controlled device. Default setting: 0</Help>
-          <Item label="function inactive" value="0" />
-          <Item label="function activated" value="1" />
-     </Value>
-    
-     <Value type="list" genre="config" instance="1" index="20" label="Control of On/Off (button) association group(2) devices" value="0" size="1">
-               <Help>Controlling devices with the B-Button. Control as the Wall Plug:  switching the Wall Plug on  switch the devices on (parameter 24) switching the Wall Plug off  switch the devices off (parameter 24)    This parameter is inactive in Always On mode (parameter 1). Default setting: 0</Help>
-               <Item label="Control as the wallplug" value="0" />
-               <Item label="Control opposite of wallplug" value="1" />
-     </Value>
-     
-     
-      <Value type="short" genre="config" instance="1" index="21" label="DOWN value- On/Off(power) association group(3)" value="300" min="0" max="24900" size="2">
-           <Help>Lower power threshold, used in parameter 23. Available settings: 0 - 24900 (0,0W - 2490,0W step 0,1W) DOWN value cannot be higher than a value specified in parameter 22. Default setting: 300 (30W)</Help>
-         </Value>
-    
-         <Value type="short" genre="config" instance="1" index="22" label="UP value- On/Off(power) association group(3)" value="500" min="100" max="25000" size="2">
-           <Help>Upper power threshold, used in parameter 23. Available settings: 100 - 25000 (10,0W - 2500,0W) UP value cannot be lower than a value specified in parameter 21. Default setting: 500 (50W)</Help>
-    </Value>
-   
-    <Value type="list" genre="config" instance="1" index="23" label="The response after exceeding defined power values" value="6" size="1">
-          <Help>Parameter defines the way 3th association group devices are controlled, depending on the actual measured power(as parameter 21 and 22 settings). Available settings: 1 - turn the associated devices ON, once the power drops below DOWN value (parameter 21), 2 - turn the associated devices OFF, once the power drops below DOWN value (parameter 21),       3 - turn the associated devices ON, once the power rises above UP value (parameter 22), 4 - turn the associated devices OFF, once the power rises above UP value (parameter 22), 5 - combination of 1 and 4. Turn the associated devices ON, once the power drops below DOWN value (parameter 21). Turn the associated devices OFF, once the power rises above UP value (parameter 22).  6 - combination of 2 and 3. Turn the associated devices OFF, once the power drops below DOWN value (parameter 21). Turn the associated devices ON, once the power rises above UP value (parameter 22). Default setting: 6</Help>
-          <Item label="Turn the associated devices on,Power below DOWN" value="1" />
-          <Item label="Turn the associated devices off,Power below DOWN" value="2" />
-          <Item label="Turn the associated devices on,Power above UP" value="3" />
-          <Item label="Turn the associated devices off,Power above UP" value="4" />
-          <Item label="1 and 4 combine" value="5" />
-          <Item label="2 and 3 combined" value="6" />
-    </Value>
-   
-    <Value type="short" genre="config" instance="1" index="24" label="Switch ON value - On/Off association groups" value="255" min="0" max="255" size="2">
-        <Help>The value of BASIC SET command frame sent to the devices associated in On/Off association groups (2, 3). On/Off (Button) association group - in accordance with parameter 20. On/Off (Power) association group - in accordance with parameter 23. Available settings: 0-99 and 255. Default setting: 255</Help>
-    </Value>
-   
-    <Value type="list" genre="config" instance="1" index="30" label="Active Alarms" value="63" min="1" max="63" size="1">
-          <Help>Define Z-Wave network alarms to which the Wall Plug will respond.</Help>
-          <Item label="General alarm" value="1" />
-          <Item label="Smoke alarm" value="2" />
-          <Item label="CO alarm" value="4" />
-          <Item label="CO2 alarm" value="8" />
-          <Item label="High temperature alarm" value="16" />
-          <Item label="Flood alarm" value="32" />
-            <Item label="All alarms" value="63" />
-    </Value>
+		<Value type="short" genre="config" instance="1" index="3" label="Overload safety switch" value="0" size="2">
+			<Help>This function allows for turning off the controlled device in case of exceeding the defined power. Controlled device will be turned off even if "always on" function is active (parameter 1). Controlled device can be turned back on via B-button or sending a control frame. Available settings: 10 - 30000 (1,0W - 3000,0W step 0,1W). Default setting: 0 (function inactive)</Help>
+		</Value>
 
-    <Value type="list" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" size="1">
-      <Help>This parameter defines how the Wall Plug will respond to alarms (device’s status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
-    </Value>
+		<Value type="byte" genre="config" instance="1" index="10" label="High priority power report" value="80" min="1" max="100" size="1">
+			<Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller with the highest priority in the Z-Wave network. By default, the Wall Plug immediately sends the power report if the power load changes by 80%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 80 (80%)</Help>
+		</Value>
 
-    <Value type="short" genre="config" instance="1" index="32" label="Alarm state duration" value="600" min="1" max="32400" size="2">
-      <Help>This parameter specifies the duration of alarm state. If a device sending an alarm frame through the Z-Wave network sets alarm duration as well, this settings are ignored. Available settings 1-32400(s) Default setting: 600</Help>
-    </Value>
+		<Value type="byte" genre="config" instance="1" index="11" label="Standard power load reporting" value="15" min="0" max="100" size="1">
+			<Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller Compared to parameter 10, the maximum number of reports sent is reduced (parameter 12) to 5 in a specified time interval. In addition, the frames are not sent in EXPLORE mode, which prevents overloading the Z-Wave network. By default changes in power load may be reported up to 5 times per 30 seconds, when power load changes by 15%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 15 (15%)</Help>
+		</Value>
 
-    <Value type="short" genre="config" instance="1" index="40" label="Power load, which when exceeded, makes the LED ring flash violet." value="25000" min="1000" max="30000" size="2">
-      <Help>Function is active only when parameter 41 is set to 0 or 1. Available settings: 1000 - 30000 (100,0W - 3000,0W, step 0,1W). Default setting: 25000 (2500W)</Help>
-    </Value>
+		<Value type="short" genre="config" instance="1" index="12" label="Power reporting interval" value="30" min="1" max="600" size="2">
+			<Help>This parameter defines how frequently standard power reports (parameter 11) will be sent. By default Wall Plug sends up to 5 reports each 30 seconds, provided the power load changes by 15%.  Available setttings: 5-600 (in seconds). Default setting: 30 (s)</Help>
+		</Value>
 
-     <Value type="list" genre="config" instance="1" index="41" label="LED ring illumination colour when controlled device is on" value="5" size="1">
-       <Help>0 - Illumination turned off completely, 1 - LED ring illumination colour changes continuously depending on active power, 2 - LED ring illumination colour changes in steps, depending on active power,  3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 1</Help>
-       <Item label="illumination turned off completely" value="0" />
-       <Item label="Colour changes continuously depending on active power" value="1" />
-       <Item label="Colour changes in steps depending on active power" value="2" />
-       <Item label="White illumination" value="3" />
-       <Item label="Red illumination" value="4" />
-       <Item label="Green illumination" value="5" />
-       <Item label="Blue illumination" value="6" />
-       <Item label="Yellow illumination" value="7" />
-       <Item label="Cyan illumination" value="8" />
-       <Item label="Magenta illumination" value="9" />
-    </Value>
+		<Value type="short" genre="config" instance="1" index="13" label="Energy reporting threshold" value="10" min="0" max="500" size="2">
+			<Help>This parameter specifies the minimum change in energy consumption (in relation to the previously reported), that will result in sending a new report. Available settings: 1-500 (0,01kWh - 5kWh).   0 - energy reports inactive. Default Setting: 10 (0,1 kWh)</Help>
+		</Value>
 
-    <Value type="list" genre="config" instance="1" index="42" label="LED ring illumination colour when controlled device is off" value="0" size="1">
-       <Help>0 - Illumination turned off completely, 1 - LED ring is illuminated with a colour corresponding to the last measured power, before the controlled device was turned off, 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
-       <Item label="illumination turned off completely" value="0" />
-       <Item label="LED ring is illuminated with a colour corresponding to the last measured power" value="1" />
-       <Item label="White illumination" value="3" />
-       <Item label="Red illumination" value="4" />
-       <Item label="Green illumination" value="5" />
-       <Item label="Blue illumination" value="6" />
-       <Item label="Yellow illumination" value="7" />
-       <Item label="Cyan illumination" value="8" />
-       <Item label="Magenta illumination" value="9" />
-      
-    </Value>
+		<Value type="short" genre="config" instance="1" index="14" label="Power and energy periodic reports" min="0" max="32400" value="3600" size="2">
+			<Help>This parameter defines time period between reports sent when changes in power load have not been recorded or if changes are insignificant (not exceeding values of parameters 20, 21 and 23). By default reports are sent every hour. Available settings: 5 - 32400 (s). 0 - periodic reports inactive. Reports will be sent only in case of power load / energy consumption changes (parameters 20,21,23) or in case of polling. Default setting: 3600</Help>
+		</Value>
 
-    <Value type="list" genre="config" instance="1" index="43" label="LED ring illumination colour at the Z-Wave network alarm detection" value="0" size="1">
-      <Help>0 - illumination turned off completely, 1 - No change in colour. LED ring illumination colour determined by parameters 41 or 42 settings, 2 - LED ring flashes red/blue/white (default), 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
-      <Item label="illumination turned off completely" value="0" />
-      <Item label="No change in colour" value="1" />
-      <Item label="LED ring flashes red / blue / white" value="2" />
-      <Item label="White illumination" value="3" />
-      <Item label="Red illumination" value="4" />
-      <Item label="Green illumination" value="5" />
-      <Item label="Blue illumination" value="6" />
-      <Item label="Yellow illumination" value="7" />
-      <Item label="Cyan illumination" value="8" />
-      <Item label="Magenta illumination" value="9" />
-          </Value>
+		<Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="1" size="1">
+			<Help>This parameter determines whether energy metering should include the amount of energy consumed by the Wall Plug itself. Results are being added to energy consumed by controlled device. Default setting: 0</Help>
+			<Item label="function inactive" value="0" />
+			<Item label="function activated" value="1" />
+		</Value>
 
-<Value type="list" genre="config" instance="1" index="50" label="Associations in Z-Wave network security mode" size="1" value="3">
-      <Help>This parameter defines how commands are sent in specified association groups: as secure or non-secure. Parameter is active only in Z-Wave network security mode. This parameter does not apply to 1st Lifeline group. Available settings: 0-3: 0 - none of the groups are  sent as secure; 1 - 2nd group sent as secure; 2 - 3rd group sent as secure; 3 - 2nd and 3rd group sent as secure; Default setting: 3</Help>
-      <Item label="none of the groups sent as secure" value="0" />
-      <Item label="2nd group send as secure" value="1" />
-      <Item label="3rd group send as secure" value="2" />
-      <Item label="2nd and 3rd group send as secure" value="3" />
-    </Value>
- 
-  </CommandClass>
+		<Value type="list" genre="config" instance="1" index="20" label="Control of On/Off (button) association group(2) devices" value="0" size="1">
+			<Help>Controlling devices with the B-Button. Control as the Wall Plug:  switching the Wall Plug on  switch the devices on (parameter 24) switching the Wall Plug off  switch the devices off (parameter 24)    This parameter is inactive in Always On mode (parameter 1). Default setting: 0</Help>
+			<Item label="Control as the wallplug" value="0" />
+			<Item label="Control opposite of wallplug" value="1" />
+		</Value>
 
-  <!-- Association Groups -->
-  <CommandClass id="133">
-    <Associations num_groups="3">
-      <Group index="1" max_associations="16" label="Lifeline" auto="true"/>
-      <Group index="2" max_associations="16" label="On/Off (button)"  />
-      <Group index="3" max_associations="1" label="On/Off (power)" auto="false"/>
-    </Associations>
-  </CommandClass>
+
+		<Value type="short" genre="config" instance="1" index="21" label="DOWN value- On/Off(power) association group(3)" value="300" min="0" max="24900" size="2">
+			<Help>Lower power threshold, used in parameter 23. Available settings: 0 - 24900 (0,0W - 2490,0W step 0,1W) DOWN value cannot be higher than a value specified in parameter 22. Default setting: 300 (30W)</Help>
+		</Value>
+
+		<Value type="short" genre="config" instance="1" index="22" label="UP value- On/Off(power) association group(3)" value="500" min="100" max="25000" size="2">
+			<Help>Upper power threshold, used in parameter 23. Available settings: 100 - 25000 (10,0W - 2500,0W) UP value cannot be lower than a value specified in parameter 21. Default setting: 500 (50W)</Help>
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="23" label="The response after exceeding defined power values" value="6" size="1">
+			<Help>Parameter defines the way 3th association group devices are controlled, depending on the actual measured power(as parameter 21 and 22 settings). Available settings: 1 - turn the associated devices ON, once the power drops below DOWN value (parameter 21), 2 - turn the associated devices OFF, once the power drops below DOWN value (parameter 21),       3 - turn the associated devices ON, once the power rises above UP value (parameter 22), 4 - turn the associated devices OFF, once the power rises above UP value (parameter 22), 5 - combination of 1 and 4. Turn the associated devices ON, once the power drops below DOWN value (parameter 21). Turn the associated devices OFF, once the power rises above UP value (parameter 22).  6 - combination of 2 and 3. Turn the associated devices OFF, once the power drops below DOWN value (parameter 21). Turn the associated devices ON, once the power rises above UP value (parameter 22). Default setting: 6</Help>
+			<Item label="Turn the associated devices on,Power below DOWN" value="1" />
+			<Item label="Turn the associated devices off,Power below DOWN" value="2" />
+			<Item label="Turn the associated devices on,Power above UP" value="3" />
+			<Item label="Turn the associated devices off,Power above UP" value="4" />
+			<Item label="1 and 4 combine" value="5" />
+			<Item label="2 and 3 combined" value="6" />
+		</Value>
+
+		<Value type="short" genre="config" instance="1" index="24" label="Switch ON value - On/Off association groups" value="255" min="0" max="255" size="2">
+			<Help>The value of BASIC SET command frame sent to the devices associated in On/Off association groups (2, 3). On/Off (Button) association group - in accordance with parameter 20. On/Off (Power) association group - in accordance with parameter 23. Available settings: 0-99 and 255. Default setting: 255</Help>
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="30" label="Active Alarms" value="63" min="1" max="63" size="1">
+			<Help>Define Z-Wave network alarms to which the Wall Plug will respond.</Help>
+			<Item label="General alarm" value="1" />
+			<Item label="Smoke alarm" value="2" />
+			<Item label="CO alarm" value="4" />
+			<Item label="CO2 alarm" value="8" />
+			<Item label="High temperature alarm" value="16" />
+			<Item label="Flood alarm" value="32" />
+			<Item label="All alarms" value="63" />
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" size="1">
+			<Help>This parameter defines how the Wall Plug will respond to alarms (device’s status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
+		</Value>
+
+		<Value type="short" genre="config" instance="1" index="32" label="Alarm state duration" value="600" min="1" max="32400" size="2">
+			<Help>This parameter specifies the duration of alarm state. If a device sending an alarm frame through the Z-Wave network sets alarm duration as well, this settings are ignored. Available settings 1-32400(s) Default setting: 600</Help>
+		</Value>
+
+		<Value type="short" genre="config" instance="1" index="40" label="Power load, which when exceeded, makes the LED ring flash violet." value="25000" min="1000" max="30000" size="2">
+			<Help>Function is active only when parameter 41 is set to 0 or 1. Available settings: 1000 - 30000 (100,0W - 3000,0W, step 0,1W). Default setting: 25000 (2500W)</Help>
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="41" label="LED ring illumination colour when controlled device is on" value="5" size="1">
+			<Help>0 - Illumination turned off completely, 1 - LED ring illumination colour changes continuously depending on active power, 2 - LED ring illumination colour changes in steps, depending on active power,  3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 1</Help>
+			<Item label="illumination turned off completely" value="0" />
+			<Item label="Colour changes continuously depending on active power" value="1" />
+			<Item label="Colour changes in steps depending on active power" value="2" />
+			<Item label="White illumination" value="3" />
+			<Item label="Red illumination" value="4" />
+			<Item label="Green illumination" value="5" />
+			<Item label="Blue illumination" value="6" />
+			<Item label="Yellow illumination" value="7" />
+			<Item label="Cyan illumination" value="8" />
+			<Item label="Magenta illumination" value="9" />
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="42" label="LED ring illumination colour when controlled device is off" value="0" size="1">
+			<Help>0 - Illumination turned off completely, 1 - LED ring is illuminated with a colour corresponding to the last measured power, before the controlled device was turned off, 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
+			<Item label="illumination turned off completely" value="0" />
+			<Item label="LED ring is illuminated with a colour corresponding to the last measured power" value="1" />
+			<Item label="White illumination" value="3" />
+			<Item label="Red illumination" value="4" />
+			<Item label="Green illumination" value="5" />
+			<Item label="Blue illumination" value="6" />
+			<Item label="Yellow illumination" value="7" />
+			<Item label="Cyan illumination" value="8" />
+			<Item label="Magenta illumination" value="9" />
+
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="43" label="LED ring illumination colour at the Z-Wave network alarm detection" value="0" size="1">
+			<Help>0 - illumination turned off completely, 1 - No change in colour. LED ring illumination colour determined by parameters 41 or 42 settings, 2 - LED ring flashes red/blue/white (default), 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
+			<Item label="illumination turned off completely" value="0" />
+			<Item label="No change in colour" value="1" />
+			<Item label="LED ring flashes red / blue / white" value="2" />
+			<Item label="White illumination" value="3" />
+			<Item label="Red illumination" value="4" />
+			<Item label="Green illumination" value="5" />
+			<Item label="Blue illumination" value="6" />
+			<Item label="Yellow illumination" value="7" />
+			<Item label="Cyan illumination" value="8" />
+			<Item label="Magenta illumination" value="9" />
+		</Value>
+
+		<Value type="list" genre="config" instance="1" index="50" label="Associations in Z-Wave network security mode" size="1" value="3">
+			<Help>This parameter defines how commands are sent in specified association groups: as secure or non-secure. Parameter is active only in Z-Wave network security mode. This parameter does not apply to 1st Lifeline group. Available settings: 0-3: 0 - none of the groups are  sent as secure; 1 - 2nd group sent as secure; 2 - 3rd group sent as secure; 3 - 2nd and 3rd group sent as secure; Default setting: 3</Help>
+			<Item label="none of the groups sent as secure" value="0" />
+			<Item label="2nd group send as secure" value="1" />
+			<Item label="3rd group send as secure" value="2" />
+			<Item label="2nd and 3rd group send as secure" value="3" />
+		</Value>
+
+	</CommandClass>
+
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="3">
+			<Group index="1" max_associations="16" label="Lifeline" auto="true"/>
+			<Group index="2" max_associations="16" label="On/Off (button)"  />
+			<Group index="3" max_associations="1" label="On/Off (power)" auto="false"/>
+		</Associations>
+	</CommandClass>
 
 </Product>

--- a/config/fibaro/fgwpfzw5.xml
+++ b/config/fibaro/fgwpfzw5.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+
+  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+  <!-- CommandClass id="113" action="remove" />
+
+  <!-- COMMAND_CLASS_SENSOR_ALARM not supported -->
+  <!-- CommandClass id="156" action="remove" />
+
+  <!-- COMMAND_CLASS_SWITCH_ALL not supported -->
+  <!-- CommandClass id="39" action="remove" />
+
+  <!-- Configuration -->
+  <CommandClass id="112">
+
+    <Value type="list" genre="config" instance="1" index="1" label="Always on function" value="0" size="1">
+      <Help>Once activated, Wall Plug will keep a connected device constantly ON, will stop reacting to alarm frames and B-button push. "Always on" function turns the Plug into a power and energy meter. Also, connected device will not be turned off upon receiving an alarm frame from another Z-Wave device (parameter 31 will be ignored). In "Always on" mode, connected device may be turned off only after user defined power has been exceeded (parameter 3). In such a case, connected device can be turned on again by pushing the B-button or sending a control frame. By default, overload protection is inactive. Default setting: 0</Help>
+      <Item label="function inactive" value="0" />
+      <Item label="function activated" value="1" />
+    </Value>
+
+     <Value type="list" genre="config" instance="1" index="2" label="Remember device status after a power failure" value="0" size="1">
+      <Help>This parameter determines how the Wall Plug will react in the event of power supply failure (e.g. taking out from the electrical outlet). After the power supply is back on, the Wall Plug can be restored to previous state or remain switched off. This parameter is ignored in Always On mode - the device automatically turns ON after plugging it into the socket. Default setting: 1</Help>
+      <Item label="Wall Plug does not memorize its state after a power failure" value="0" />
+      <Item label="Wall Plug memorizes its state after a power failure" value="1" />
+    </Value>
+
+   <Value type="short" genre="config" instance="1" index="3" label="Overload safety switch" value="0" size="2">
+      <Help>This function allows for turning off the controlled device in case of exceeding the defined power. Controlled device will be turned off even if "always on" function is active (parameter 1). Controlled device can be turned back on via B-button or sending a control frame. Available settings: 10 - 30000 (1,0W - 3000,0W step 0,1W). Default setting: 0 (function inactive)</Help>
+    </Value>
+   
+    <Value type="byte" genre="config" instance="1" index="10" label="High priority power report" value="80" min="1" max="100" size="1">
+    <Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller with the highest priority in the Z-Wave network. By default, the Wall Plug immediately sends the power report if the power load changes by 80%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 80 (80%)</Help>
+    </Value>
+   
+    <Value type="byte" genre="config" instance="1" index="11" label="Standard power load reporting" value="15" min="0" max="100" size="1">
+    <Help>This parameter determines the minimum percentage change in active power that will result in sending power report to the main controller Compared to parameter 10, the maximum number of reports sent is reduced (parameter 12) to 5 in a specified time interval. In addition, the frames are not sent in EXPLORE mode, which prevents overloading the Z-Wave network. By default changes in power load may be reported up to 5 times per 30 seconds, when power load changes by 15%. Available settings: 1-99:power change in percent, 100:reports are disabled. Default setting: 15 (15%)</Help>
+    </Value>
+   
+    <Value type="short" genre="config" instance="1" index="12" label="Power reporting interval" value="30" min="1" max="600" size="2">
+    <Help>This parameter defines how frequently standard power reports (parameter 11) will be sent. By default Wall Plug sends up to 5 reports each 30 seconds, provided the power load changes by 15%.  Available setttings: 5-600 (in seconds). Default setting: 30 (s)</Help>
+    </Value>
+   
+    <Value type="short" genre="config" instance="1" index="13" label="Energy reporting threshold" value="10" min="0" max="500" size="2">
+    <Help>This parameter specifies the minimum change in energy consumption (in relation to the previously reported), that will result in sending a new report. Available settings: 1-500 (0,01kWh - 5kWh).   0 - energy reports inactive. Default Setting: 10 (0,1 kWh)</Help>
+    </Value>
+   
+    <Value type="short" genre="config" instance="1" index="14" label="Power and energy periodic reports" min="0" max="32400" value="3600" size="2">
+    <Help>This parameter defines time period between reports sent when changes in power load have not been recorded or if changes are insignificant (not exceeding values of parameters 20, 21 and 23). By default reports are sent every hour. Available settings: 5 - 32400 (s). 0 - periodic reports inactive. Reports will be sent only in case of power load / energy consumption changes (parameters 20,21,23) or in case of polling. Default setting: 3600</Help>
+    </Value>
+   
+    <Value type="list" genre="config" instance="1" index="15" label="Measuring energy consumed by the Wall Plug itself" value="1" size="1">
+          <Help>This parameter determines whether energy metering should include the amount of energy consumed by the Wall Plug itself. Results are being added to energy consumed by controlled device. Default setting: 0</Help>
+          <Item label="function inactive" value="0" />
+          <Item label="function activated" value="1" />
+     </Value>
+    
+     <Value type="list" genre="config" instance="1" index="20" label="Control of On/Off (button) association group(2) devices" value="0" size="1">
+               <Help>Controlling devices with the B-Button. Control as the Wall Plug:  switching the Wall Plug on  switch the devices on (parameter 24) switching the Wall Plug off  switch the devices off (parameter 24)    This parameter is inactive in Always On mode (parameter 1). Default setting: 0</Help>
+               <Item label="Control as the wallplug" value="0" />
+               <Item label="Control opposite of wallplug" value="1" />
+     </Value>
+     
+     
+      <Value type="short" genre="config" instance="1" index="21" label="DOWN value- On/Off(power) association group(3)" value="300" min="0" max="24900" size="2">
+           <Help>Lower power threshold, used in parameter 23. Available settings: 0 - 24900 (0,0W - 2490,0W step 0,1W) DOWN value cannot be higher than a value specified in parameter 22. Default setting: 300 (30W)</Help>
+         </Value>
+    
+         <Value type="short" genre="config" instance="1" index="22" label="UP value- On/Off(power) association group(3)" value="500" min="100" max="25000" size="2">
+           <Help>Upper power threshold, used in parameter 23. Available settings: 100 - 25000 (10,0W - 2500,0W) UP value cannot be lower than a value specified in parameter 21. Default setting: 500 (50W)</Help>
+    </Value>
+   
+    <Value type="list" genre="config" instance="1" index="23" label="The response after exceeding defined power values" value="6" size="1">
+          <Help>Parameter defines the way 3th association group devices are controlled, depending on the actual measured power(as parameter 21 and 22 settings). Available settings: 1 - turn the associated devices ON, once the power drops below DOWN value (parameter 21), 2 - turn the associated devices OFF, once the power drops below DOWN value (parameter 21),       3 - turn the associated devices ON, once the power rises above UP value (parameter 22), 4 - turn the associated devices OFF, once the power rises above UP value (parameter 22), 5 - combination of 1 and 4. Turn the associated devices ON, once the power drops below DOWN value (parameter 21). Turn the associated devices OFF, once the power rises above UP value (parameter 22).  6 - combination of 2 and 3. Turn the associated devices OFF, once the power drops below DOWN value (parameter 21). Turn the associated devices ON, once the power rises above UP value (parameter 22). Default setting: 6</Help>
+          <Item label="Turn the associated devices on,Power below DOWN" value="1" />
+          <Item label="Turn the associated devices off,Power below DOWN" value="2" />
+          <Item label="Turn the associated devices on,Power above UP" value="3" />
+          <Item label="Turn the associated devices off,Power above UP" value="4" />
+          <Item label="1 and 4 combine" value="5" />
+          <Item label="2 and 3 combined" value="6" />
+    </Value>
+   
+    <Value type="short" genre="config" instance="1" index="24" label="Switch ON value - On/Off association groups" value="255" min="0" max="255" size="2">
+        <Help>The value of BASIC SET command frame sent to the devices associated in On/Off association groups (2, 3). On/Off (Button) association group - in accordance with parameter 20. On/Off (Power) association group - in accordance with parameter 23. Available settings: 0-99 and 255. Default setting: 255</Help>
+    </Value>
+   
+    <Value type="list" genre="config" instance="1" index="30" label="Active Alarms" value="63" min="1" max="63" size="1">
+          <Help>Define Z-Wave network alarms to which the Wall Plug will respond.</Help>
+          <Item label="General alarm" value="1" />
+          <Item label="Smoke alarm" value="2" />
+          <Item label="CO alarm" value="4" />
+          <Item label="CO2 alarm" value="8" />
+          <Item label="High temperature alarm" value="16" />
+          <Item label="Flood alarm" value="32" />
+            <Item label="All alarms" value="63" />
+    </Value>
+
+    <Value type="list" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" size="1">
+      <Help>This parameter defines how the Wall Plug will respond to alarms (device’s status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
+    </Value>
+
+    <Value type="short" genre="config" instance="1" index="32" label="Alarm state duration" value="600" min="1" max="32400" size="2">
+      <Help>This parameter specifies the duration of alarm state. If a device sending an alarm frame through the Z-Wave network sets alarm duration as well, this settings are ignored. Available settings 1-32400(s) Default setting: 600</Help>
+    </Value>
+
+    <Value type="short" genre="config" instance="1" index="40" label="Power load, which when exceeded, makes the LED ring flash violet." value="25000" min="1000" max="30000" size="2">
+      <Help>Function is active only when parameter 41 is set to 0 or 1. Available settings: 1000 - 30000 (100,0W - 3000,0W, step 0,1W). Default setting: 25000 (2500W)</Help>
+    </Value>
+
+     <Value type="list" genre="config" instance="1" index="41" label="LED ring illumination colour when controlled device is on" value="5" size="1">
+       <Help>0 - Illumination turned off completely, 1 - LED ring illumination colour changes continuously depending on active power, 2 - LED ring illumination colour changes in steps, depending on active power,  3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 1</Help>
+       <Item label="illumination turned off completely" value="0" />
+       <Item label="Colour changes continuously depending on active power" value="1" />
+       <Item label="Colour changes in steps depending on active power" value="2" />
+       <Item label="White illumination" value="3" />
+       <Item label="Red illumination" value="4" />
+       <Item label="Green illumination" value="5" />
+       <Item label="Blue illumination" value="6" />
+       <Item label="Yellow illumination" value="7" />
+       <Item label="Cyan illumination" value="8" />
+       <Item label="Magenta illumination" value="9" />
+    </Value>
+
+    <Value type="list" genre="config" instance="1" index="42" label="LED ring illumination colour when controlled device is off" value="0" size="1">
+       <Help>0 - Illumination turned off completely, 1 - LED ring is illuminated with a colour corresponding to the last measured power, before the controlled device was turned off, 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
+       <Item label="illumination turned off completely" value="0" />
+       <Item label="LED ring is illuminated with a colour corresponding to the last measured power" value="1" />
+       <Item label="White illumination" value="3" />
+       <Item label="Red illumination" value="4" />
+       <Item label="Green illumination" value="5" />
+       <Item label="Blue illumination" value="6" />
+       <Item label="Yellow illumination" value="7" />
+       <Item label="Cyan illumination" value="8" />
+       <Item label="Magenta illumination" value="9" />
+      
+    </Value>
+
+    <Value type="list" genre="config" instance="1" index="43" label="LED ring illumination colour at the Z-Wave network alarm detection" value="0" size="1">
+      <Help>0 - illumination turned off completely, 1 - No change in colour. LED ring illumination colour determined by parameters 41 or 42 settings, 2 - LED ring flashes red/blue/white (default), 3 - White illumination, 4 - Red illumination, 5 - Green illumination, 6 - Blue illumination, 7 - Yellow illumination, 8 - Cyan illumination, 9 - Magenta illumination. Default setting: 0</Help>
+      <Item label="illumination turned off completely" value="0" />
+      <Item label="No change in colour" value="1" />
+      <Item label="LED ring flashes red / blue / white" value="2" />
+      <Item label="White illumination" value="3" />
+      <Item label="Red illumination" value="4" />
+      <Item label="Green illumination" value="5" />
+      <Item label="Blue illumination" value="6" />
+      <Item label="Yellow illumination" value="7" />
+      <Item label="Cyan illumination" value="8" />
+      <Item label="Magenta illumination" value="9" />
+          </Value>
+
+<Value type="list" genre="config" instance="1" index="50" label="Associations in Z-Wave network security mode" size="1" value="3">
+      <Help>This parameter defines how commands are sent in specified association groups: as secure or non-secure. Parameter is active only in Z-Wave network security mode. This parameter does not apply to 1st Lifeline group. Available settings: 0-3: 0 - none of the groups are  sent as secure; 1 - 2nd group sent as secure; 2 - 3rd group sent as secure; 3 - 2nd and 3rd group sent as secure; Default setting: 3</Help>
+      <Item label="none of the groups sent as secure" value="0" />
+      <Item label="2nd group send as secure" value="1" />
+      <Item label="3rd group send as secure" value="2" />
+      <Item label="2nd and 3rd group send as secure" value="3" />
+    </Value>
+ 
+  </CommandClass>
+
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="3">
+      <Group index="1" max_associations="16" label="Lifeline" auto="true"/>
+      <Group index="2" max_associations="16" label="On/Off (button)"  />
+      <Group index="3" max_associations="1" label="On/Off (power)" auto="false"/>
+    </Associations>
+  </CommandClass>
+
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -407,7 +407,7 @@
 		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
 		<Product type="0203" id="1000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
 		<Product type="0600" id="1000" name="FGWPE Wall Plug" config="fibaro/fgwpe.xml" />
-		<Product type="0602" id="1001" name="FGWPE Wall Plug" config="fibaro/fgwpe.xml" />
+		<Product type="0602" id="1001" name="FGWPF Wall Plug Gen5" config="fibaro/fgwpfzw5.xml" />
 		<Product type="0800" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="2001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="4001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />


### PR DESCRIPTION
Added the file provided in the google discussion: https://groups.google.com/forum/#!topic/openzwave/4FmIYvXS9dY

Fixed some typos and performed a pretty print.

The previous file for the fibaro wall plug was not working correctly. (Power metering not reporting, incorrect parameters, ...)
 