### PR TITLE
Fix ValueList::SetByValue and add ValueList::SetByIndex()

### DIFF
--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -216,7 +216,7 @@ void ValueList::WriteXML
 
 //-----------------------------------------------------------------------------
 // <ValueList::SetByValue>
-// Set a new value in the device, selected by item index
+// Set a new value in the device, selected by item value
 //-----------------------------------------------------------------------------
 bool ValueList::SetByValue
 (
@@ -225,7 +225,29 @@ bool ValueList::SetByValue
 {
 	// create a temporary copy of this value to be submitted to the Set() call and set its value to the function param
   	ValueList* tempValue = new ValueList( *this );
-	tempValue->m_valueIdx = _value;
+	tempValue->m_valueIdx = GetItemIdxByValue(_value);
+
+	// Set the value in the device.
+	bool ret = ((Value*)tempValue)->Set();
+
+	// clean up the temporary value
+	delete tempValue;
+
+	return ret;
+}
+
+//-----------------------------------------------------------------------------
+// <ValueList::SetByIndex>
+// Set a new value in the device, selected by item index
+//-----------------------------------------------------------------------------
+bool ValueList::SetByIndex
+(
+	int32 const _index
+)
+{
+	// create a temporary copy of this value to be submitted to the Set() call and set its value to the function param
+  	ValueList* tempValue = new ValueList( *this );
+	tempValue->m_valueIdx = _index;
 
 	// Set the value in the device.
 	bool ret = ((Value*)tempValue)->Set();
@@ -253,7 +275,7 @@ bool ValueList::SetByLabel
 		return false;
 	}
 
-	return SetByValue( index );
+	return SetByIndex( index );
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueList.h
+++ b/cpp/src/value_classes/ValueList.h
@@ -59,6 +59,7 @@ namespace OpenZWave
 
 		bool SetByLabel( string const& _label );
 		bool SetByValue( int32 const _value );
+		bool SetByIndex( int32 const _index );
 
 		void OnValueRefreshed( int32 const _valueIdx );
 


### PR DESCRIPTION
continuing from
https://github.com/OpenZWave/open-zwave/pull/1035
and
https://github.com/OpenZWave/open-zwave/issues/1065

When using the
```
bool Manager::SetConfigParam
(
		uint32 const _homeId,
		uint8 const _nodeId,
		uint8 const _param,
		int32 _value,
		uint8 const _size
)
```
function, this clearly takes a value as a argument.
Coming down this path, the ValueList::SetByValue need to get a index for the value. That's why I made the first PR.
Now that this got reverted i again got crashes.
So this commit adds a SetByIndex() function. Now both paths should work.

![image](https://cloud.githubusercontent.com/assets/4622393/23306335/69e68dbe-faa3-11e6-8802-e57a67115132.png)


The ValueList::SetByLabel and Node::SetConfigParam were the only callers to ValueList::SetByValue(). So I changed the ValueList::SetByLabel to use the new SetByIndex().

@jotakar or @madarwin could you test this?