### PR TITLE
zp3102us device incorrectly labelled EU

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -948,11 +948,11 @@
 		<Product type="2001" id="0104" name="ZD2102 JP Door/Window Sensor" config="vision/zd2102.xml"/>
 		<Product type="2001" id="0105" name="ZD2102 EU Door/Window Sensor" config="vision/zd2102.xml"/>
 		<Product type="2001" id="0106" name="ZD2102 EU Door/Window Sensor" config="vision/zd2102.xml"/>
-		<Product type="2002" id="0201" name="ZP3102 US PIR Motion Sensor" config="vision/zp3102.xml"/>
-		<Product type="2002" id="0202" name="ZP3102 AU PIR Motion Sensor" config="vision/zp3102.xml"/>
-		<Product type="2002" id="0203" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>
-		<Product type="2002" id="0204" name="ZP3102 JP PIR Motion Sensor" config="vision/zp3102.xml"/>
-		<Product type="2002" id="0205" name="ZP3102 EU PIR Motion Sensor" config="vision/zp3102.xml"/>
+		<Product type="2002" id="0201" name="ZP3102 PIR Motion Sensor" config="vision/zp3102.xml"/>
+		<Product type="2002" id="0202" name="ZP3102 PIR Motion Sensor" config="vision/zp3102.xml"/>
+		<Product type="2002" id="0203" name="ZP3102 PIR Motion Sensor" config="vision/zp3102.xml"/>
+		<Product type="2002" id="0204" name="ZP3102 PIR Motion Sensor" config="vision/zp3102.xml"/>
+		<Product type="2002" id="0205" name="ZP3102 PIR Motion Sensor" config="vision/zp3102.xml"/>
 		<Product type="2003" id="0301" name="ZS5101 Shock and Vibration Sensor" config="vision/zs5101eu.xml"/>
 		<Product type="2003" id="0302" name="ZS5101 Shock and Vibration Sensor" config="vision/zs5101eu.xml"/>
 		<Product type="2003" id="0306" name="ZS5101 Shock and Vibration Sensor" config="vision/zs5101eu.xml"/>


### PR DESCRIPTION
http://products.z-wavealliance.org/products/1702
Product Type ID: 0x2002
Product ID: 0x0205 
Brand Name: Vision
Product Identifier: ZP3102US-5 

http://products.z-wavealliance.org/products/703
Product Type ID: 0x2002
Product ID: 0x0202 
Brand Name: Vision
Product Identifier: ZP3102EU 

after further inspection, looks like some of these devices share the same device id and types, although clearly a different description. Perhaps solution is to just remove the country indicator all together? i'll leave that decision up to the person approving this merge

http://products.z-wavealliance.org/products/1070