### PR TITLE
Set a time interval between commands for Remotec ZXT120, and other slow devices

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1282,6 +1282,17 @@ void Driver::RemoveCurrentMsg
 (
 )
 {
+    //OJO: set a sleep time interval (microseconds) for slow nodes, usleep(microseconds)
+    uint8 nodeId = GetNodeNumber( m_currentMsg );
+    if( Node* node = GetNodeUnsafe( nodeId ) )
+    {
+       uint32 toSleep = node->GettoSleep();
+       if (toSleep > 0)
+        {
+            usleep(toSleep);
+        }
+
+    }
 	Log::Write( LogLevel_Detail, GetNodeNumber( m_currentMsg ), "Removing current message" );
 	if( m_currentMsg != NULL)
 	{
@@ -4528,7 +4539,24 @@ uint32 Driver::GetNodeMaxBaudRate
 
 	return baud;
 }
+//-----------------------------------------------------------------------------
+// <Driver::GetNodetoSleep>
+// Get the value of toSleep for delay between commands
+//-----------------------------------------------------------------------------
+uint32 Driver::GetNodetoSleep
+(
+        uint8 const _nodeId
+)
+{
+    uint16 tsleep = 0;
+    LockGuard LG(m_nodeMutex);
+    if( Node* node = GetNode( _nodeId ) )
+    {
+        tsleep = node->GettoSleep();
+    }
 
+    return tsleep;
+}
 //-----------------------------------------------------------------------------
 // <Driver::GetNodeVersion>
 // Get the version number of a node
@@ -4992,7 +5020,22 @@ void Driver::SetNodeLocation
 		node->SetLocation( _location );
 	}
 }
-
+//-----------------------------------------------------------------------------
+// <Driver::SetNodetoSleep>
+// Set the toSleep value with the specified ID
+//-----------------------------------------------------------------------------
+void Driver::SetNodetoSleep
+(
+        uint8 const _nodeId,
+        uint32 const& _toSpeed
+)
+{
+    LockGuard LG(m_nodeMutex);
+    if( Node* node = GetNode( _nodeId ) )
+    {
+        node->SettoSleep( _toSpeed );
+    }
+}
 //-----------------------------------------------------------------------------
 // <Driver::SetNodeLevel>
 // Helper to set the node level through the basic command class

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -4548,14 +4548,14 @@ uint32 Driver::GetNodePacketDelay
         uint8 const _nodeId
 )
 {
-    uint16 tsleep = 0;
+    uint32 t_delay= 0;
     LockGuard LG(m_nodeMutex);
     if( Node* node = GetNode( _nodeId ) )
     {
-        tsleep = node->GetPacketDelay();
+        t_delay = node->GetPacketDelay();
     }
 
-    return tsleep;
+    return t_delay;
 }
 //-----------------------------------------------------------------------------
 // <Driver::GetNodeVersion>

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1282,7 +1282,7 @@ void Driver::RemoveCurrentMsg
 (
 )
 {
-    //OJO: set a sleep time interval (microseconds) for slow nodes, usleep(microseconds)
+    //OJO: set a delay time interval (microseconds) for slow nodes, usleep(microseconds)
     uint8 nodeId = GetNodeNumber( m_currentMsg );
     if( Node* node = GetNodeUnsafe( nodeId ) )
     {

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1286,10 +1286,10 @@ void Driver::RemoveCurrentMsg
     uint8 nodeId = GetNodeNumber( m_currentMsg );
     if( Node* node = GetNodeUnsafe( nodeId ) )
     {
-       uint32 toSleep = node->GettoSleep();
-       if (toSleep > 0)
+       uint32 PacketDelay = node->GetPacketDelay();
+       if (PacketDelay > 0)
         {
-            usleep(toSleep);
+            usleep(PacketDelay);
         }
 
     }
@@ -4540,10 +4540,10 @@ uint32 Driver::GetNodeMaxBaudRate
 	return baud;
 }
 //-----------------------------------------------------------------------------
-// <Driver::GetNodetoSleep>
-// Get the value of toSleep for delay between commands
+// <Driver::GetNodePacketDelay>
+// Get the value of PacketDelay for delay between commands
 //-----------------------------------------------------------------------------
-uint32 Driver::GetNodetoSleep
+uint32 Driver::GetNodePacketDelay
 (
         uint8 const _nodeId
 )
@@ -4552,7 +4552,7 @@ uint32 Driver::GetNodetoSleep
     LockGuard LG(m_nodeMutex);
     if( Node* node = GetNode( _nodeId ) )
     {
-        tsleep = node->GettoSleep();
+        tsleep = node->GetPacketDelay();
     }
 
     return tsleep;
@@ -5021,10 +5021,10 @@ void Driver::SetNodeLocation
 	}
 }
 //-----------------------------------------------------------------------------
