### PR TITLE
Add Schlage BE468 lock

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -829,6 +829,7 @@
 	<Manufacturer id="003b" name="Schlage">
 		<Product type="634b" id="504c" name="FE599GR Wireless Door Lock"/>
 		<Product type="6341" id="5044" name="BE469NXCEN Touchscreen DeadBolt" config="schlage/BE469NXCEN.xml"/>
+		<Product type="6349" id="5044" name="BE468CAM619 Touchscreen DeadBolt" config="schlage/BE468CAM619.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0097" name="Schlage Link">
 		<Product type="1182" id="4501" name="iTemp Dual Sensor" config="schlagelink/itemp.xml" />

--- a/config/schlage/BE468CAM619.xml
+++ b/config/schlage/BE468CAM619.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<CommandClass id="112">
+		<Value type="list" genre="config" index="3" label="Beeper" min="0" max="255" size="1" value="255">
+			<Help>
+				Enable or disable the beeper.
+			</Help>
+			<Item label="Disable Beeper" value="0" />
+			<Item label="Enable Beeper" value="255" />
+
+		</Value>
+		<Value type="list" genre="config" index="4" label="Vacation Mode" min="0" max="255" size="1" value="0">
+			<Help>
+				Prevents all user codes from unlocking the deadbolt.
+				Enable for extra security while you are away for
+				an extended period of time.
+			</Help>
+			<Item label="Disable Vacation Mode" value="0" />
+			<Item label="Enable Vacation Mode" value="255" />
+		</Value>
+		<Value type="list" genre="config" index="5" label="Lock &amp; Leave" units="" min="0" max="255" size="1" value="255">
+			<Help>
+				When enabled: Press the Outside Schlage Button to lock the
+				deadbolt. (Default setting).
+				When disabled: Press the Outside Schlage Button and then enter
+				a user code to lock the deadbolt.
+			</Help>
+			<Item label="Disable Lock &amp; Leave" value="0" />
+			<Item label="Enable Lock &amp; Leave" value="255" />
+		</Value>
+		<Value type="int" genre="config" index="12" read_only="true" label="Electronic transition count" />
+		<Value type="int" genre="config" index="13" read_only="true" label="Mechanical transition count" />
+		<Value type="int" genre="config" index="14" read_only="true" label="Electronic failed count">
+			<Help>
+				Each failed electronic attempt increments this count by one.
+			</Help>
+		</Value>
+		<Value type="list" genre="config" index="15" label="Auto lock" size="1" value="0">
+			<Help>
+				When enabled, the lock will automatically relock 30 seconds
+				after unlocking. (Disabled by default.)
+			</Help>
+			<Item label="Disable auto lock" value="0" />
+			<Item label="Enable auto lock" value="255" />
+		</Value>
+		<Value type="byte" genre="config" index="16" label="User code pin length" min="4" max="8" value="4">
+			<Help>
+				User Code PIN length, a value between 4 and 8. 
+				IMPORTANT: All user codes must be the same length.
+			</Help>
+		</Value>
+		<Value type="int" genre="config" index="17" label="Electrical High Preload Transition Count" read_only="true">
+			<Help>
+				A subset of Electronic transition count, the number of transitions
+				with high preload.
+			</Help>
+		</Value>
+		<Value type="byte" genre="config" index="18" label="Bootloader Version" read_only="true">
+			<Help>The version of the bootloader</Help>
+		</Value>
+	</CommandClass>
+
+	<CommandClass id="113">
+		<!-- These Door Locks don't send a DoorLockReport when the
+		Lock Status is Changed, but instead send a Alarm Message -
+		So we trigger a Refresh of the DoorLock Command Class when
+		we recieve a Alarm Message Instead -->
+		<TriggerRefreshValue Genre="user" Index="0" Instance="1">
+			<RefreshClassValue CommandClass="98" RequestFlags="0" Index="1" Instance="1" />
+		</TriggerRefreshValue>
+	</CommandClass>
+</Product>


### PR DESCRIPTION
This adds information about the Schlage BE468 lock. It is nearly identical to the BE469, but it is missing a few of the features.