### PR TITLE
Support for the BeNext TagReader500

### DIFF
--- a/config/BeNext/TagReader500.xml
+++ b/config/BeNext/TagReader500.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--http://www.pepper1.net/zwavedb/device/302-->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+
+  <!-- Configuration -->
+  <CommandClass id="112">
+
+    <Value type="byte" genre="config" instance="1" index="1" label="Set to Default" value="-86">
+      <Help>Set all configuration values to default values (factory settings).</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="2" label="Feedback Time" value="15">
+      <Help>To configure the time the beep is automatically turned off in seconds.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="3" label="Feedback Timeout" value="0">
+      <Help>To configure the timeout to wait for a WAKEUP_NO_MORE_INFORMATION before the error beep is automatically sound. The error beeps are fixed 8 beeps shortly after each other.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="4" label="Feedback beeps per second" value="2">
+      <Help>To configure the number of beeps per second. Every beep is fixed about 10ms.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="5" label="Always awake mode" value="1">
+      <Help>To configure the always awake mode.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="6" label="Not used" value="0">
+      <Help>Not used</Help>
+    </Value>	
+
+    <Value type="byte" genre="config" instance="1" index="7" label="Operation mode" value="0">
+      <Help>The mode that the Tag Reader 500 communicates with the associated gateway.</Help>
+    </Value>
+
+    <Value type="byte" genre="config" instance="1" index="8" label="Gateway confirmation" value="0">
+      <Help>In gateway mode it is possible to let the gateway decide if the Tag Reader 500 can arm to home or away. If gateway indication is disabled the Tag Reader 500 automatically assumes that</Help>
+    </Value>
+
+
+  </CommandClass>
+  
+  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+  <CommandClass id="113" getsupported="false" />
+
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="1">
+      <Group index="1" max_associations="5" label="Group 1" />
+    </Associations>
+  </CommandClass>
+
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -189,6 +189,7 @@
 		<Product type="0006" id="0200" name="Energy Switch" config="BeNext/EnergySwitch.xml"/>
 		<Product type="0007" id="0100" name="Tag Reader" config="BeNext/TagReader.xml"/>
 		<Product type="0007" id="0101" name="Tag Reader" config="BeNext/TagReader.xml"/>
+		<Product type="0007" id="0200" name="Tag Reader 500" config="BeNext/TagReader500.xml"/>
 		<Product type="0008" id="0101" name="Power Switch"/>
 		<Product type="000d" id="0100" name="Built-in Dimmer" config="BeNext/BuiltinDimmer.xml"/>
 		<Product type="0014" id="0100" name="Panic Button" config="BeNext/PanicButton.xml"/>

--- a/cpp/src/command_classes/UserCode.cpp
+++ b/cpp/src/command_classes/UserCode.cpp
@@ -31,7 +31,7 @@
 #include "Node.h"
 #include "Options.h"
 #include "platform/Log.h"
-
+#include <unistd.h>
 #include "value_classes/ValueByte.h"
 #include "value_classes/ValueRaw.h"
 
@@ -43,13 +43,13 @@ enum UserCodeCmd
 	UserCodeCmd_Get			= 0x02,
 	UserCodeCmd_Report		= 0x03,
 	UserNumberCmd_Get		= 0x04,
-	UserNumberCmd_Report		= 0x05
+	UserNumberCmd_Report	= 0x05
 };
 
 enum
 {
 	UserCodeIndex_Refresh	= 254,
-	UserCodeIndex_Count		= 255
+	UserCodeIndex_Count	= 255
 };
 
 const uint8 UserCodeLength = 10;
@@ -67,6 +67,7 @@ UserCode::UserCode
 	m_queryAll( false ),
 	m_currentCode( 0 ),
 	m_userCodeCount( 0 ),