-// <Driver::SetNodetoSleep>
-// Set the toSleep value with the specified ID
+// <Driver::SetNodePacketDelay>
+// Set the PacketDelay value with the specified ID
 //-----------------------------------------------------------------------------
-void Driver::SetNodetoSleep
+void Driver::SetNodePacketDelay
 (
         uint8 const _nodeId,
         uint32 const& _toSpeed
@@ -5033,7 +5033,7 @@ void Driver::SetNodetoSleep
     LockGuard LG(m_nodeMutex);
     if( Node* node = GetNode( _nodeId ) )
     {
-        node->SettoSleep( _toSpeed );
+        node->SetPacketDelay( _toSpeed );
     }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -418,8 +418,8 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint8 GetNodePlusType( uint8 const _nodeId );
 		string GetNodePlusTypeString ( uint8 const _nodeId );
 		bool IsNodeZWavePlus( uint8 const _nodeId );
-
-
+		uint32 GetNodetoSleep(uint8 const _nodeId);
+		
 		uint16 GetNodeManufacturerId( uint8 const _nodeId );
 		uint16 GetNodeProductType( uint8 const _nodeId );
 		uint16 GetNodeProductId( uint8 const _nodeId );
@@ -430,9 +430,8 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		void SetNodeLevel( uint8 const _nodeId, uint8 const _level );
 		void SetNodeOn( uint8 const _nodeId );
 		void SetNodeOff( uint8 const _nodeId );
-
+		void SetNodetoSleep(uint8 const _nodeId, uint32 const& _toSleep);
 		Value* GetValue( ValueID const& _id );
-
 		bool IsAPICallSupported( uint8 const _apinum )const{ return (( m_apiMask[( _apinum - 1 ) >> 3] & ( 1 << (( _apinum - 1 ) & 0x07 ))) != 0 ); }
 		void SetAPICall( uint8 const _apinum, bool _toSet )
 		{

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -418,7 +418,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint8 GetNodePlusType( uint8 const _nodeId );
 		string GetNodePlusTypeString ( uint8 const _nodeId );
 		bool IsNodeZWavePlus( uint8 const _nodeId );
-		uint32 GetNodetoSleep(uint8 const _nodeId);
+		uint32 GetNodePacketDelay(uint8 const _nodeId);
 		
 		uint16 GetNodeManufacturerId( uint8 const _nodeId );
 		uint16 GetNodeProductType( uint8 const _nodeId );
@@ -430,7 +430,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		void SetNodeLevel( uint8 const _nodeId, uint8 const _level );
 		void SetNodeOn( uint8 const _nodeId );
 		void SetNodeOff( uint8 const _nodeId );
-		void SetNodetoSleep(uint8 const _nodeId, uint32 const& _toSleep);
+		void SetNodePacketDelay(uint8 const _nodeId, uint32 const& _PacketDelay);
 		Value* GetValue( ValueID const& _id );
 		bool IsAPICallSupported( uint8 const _apinum )const{ return (( m_apiMask[( _apinum - 1 ) >> 3] & ( 1 << (( _apinum - 1 ) & 0x07 ))) != 0 ); }
 		void SetAPICall( uint8 const _apinum, bool _toSet )

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -1412,28 +1412,28 @@ string Manager::GetNodeProductId
 }
 
 //-----------------------------------------------------------------------------
-// <Manager::SetNodetoSleep>
-// Set a value for toSleep of a node
+// <Manager::SetNodePacketDelay>
+// Set a value for PacketDelay of a node
 //-----------------------------------------------------------------------------
-void Manager::SetNodetoSleep
+void Manager::SetNodePacketDelay
 (
         uint32 const _homeId,
         uint8 const _nodeId,
-        uint32 const& _toSleep
+        uint32 const& _PacketDelay
 
 )
 {
     if( Driver* driver = GetDriver( _homeId ) )
     {
-        driver->SetNodetoSleep( _nodeId, _toSleep );
+        driver->SetNodePacketDelay( _nodeId, _PacketDelay );
     }
 }
 
 //-----------------------------------------------------------------------------
-// <Manager::GetNodetoSleep>
-// Get the toSleep value of a node
+// <Manager::GetNodePacketDelay>
+// Get the PacketDelayvalue of a node
 //-----------------------------------------------------------------------------
-uint32 Manager::GetNodetoSleep
+uint32 Manager::GetNodePacketDelay
 (
         uint32 const _homeId,
         uint8 const _nodeId
@@ -1441,7 +1441,7 @@ uint32 Manager::GetNodetoSleep
 {
     if( Driver* driver = GetDriver( _homeId ) )
     {
-        uint32 mid = driver->GetNodetoSleep( _nodeId );
+        uint32 mid = driver->GetNodePacketDelay( _nodeId );
         return mid;
     }
 

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -1412,6 +1412,43 @@ string Manager::GetNodeProductId
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::SetNodetoSleep>
+// Set a value for toSleep of a node
+//-----------------------------------------------------------------------------
+void Manager::SetNodetoSleep
+(
+        uint32 const _homeId,
+        uint8 const _nodeId,
+        uint32 const& _toSleep
+
+)
+{
+    if( Driver* driver = GetDriver( _homeId ) )
+    {
+        driver->SetNodetoSleep( _nodeId, _toSleep );
+    }
+}
+
+//-----------------------------------------------------------------------------
+// <Manager::GetNodetoSleep>
+// Get the toSleep value of a node
+//-----------------------------------------------------------------------------
+uint32 Manager::GetNodetoSleep
+(
+        uint32 const _homeId,
+        uint8 const _nodeId
+)
+{
+    if( Driver* driver = GetDriver( _homeId ) )
+    {
+        uint32 mid = driver->GetNodetoSleep( _nodeId );
+        return mid;
+    }
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
 // <Manager::SetNodeOn>
 // Helper method to turn a node on
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -870,7 +870,13 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 * \return the node's PlusType as a string
 		 */
 		string GetNodePlusTypeString ( uint32 const _homeId, uint8 const _nodeId );
-
+		/*
+		* Get and Set th toSleep value for node
+		* This value is for a time interval between two commands sent one after one
+		* and so allow the device process the first command before receive the second one.
+		*/
+        	uint32 GetNodetoSleep(uint32 const _homeId, uint8 const _nodeId);
+        	void SetNodetoSleep( uint32 const _homeId, uint8 const _nodeId, uint32 const& _toSleep);
 
 
 	/*@}*/

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -871,12 +871,19 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 */
 		string GetNodePlusTypeString ( uint32 const _homeId, uint8 const _nodeId );
 		/*
-		* Get and Set th toSleep value for node
-		* This value is for a time interval between two commands sent one after one
-		* and so allow the device process the first command before receive the second one.
-		*/
-        	uint32 GetNodetoSleep(uint32 const _homeId, uint8 const _nodeId);
-        	void SetNodetoSleep( uint32 const _homeId, uint8 const _nodeId, uint32 const& _toSleep);
+		* \brief Get and Set th PacketDelay value for time interval between consecutives commands to slow nodes
+		* \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		* \param _nodeId The ID of the node to query.
+		* \return the time interval PacketDelay
+		*/ 
+        	uint32 GetNodePacketDelay(uint32 const _homeId, uint8 const _nodeId);
+		/*
+		* \brief Set and Set th PacketDelay value for time interval between consecutives commands to slow nodes
+		* \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		* \param _nodeId The ID of the node to query.
+		* \param _PacketDelay the time interval, microseconds less than 10000000
+		*/ 
+        	void SetNodePacketDelay( uint32 const _homeId, uint8 const _nodeId, uint32 const& _PacketDelay);
 
 
 	/*@}*/

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -1856,10 +1856,6 @@ void Node::SetPacketDelay
 )
 {
     	m_PacketDelay = _PacketDelay;
-    	// Notify the watchers of the value changes
-    	Notification* notification = new Notification( Notification::Type_NodeNaming );
-    	notification->SetHomeAndNodeIds( m_homeId, m_nodeId );
-    	GetDriver()->QueueNotification( notification );
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -150,6 +150,7 @@ m_numRouteNodes( 0 ),
 m_addingNode( false ),
 m_manufacturerName( "" ),
 m_productName( "" ),
+m_PacketDelay ( 0 ),
 m_nodeName( "" ),
 m_location( "" ),
 m_manufacturerId( 0 ),
@@ -1281,10 +1282,10 @@ void Node::WriteXML
 	snprintf( str, 32, "%d", m_version );
 	nodeElement->SetAttribute( "version", str );
 
-    	if (m_PacketDelay > 0){
-        	snprintf( str, 32, "%d", m_PacketDelay );
-        	nodeElement->SetAttribute( "PacketDelay", str );
-    	}
+    	
+        snprintf( str, 32, "%d", m_PacketDelay );
+        nodeElement->SetAttribute( "PacketDelay", str );
+    	
 	
 	if( m_security )
 	{

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -971,7 +971,13 @@ void Node::ReadXML
 		m_nodeType = (uint8)intVal;
 		m_nodePlusInfoReceived = true;
 	}
-
+	
+    	m_toSleep = 0;
+    	if( TIXML_SUCCESS == _node->QueryIntAttribute( "toSleep", &intVal ) )
+    	{
+        	m_toSleep = (uint32)intVal;
+    	}
+	
 	str = _node->Attribute( "type" );
 	if( str )
 	{
@@ -1275,6 +1281,11 @@ void Node::WriteXML
 	snprintf( str, 32, "%d", m_version );
 	nodeElement->SetAttribute( "version", str );
 
+    	if (m_toSleep > 0){
+        	snprintf( str, 32, "%d", m_toSleep );
+        	nodeElement->SetAttribute( "toSleep", str );
+    	}
+	
 	if( m_security )
 	{
 		nodeElement->SetAttribute( "security", "true" );
@@ -1833,6 +1844,22 @@ void Node::SetLocation
 		// The node supports naming, so we try to write the location into the device
 		cc->SetLocation( _location );
 	}
+}
+
+//-----------------------------------------------------------------------------
+// <Node::toSleep>
+// Set toSleep value for the node
+//-----------------------------------------------------------------------------
+void Node::SettoSleep
+(
+        uint32 const& _toSleep
+)
+{
+    	m_toSleep = _toSleep;
+    	// Notify the watchers of the value changes
+    	Notification* notification = new Notification( Notification::Type_NodeNaming );
+    	notification->SetHomeAndNodeIds( m_homeId, m_nodeId );
+    	GetDriver()->QueueNotification( notification );
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -972,10 +972,10 @@ void Node::ReadXML
 		m_nodePlusInfoReceived = true;
 	}
 	
-    	m_toSleep = 0;
-    	if( TIXML_SUCCESS == _node->QueryIntAttribute( "toSleep", &intVal ) )
+    	m_PacketDelay = 0;
+    	if( TIXML_SUCCESS == _node->QueryIntAttribute( "PacketDelay", &intVal ) )
     	{
-        	m_toSleep = (uint32)intVal;
+        	m_PacketDelay = (uint32)intVal;
     	}
 	
 	str = _node->Attribute( "type" );
@@ -1281,9 +1281,9 @@ void Node::WriteXML
 	snprintf( str, 32, "%d", m_version );
 	nodeElement->SetAttribute( "version", str );
 
-    	if (m_toSleep > 0){
-        	snprintf( str, 32, "%d", m_toSleep );
-        	nodeElement->SetAttribute( "toSleep", str );
+    	if (m_PacketDelay > 0){
+        	snprintf( str, 32, "%d", m_PacketDelay );
+        	nodeElement->SetAttribute( "PacketDelay", str );
     	}
 	
 	if( m_security )
@@ -1847,15 +1847,15 @@ void Node::SetLocation
 }
 
 //-----------------------------------------------------------------------------
-// <Node::toSleep>
-// Set toSleep value for the node
+// <Node::PacketDelay>
+// Set PacketDelay value for the node
 //-----------------------------------------------------------------------------
-void Node::SettoSleep
+void Node::SetPacketDelay
 (
-        uint32 const& _toSleep
+        uint32 const& _PacketDelay
 )
 {
-    	m_toSleep = _toSleep;
+    	m_PacketDelay = _PacketDelay;
     	// Notify the watchers of the value changes
     	Notification* notification = new Notification( Notification::Type_NodeNaming );
     	notification->SetHomeAndNodeIds( m_homeId, m_nodeId );

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -1848,7 +1848,7 @@ void Node::SetLocation
 
 //-----------------------------------------------------------------------------
 // <Node::PacketDelay>
-// Set PacketDelay value for the node
+// Set the new param PacketDelay value for the node
 //-----------------------------------------------------------------------------
 void Node::SetPacketDelay
 (

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -356,7 +356,8 @@ namespace OpenZWave
 			uint16 GetProductType()const{ return m_productType; }
 //			string GetProductId()const{ return string(m_productId); }
 			uint16 GetProductId()const{ return m_productId; }
-
+ 			uint32 GettoSleep() const{ return m_toSleep;}
+		
 			void SetManufacturerName( string const& _manufacturerName ){ m_manufacturerName = _manufacturerName; }
 			void SetProductName( string const& _productName ){ m_productName = _productName; }
 			void SetNodeName( string const& _nodeName );
@@ -365,12 +366,14 @@ namespace OpenZWave
 			void SetManufacturerId( uint16 const& _manufacturerId ){ m_manufacturerId = _manufacturerId; }
 			void SetProductType( uint16 const& _productType ){ m_productType = _productType; }
 			void SetProductId( uint16 const& _productId ){ m_productId = _productId; }
-
+            		void   SettoSleep(uint32 const& _toSleep);
+		
 			string		m_manufacturerName;
 			string		m_productName;
 			string		m_nodeName;
 			string		m_location;
-
+ 			uint32      m_toSleep; 
+		
 			uint16		m_manufacturerId;
 			uint16		m_productType;
 			uint16		m_productId;

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -356,7 +356,7 @@ namespace OpenZWave
 			uint16 GetProductType()const{ return m_productType; }
 //			string GetProductId()const{ return string(m_productId); }
 			uint16 GetProductId()const{ return m_productId; }
- 			uint32 GettoSleep() const{ return m_toSleep;}
+ 			uint32 GetPacketDelay() const{ return m_PacketDelay;}
 		
 			void SetManufacturerName( string const& _manufacturerName ){ m_manufacturerName = _manufacturerName; }
 			void SetProductName( string const& _productName ){ m_productName = _productName; }
@@ -366,13 +366,13 @@ namespace OpenZWave
 			void SetManufacturerId( uint16 const& _manufacturerId ){ m_manufacturerId = _manufacturerId; }
 			void SetProductType( uint16 const& _productType ){ m_productType = _productType; }
 			void SetProductId( uint16 const& _productId ){ m_productId = _productId; }
-            		void   SettoSleep(uint32 const& _toSleep);
+            		void   SetPacketDelay(uint32 const& _PacketDelay);
 		
 			string		m_manufacturerName;
 			string		m_productName;
 			string		m_nodeName;
 			string		m_location;
- 			uint32      m_toSleep; 
+ 			uint32      	m_PacketDelay; 
 		
 			uint16		m_manufacturerId;
 			uint16		m_productType;


### PR DESCRIPTION
Remotez ZXT120 (v1.8)  result in timeout error when we send a commandSet fllowed by a commandGet
It looks like it answer an ACK before it process the command and then it doesn't act and the error comes.
Then I create a new param for nodes, named toSleep, that sets a time interval after a command is sent to the node (just before the command message is removed from queue). 
The toSleep parameter is stored in the config file zwcfg_0xxxxxx, in the <Node id="19" ...> area.
I know its working for me and another network working with Domoticz.
