### PR TITLE
possible fix (or workaround) for a deadlock

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1526,27 +1526,28 @@ void Driver::CheckCompletedNodeQueries
 		bool sleepingOnly = true;
 		bool deadFound = false;
 
-		LockGuard LG(m_nodeMutex);
-		for( int i=0; i<256; ++i )
 		{
-			if( m_nodes[i] )
+			LockGuard LG(m_nodeMutex);
+			for( int i=0; i<256; ++i )
 			{
-				if( m_nodes[i]->GetCurrentQueryStage() != Node::QueryStage_Complete )
+				if( m_nodes[i] )
 				{
-					if ( !m_nodes[i]->IsNodeAlive() )
+					if ( m_nodes[i]->GetCurrentQueryStage() != Node::QueryStage_Complete )
 					{
-						deadFound = true;
-						continue;
-					}
-					all = false;
-					if( m_nodes[i]->IsListeningDevice() )
-					{
-						sleepingOnly = false;
+						if( !m_nodes[i]->IsNodeAlive() )
+						{
+							deadFound = true;
+							continue;
+						}
+						all = false;
+						if( m_nodes[i]->IsListeningDevice() )
+						{
+							sleepingOnly = false;
+						}
 					}
 				}
 			}
 		}
-		LG.Unlock();
 
 		Log::Write( LogLevel_Warning, "CheckCompletedNodeQueries all=%d, deadFound=%d sleepingOnly=%d", all, deadFound, sleepingOnly );
 		if( all )
@@ -3202,7 +3203,6 @@ void Driver::HandleRemoveNodeFromNetworkRequest
 							}
 						}
 					}
-					LG.Unlock();
 				}
 				else
 				{
@@ -3236,11 +3236,11 @@ void Driver::HandleRemoveNodeFromNetworkRequest
 
 				if ( m_currentControllerCommand->m_controllerCommandNode != 0 && m_currentControllerCommand->m_controllerCommandNode != 0xff )
 				{
-					LockGuard LG(m_nodeMutex);
-					delete m_nodes[m_currentControllerCommand->m_controllerCommandNode];
-					m_nodes[m_currentControllerCommand->m_controllerCommandNode] = NULL;
-					LG.Unlock();
-
+					{
+						LockGuard LG(m_nodeMutex);
+						delete m_nodes[m_currentControllerCommand->m_controllerCommandNode];
+						m_nodes[m_currentControllerCommand->m_controllerCommandNode] = NULL;
+					}
 					Notification* notification = new Notification( Notification::Type_NodeRemoved );
 					notification->SetHomeAndNodeIds( m_homeId, m_currentControllerCommand->m_controllerCommandNode );
 					QueueNotification( notification );
@@ -3385,11 +3385,11 @@ void Driver::HandleRemoveFailedNodeRequest
 			Log::Write( LogLevel_Info, nodeId, "Received reply to FUNC_ID_ZW_REMOVE_FAILED_NODE_ID - node %d successfully moved to failed nodes list", m_currentControllerCommand->m_controllerCommandNode );
 			state = ControllerState_Completed;
 
-			LockGuard LG(m_nodeMutex);
-			delete m_nodes[m_currentControllerCommand->m_controllerCommandNode];
-			m_nodes[m_currentControllerCommand->m_controllerCommandNode] = NULL;
-			LG.Unlock();
-
+			{
+				LockGuard LG(m_nodeMutex);
+				delete m_nodes[m_currentControllerCommand->m_controllerCommandNode];
+				m_nodes[m_currentControllerCommand->m_controllerCommandNode] = NULL;
+			}
 			Notification* notification = new Notification( Notification::Type_NodeRemoved );
 			notification->SetHomeAndNodeIds( m_homeId, m_currentControllerCommand->m_controllerCommandNode );
 			QueueNotification( notification );
@@ -3730,10 +3730,11 @@ bool Driver::HandleApplicationUpdateRequest
 		{
 			Log::Write( LogLevel_Info, nodeId, "** Network change **: Z-Wave node %d was removed", nodeId );
 
-			LockGuard LG(m_nodeMutex);
-			delete m_nodes[nodeId];
-			m_nodes[nodeId] = NULL;
-			LG.Unlock();
+			{
+				LockGuard LG(m_nodeMutex);
+				delete m_nodes[nodeId];
+				m_nodes[nodeId] = NULL;
+			}
 
 			Notification* notification = new Notification( Notification::Type_NodeRemoved );
 			notification->SetHomeAndNodeIds( m_homeId, nodeId );
@@ -4353,17 +4354,17 @@ void Driver::InitAllNodes
 )
 {
 	// Delete all the node data
-	LockGuard LG(m_nodeMutex);
-	for( int i=0; i<256; ++i )
 	{
-		if( m_nodes[i] )
+		LockGuard LG(m_nodeMutex);
+		for( int i=0; i<256; ++i )
 		{
-			delete m_nodes[i];
-			m_nodes[i] = NULL;
+			if( m_nodes[i] )
+			{
+				delete m_nodes[i];
+				m_nodes[i] = NULL;
+			}
 		}
 	}
-	LG.Unlock();
-
 	// Fetch new node data from the Z-Wave network
 	m_controller->PlayInitSequence( this );
 }

--- a/cpp/src/platform/unix/MutexImpl.cpp
+++ b/cpp/src/platform/unix/MutexImpl.cpp
@@ -85,6 +85,7 @@ bool MutexImpl::Lock
 			++m_lockCount;
 			return true;
 		}
+		Log::Write(LogLevel_Error, "MutexImpl::Lock failed with error: %d (%d)\n", errno, err);
 		fprintf(stderr, "MutexImpl::Lock error %d (%d)\n", errno, err);
 		return false;
 	}
