### PR TITLE
unix: fix compilation against musl libc

### DIFF
--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -25,6 +25,7 @@
 //	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
+#include <sys/select.h>
 #include <unistd.h>
 #include <pthread.h>
 #include "Defs.h"


### PR DESCRIPTION
POSIX.1-2001 requires sys/select.h for select() and friends.
Compile-tested on glibc and musl, runtime tested on musl.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>