### PR TITLE
Add Ecolink TILTZWAVE2.5-ECO Garage Door Sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -285,7 +285,7 @@
 		<Product type="0001" id="0001" name="PIR Motion Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0001" id="0002" name="Door/Window Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0001" id="0003" name="Garage Door Sensor" config="ecolink/sensor.xml"/>
-		<Product type="0004" id="0003" name="TILT-ZWAVE2.5-ECO Garage Door Sensor" config="ecolink/sensor.xml"/>
+		<Product type="0004" id="0003" name="Garage Door Tilt Sensor" config="ecolink/sensor.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0087" name="Eka Systems">
 	</Manufacturer>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -285,6 +285,7 @@
 		<Product type="0001" id="0001" name="PIR Motion Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0001" id="0002" name="Door/Window Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0001" id="0003" name="Garage Door Sensor" config="ecolink/sensor.xml"/>
+		<Product type="0004" id="0003" name="TILT-ZWAVE2.5-ECO Garage Door Sensor" config="ecolink/sensor.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0087" name="Eka Systems">
 	</Manufacturer>


### PR DESCRIPTION
Ecolink TILTZWAVE2.5-ECO[1] is the z-wave plus update to the TILTZWAVE2-ECO sensor.

[1] - http://products.z-wavealliance.org/products/1501