### PR TITLE
ForceInstances, implement remove()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- Apply ForceInstances patch to association removal too.
 Version 1.5
  - Pull Request #743 - Updated Fibaro Devices from Navstev0 (Justin)
  - Pull Request #740 - Updated Fibaro FGMS-001 ID's from Technosf (Justin)

--- a/cpp/src/command_classes/MultiInstanceAssociation.cpp
+++ b/cpp/src/command_classes/MultiInstanceAssociation.cpp
@@ -442,7 +442,8 @@ void MultiInstanceAssociation::Remove
 	Log::Write( LogLevel_Info, GetNodeId(), "MultiInstanceAssociation::Remove - Removing instance %d on node %d from group %d of node %d",
 	           _instance, _targetNodeId, _groupIdx, GetNodeId());
 
-	if ( _instance == 0x00 )
+	if ( ( _instance == 0x00 )
+			&& (m_alwaysSetInstance == false) )
 	{
 		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Remove", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->Append( GetNodeId() );
@@ -456,6 +457,13 @@ void MultiInstanceAssociation::Remove
 	}
 	else
 	{
+		/* for Qubino devices, we should always set a Instance if its the ControllerNode, so MultChannelEncap works.  - See Bug #857 */
+		if ( ( m_alwaysSetInstance  == true )
+				&& ( _instance == 0 )
+				&& ( GetDriver()->GetControllerNodeId() == _targetNodeId ) )
+		{
+			_instance = 0x01;
+		}
 		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Remove", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->Append( GetNodeId() );
 		msg->Append( 6 );


### PR DESCRIPTION
Fix for #1143.

Implement ForceInstances in MultiInstanceAssociation::Remove().