+	m_userCodeLength( UserCodeLength ),
 	m_refreshUserCodes(false)
 {
 	SetStaticRequest( StaticRequest_Values );
@@ -202,7 +203,9 @@ bool UserCode::HandleMsg
 {
 	if( UserNumberCmd_Report == (UserCodeCmd)_data[0] )
 	{
-		m_userCodeCount = _data[1];
+		m_userCodeCount 	= _data[1];
+		m_userCodeLength 	= UserCodeLength;
+
 		if( m_userCodeCount > 254 )
 		{
 			// Make space for code count.
@@ -226,21 +229,26 @@ bool UserCode::HandleMsg
 
 		if( Node* node = GetNodeUnsafe() )
 		{
-			uint8 data[UserCodeLength];
+			uint8 data[m_userCodeLength];
 
-			memset( data, 0, UserCodeLength );
+			memset( data, 0, m_userCodeLength );
+
+			//
+			//	create all initial user codes in XML
+			//
 			for( uint8 i = 0; i <= m_userCodeCount; i++ )
 			{
 				char str[16];
+
 				if (i == 0)
 				{
 					snprintf( str, sizeof(str), "Enrollment Code");
-					node->CreateValueRaw( ValueID::ValueGenre_User, GetCommandClassId(), _instance, i, str, "", true, false, data, UserCodeLength, 0 );
+					node->CreateValueRaw( ValueID::ValueGenre_User, GetCommandClassId(), _instance, i, str, "", true, false, data, m_userCodeLength, 0 );
 				}
 				else
 				{
 					snprintf( str, sizeof(str), "Code %d:", i);
-					node->CreateValueRaw( ValueID::ValueGenre_User, GetCommandClassId(), _instance, i, str, "", false, false, data, UserCodeLength, 0 );
+					node->CreateValueRaw( ValueID::ValueGenre_User, GetCommandClassId(), _instance, i, str, "", false, false, data, m_userCodeLength, 0 );
 				}
 			}
 		}
@@ -248,45 +256,76 @@ bool UserCode::HandleMsg
 	}
 	else if( UserCodeCmd_Report == (UserCodeCmd)_data[0] )
 	{
-		int i = _data[1];
-		if( ValueRaw* value = static_cast<ValueRaw*>( GetValue( _instance, i ) ) )
+		int index = _data[1];
+
+		if (index == 0)
 		{
-			uint8 data[UserCodeLength];
-			int8 size = _length - 4;
+			//
+			//	UserID == 0, we are in the first phase of enrollment, keep the actual user code length
+			//
+			m_userCodeLength = _length - 4;
+
+			if (m_userCodeLength > UserCodeLength)
+			{
+				m_userCodeLength = UserCodeLength;
+			}
+		}
+
+		if( ValueRaw* value = static_cast<ValueRaw*>( GetValue( _instance, index ) ) )
+		{
+			uint8 data[m_userCodeLength];
+			int8 size = m_userCodeLength;
+
 			if( size > UserCodeLength )
 			{
 				Log::Write( LogLevel_Warning, GetNodeId(), "User Code length %d is larger then maximum %d", size, UserCodeLength );
-				size = UserCodeLength;
+				size = m_userCodeLength;
 			}
+
 			Log::Write( LogLevel_Info, GetNodeId(), "User Code Packet is %d", size );
-			m_userCodesStatus[i] = _data[2];
-			if (size > 0) {
+
+			m_userCodesStatus[index] = _data[2];
+
+			if (size > 0)
+			{
+				//
+				//	create new entry
+				//
 				memcpy( data, &_data[3], size );
-			} else {
+			}
+			else
+			{
+				//
+				//	delete entry
+				//
 				size = 1;
 				data[0] = 0;
 			}
 			value->OnValueRefreshed( data, size );
 			value->Release();
 		}
-		Log::Write( LogLevel_Info, GetNodeId(), "Received User Code Report from node %d for User Code %d (%s)", GetNodeId(), i, CodeStatus( _data[2] ).c_str() );
-		if( m_queryAll && i == m_currentCode )
+
+		Log::Write( LogLevel_Info, GetNodeId(), "Received User Code Report from node %d for User Code %d (%s)", GetNodeId(), index, CodeStatus( _data[2] ).c_str() );
+
+		if( m_queryAll && index == m_currentCode )
 		{
 
 			if (m_refreshUserCodes || (_data[2] != UserCode_Available)) {
-				if( ++i <= m_userCodeCount )
+				if( ++index <= m_userCodeCount )
 				{
-					m_currentCode = i;
+					m_currentCode = index;
 					RequestValue( 0, m_currentCode, _instance, Driver::MsgQueue_Query );
 				}
 				else
 				{
 					m_queryAll = false;
+
 					/* we might have reset this as part of the RefreshValues Button Value */
 					Options::Get()->GetOptionAsBool("RefreshAllUserCodes", &m_refreshUserCodes );
 				}
-			} else {
-				Log::Write( LogLevel_Info, GetNodeId(), "Not Requesting additional UserCode Slots as RefreshAllUserCodes is false, and slot %d is available", i);
+			} else
+			{
+				Log::Write( LogLevel_Info, GetNodeId(), "Not Requesting additional UserCode Slots as RefreshAllUserCodes is false, and slot %d is available", index);
 				m_queryAll = false;
 			}
 		}
@@ -308,6 +347,7 @@ bool UserCode::SetValue
 	if( (ValueID::ValueType_Raw == _value.GetID().GetType()) && (_value.GetID().GetIndex() < UserCodeIndex_Refresh) )
 	{
 		ValueRaw const* value = static_cast<ValueRaw const*>(&_value);
+
 		uint8* s = value->GetValue();
 		uint8 len = value->GetLength();
 
@@ -319,19 +359,23 @@ bool UserCode::SetValue
 		Msg* msg = new Msg( "UserCodeCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 		msg->SetInstance( this, _value.GetID().GetInstance() );
 		msg->Append( GetNodeId() );
-		msg->Append( 4 + len );
+		msg->Append( 4 + m_userCodeLength );
 		msg->Append( GetCommandClassId() );
 		msg->Append( UserCodeCmd_Set );
 		msg->Append( value->GetID().GetIndex() );
 		msg->Append( UserCode_Occupied );
-		for( uint8 i = 0; i < len; i++ )
+
+		for( uint8 i = 0; i < m_userCodeLength; i++ )
 		{
 			msg->Append( s[i] );
 		}
+
 		msg->Append( GetDriver()->GetTransmitOptions() );
 		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+
 		return true;
 	}
+
 	if ( (ValueID::ValueType_Button == _value.GetID().GetType()) && (_value.GetID().GetIndex() == UserCodeIndex_Refresh) )
 	{
 		m_refreshUserCodes = true;

--- a/cpp/src/command_classes/UserCode.h
+++ b/cpp/src/command_classes/UserCode.h
@@ -102,6 +102,7 @@ namespace OpenZWave
 		bool		m_queryAll;				// True while we are requesting all the user codes.
 		uint8		m_currentCode;
 		uint8		m_userCodeCount;
+		uint8       	m_userCodeLength;
 		uint8		m_userCodesStatus[256];
 		bool		m_refreshUserCodes;
 	};


### PR DESCRIPTION
The new BeNext TagReader500 is using a variable Usercode length ranging form 4 up to 10 
digits and fails to work with the current OpenZWave implementation. The previous models where always using 10 digit, sometimes zero filled, usercodes. I have added the device to the xml files and updated UserCode.h & Usercode.cpp to support the new device.