### PR TITLE
Fix Debian package build

### DIFF
--- a/debian/libopenzwave1.3-dev.install
+++ b/debian/libopenzwave1.3-dev.install
@@ -1,3 +1,3 @@
 usr/lib/*/libopenzwave.so
 usr/include/openzwave/*
-usr/lib*/pkgconfig/libopenzwave.pc
+usr/lib/*/pkgconfig/libopenzwave.pc

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,7 @@ LIBDIR := /usr/lib/$(DEB_HOST_MULTIARCH)/
 	dh $@
 
 override_dh_auto_build:
-	CPPFLAGS=$(CPPFLAGS) VERSION_MAJ=$(MAJOR) VERSION_MIN=$(MINOR) VERSION_REV=$(REV) PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=$(LIBDIR) make
+	CPPFLAGS="$(CPPFLAGS)" VERSION_MAJ=$(MAJOR) VERSION_MIN=$(MINOR) VERSION_REV=$(REV) PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=$(LIBDIR) make
 
 override_dh_auto_install:
 	VERSION_MAJ=$(MAJOR) VERSION_MIN=$(MINOR) VERSION_REV=$(REV) DESTDIR=$(DESTDIR) PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=$(LIBDIR) make install


### PR DESCRIPTION
Without this, `dpkg-buildpackage` fails with the following:

```
make[1]: Entering directory '/home/ubuntu/open-zwave'
CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2 VERSION_MAJ=1 VERSION_MIN=4 VERSION_REV=79 PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=/usr/lib/x86_64-linux-gnu/ make
/bin/sh: 1: -D_FORTIFY_SOURCE=2: not found
debian/rules:27: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 127
make[1]: Leaving directory '/home/ubuntu/open-zwave'
debian/rules:24: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
```

and then fails with this:

```
dh_install: libopenzwave1.3-dev missing files: usr/lib*/pkgconfig/libopenzwave.pc
dh_install: missing files, aborting
debian/rules:24: recipe for target 'binary' failed
make: *** [binary] Error 2
dpkg-buildpackage: error: debian/rules binary gave error exit status 2
```