### PR TITLE
apply ForceInstances more selectively

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- Add config option for ForceInstances limited to the controller node.
 Version 1.5
  - Pull Request #743 - Updated Fibaro Devices from Navstev0 (Justin)
  - Pull Request #740 - Updated Fibaro FGMS-001 ID's from Technosf (Justin)

--- a/config/device_configuration.xsd
+++ b/config/device_configuration.xsd
@@ -128,6 +128,7 @@
     <xs:simpleType>
      <xs:restriction base='xs:string'>
       <xs:enumeration value='true'/>
+      <xs:enumeration value='controller'/>
       <xs:enumeration value='false'/>
      </xs:restriction>
     </xs:simpleType>

--- a/config/fibaro/fgs213.xml
+++ b/config/fibaro/fgs213.xml
@@ -243,5 +243,5 @@
       <Group index="5" max_associations="16" label="Dimmer S2"/>
     </Associations>
   </CommandClass>
-  <CommandClass id="142" ForceInstances="true"/>
+  <CommandClass id="142" ForceInstances="controller"/>
 </Product>

--- a/config/fibaro/fgs223.xml
+++ b/config/fibaro/fgs223.xml
@@ -264,5 +264,5 @@
             <Group index="5" max_associations="16" label="Dimmer S2"/>
         </Associations>
     </CommandClass>
-    <CommandClass id="142" ForceInstances="true"/>
+    <CommandClass id="142" ForceInstances="controller"/>
 </Product>

--- a/cpp/src/command_classes/MultiInstanceAssociation.cpp
+++ b/cpp/src/command_classes/MultiInstanceAssociation.cpp
@@ -451,7 +451,8 @@ void MultiInstanceAssociation::Remove
 	Log::Write( LogLevel_Info, GetNodeId(), "MultiInstanceAssociation::Remove - Removing instance %d on node %d from group %d of node %d",
 	           _instance, _targetNodeId, _groupIdx, GetNodeId());
 
-	if ( _instance == 0x00 )
+	if ( (_instance == 0x00 )
+			&& (m_forceInstance != ForceInstance_AllNodes) )
 	{
 		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Remove", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->Append( GetNodeId() );

--- a/cpp/src/command_classes/MultiInstanceAssociation.cpp
+++ b/cpp/src/command_classes/MultiInstanceAssociation.cpp
@@ -58,7 +58,7 @@ MultiInstanceAssociation::MultiInstanceAssociation
 	CommandClass( _homeId, _nodeId ),
 	m_queryAll(false),
 	m_numGroups(0),
-	m_alwaysSetInstance(false)
+	m_forceInstance(ForceInstance_None)
 {
 	SetStaticRequest( StaticRequest_Values );
 }
@@ -103,12 +103,16 @@ void MultiInstanceAssociation::ReadXML
 
 		associationsElement = associationsElement->NextSiblingElement();
 	}
+
+	m_forceInstance = ForceInstance_None;
 	char const*  str = _ccElement->Attribute("ForceInstances");
 	if( str )
 	{
-                m_alwaysSetInstance = !strcmp( str, "true");
+		if ( !strcmp( str, "true") )
+			m_forceInstance = ForceInstance_AllNodes;
+		else if ( !strcmp( str, "controller") )
+			m_forceInstance = ForceInstance_ControllerNode;
 	}
-
 }
 
 //-----------------------------------------------------------------------------
@@ -133,8 +137,12 @@ void MultiInstanceAssociation::WriteXML
 		_ccElement->LinkEndChild( associationsElement );
 		node->WriteGroups( associationsElement );
 	}
-	if (m_alwaysSetInstance) {
+
+	if (m_forceInstance == ForceInstance_AllNodes) {
 		_ccElement->SetAttribute("ForceInstances", "true");
+	}
+	else if (m_forceInstance == ForceInstance_ControllerNode) {
+		_ccElement->SetAttribute("ForceInstances", "controller");
 	}
 }
 
@@ -392,8 +400,16 @@ void MultiInstanceAssociation::Set
 	Log::Write( LogLevel_Info, GetNodeId(), "MultiInstanceAssociation::Set - Adding instance %d on node %d to group %d of node %d", 
 	           _instance, _targetNodeId, _groupIdx, GetNodeId() );
 
+	/* for some devices, we should always set a Instance if its the ControllerNode, so MultChannelEncap works.  - See Bug #857 */
+	if ( ( m_forceInstance != ForceInstance_None )
+			&& ( _instance == 0 )
+			&& ( GetDriver()->GetControllerNodeId() == _targetNodeId ) )
+	{
+		_instance = 0x01;
+	}
+
 	if ( (_instance == 0x00 )
-			&& (m_alwaysSetInstance == false) )
+			&& (m_forceInstance != ForceInstance_AllNodes) )
 	{
 		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->Append( GetNodeId() );
@@ -407,13 +423,6 @@ void MultiInstanceAssociation::Set
 	}
 	else 
 	{
-		/* for Qubino devices, we should always set a Instance if its the ControllerNode, so MultChannelEncap works.  - See Bug #857 */
-		if ( ( m_alwaysSetInstance  == true )
-				&& ( _instance == 0 )
-				&& ( GetDriver()->GetControllerNodeId() == _targetNodeId ) )
-		{
-			_instance = 0x01;
-		}
 		Msg* msg = new Msg( "MultiInstanceAssociationCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->Append( GetNodeId() );
 		msg->Append( 6 );

--- a/cpp/src/command_classes/MultiInstanceAssociation.h
+++ b/cpp/src/command_classes/MultiInstanceAssociation.h
@@ -61,6 +61,13 @@ namespace OpenZWave
 		void Remove( uint8 const _group, uint8 const _nodeId, uint8 const _instance );
 
 	private:
+		enum ForceInstance
+		{
+			ForceInstance_None = 0,
+			ForceInstance_ControllerNode,
+			ForceInstance_AllNodes
+		};
+
 		MultiInstanceAssociation( uint32 const _homeId, uint8 const _nodeId );
 		void QueryGroup( uint8 _groupIdx, uint32 const _requestFlags );
 		void AutoAssociate();
@@ -68,8 +75,7 @@ namespace OpenZWave
 		bool			m_queryAll;			// When true, once a group has been queried, we request the next one.
 		uint8			m_numGroups;		// Number of groups supported by the device.  255 is reported by certain manufacturers and requires special handling.
 		vector<InstanceAssociation>	m_pendingMembers;	// Used to build a list of group members from multiple reports
-		bool			m_alwaysSetInstance; // Should we also set a instance, even if a instance wasn't specified (for Qubino devices - See bug #857)
-			
+		ForceInstance	m_forceInstance;	// Should we always set a instance, even if a instance wasn't specified (for some devices - See bug #857)
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
Fix for #1142 (and #1143)

Allow a per-device-model choice between ForceInstances for all associations or just associations to the controller. Fix fibaro FGS-2x3 to do this for associations to the controller only. Includes a modified fix for Remove().

A simpler code change can be found in my [controller-only](https://github.com/martian/open-zwave/tree/ForceInstances-controller-only) branch. That variant does affect all device models, including Qubino.


  