### PR TITLE
Update fgwpfzw5.xml

### DIFF
--- a/config/fibaro/fgwpfzw5.xml
+++ b/config/fibaro/fgwpfzw5.xml
@@ -97,7 +97,7 @@
 		</Value>
 
 		<Value type="short" genre="config" instance="1" index="31" label="Response to alarm frames" value="0" min="0" max="50" size="1">
-			<Help>This parameter defines how the Wall Plug will respond to alarms (device’s status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
+			<Help>This parameter defines how the Wall Plug will respond to alarms (device's status change). In case of values 1 or 2 the Wall Plug is operating normally and LED ring signals an alarm through time defined in parameter 32 or until the alarm is cancelled. In case of values 5 to 50 the Wall Plug does not report status change, power changes, ignores BASIC SET command frames. After time defined in parameter 32 or after the alarm cancellation, connected device is set to the previous state.. 0- no reaction 1-turn connected device on 2-turn connected device off 5-50(0,5-50,0s step 0,1s)-cyclically change device state with set period. Default setting:0-no reaction</Help>
 		</Value>
 
 		<Value type="short" genre="config" instance="1" index="32" label="Alarm state duration" value="600" min="1" max="32400" size="2">


### PR DESCRIPTION
Removed illegal character in the description of a parameter which caused firefox, and possible other browsers, not to load the list of devices. (XML parse error) 