@@ -118,6 +119,7 @@ void MutexImpl::Unlock
 		int err = pthread_mutex_unlock( &m_criticalSection );
 		if( err != 0 )
 		{
+		    Log::Write(LogLevel_Error, "MutexImpl::UnLock failed with error: %d (%d)\n", errno, err);
 			fprintf(stderr, "MutexImpl::Unlock error %d (%d)\n", errno, err);
 		}
 	}


### PR DESCRIPTION
My OpenZwave stopped responding multiple times a day. And after a certain time i was seeing alot of `2016-12-21 06:21:20.520 Error, ERROR: Not enough space in stream buffer`.  
 Looking into this I found out that the driverThread was hanging while trying to get a lock for m_nodeMutex.
```
2017-01-20 10:54:57.871 Warning, CheckCompletedNodeQueries m_allNodesQueried=0 m_awakeNodesQueried=1
2017-01-20 10:54:57.874 Always,       Locking 827319692 from void OpenZWave::Driver::CheckCompletedNodeQueries()
2017-01-20 10:54:57.876 Always,       Locking 818914372 from bool OpenZWave::Manager::IsNodeFailed(uint32, uint8)
2017-01-20 10:54:57.878 Always,       Locking 827319692 from void OpenZWave::Driver::CheckCompletedNodeQueries() ... done with ret: true
2017-01-20 10:54:57.882 Always,       Unlocking 827319692
2017-01-20 10:54:57.884 Always,       Locking 818914372 from bool OpenZWave::Manager::IsNodeFailed(uint32, uint8) ... done with ret: true
2017-01-20 10:54:57.891 Always,       LockGuard destructor 818914372, isSignaled? false
2017-01-20 10:54:57.898 Always,       Locking 818914264 from bool OpenZWave::Manager::RefreshValue(const OpenZWave::ValueID&)
2017-01-20 10:54:57.900 Always,       Locking 818914264 from bool OpenZWave::Manager::RefreshValue(const OpenZWave::ValueID&) ... done with ret: true
2017-01-20 10:54:57.904 Warning, CheckCompletedNodeQueries all=0, deadFound=1 sleepingOnly=1
2017-01-20 10:54:57.906 Always,       LockGuard destructor 827319692, isSignaled? false
2017-01-20 10:54:57.909 Always,       LockGuard destructor 818914264, isSignaled? false
2017-01-20 10:54:57.925 Error, MutexImpl::UnLock failed with error: 2 (1)
```
In this log you see that 827319692 is trying to unlock twice, once with a call to the LockGuard::Unlock() and once via the destructor. But in the meantime another thread (818914264) got the lock and also tries to unlock the mutex. So now 1 unlock fails and as a result the m_lockcount is now -1. The next lock increases this again to 0, but as isSignaled() returns true when m_lockcount is 0 the destructor of the LockGuard does not unlock this, and thus the mutex is locked forever.
To work around this I removed all manual calls to the LockGuard::Unlock() method and instead made a scope around them, now no LockGuard should try to unlock twice.
I did not look at the MutexImplementations for windows and winRT.
Does this make any sense?

What i am not sure, in case the unlocking fails, would it help to increase the m_lockCount again?

perhaps #986 and https://groups.google.com/forum/#!topic/openzwave/tgtXfSude5I could be related to this?