### PR TITLE
Added Samsung Smarthings Hub

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -781,6 +781,9 @@
 	</Manufacturer>
 	<Manufacturer id="0065" name="RS Scene">
 	</Manufacturer>
+	<Manufacturer id="0150" name="Samsung SmartThings">
+		<Product type="0002" id="0006" name="SmartThings Hub" />
+	</Manufacturer>
 	<Manufacturer id="003b" name="Schlage">
 		<Product type="634b" id="504c" name="FE599GR Wireless Door Lock"/>
 		<Product type="6341" id="5044" name="BE469NXCEN Touchscreen DeadBolt" config="schlage/BE469NXCEN.xml"/>


### PR DESCRIPTION
When a zwave controller is acting as a secondary device on a network controlled by the Samsung SmartThings hub, their main controller shows as unknown. This addition resolves that.