### PR TITLE
Fixed poll_interval_between parsing in Driver::ReadConfig

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -721,7 +721,7 @@ bool Driver::ReadConfig
 	char const* cstr = driverElement->Attribute( "poll_interval_between" );
 	if( cstr )
 	{
-		m_bIntervalBetweenPolls = !strcmp( str, "true" );
+		m_bIntervalBetweenPolls = !strcmp( cstr, "true" );
 	}
 
 	// Read the nodes


### PR DESCRIPTION
Fixed parsing of poll_interval_between in Driver::ReadConfig().