### PR TITLE
CentralScene, Create Scene values when specified in configuration file

### DIFF
--- a/config/remotec/zrc-90.xml
+++ b/config/remotec/zrc-90.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Product xmlns='http://code.google.com/p/open-zwave/'>
+	<CommandClass id="91" action="add" scenecount="8" />
 	<!-- Association Groups -->
 	<CommandClass id="133">
 		<Associations num_groups="1">

--- a/cpp/src/command_classes/CentralScene.cpp
+++ b/cpp/src/command_classes/CentralScene.cpp
@@ -128,6 +128,7 @@ void CentralScene::ReadXML
 	if( TIXML_SUCCESS == _ccElement->QueryIntAttribute( "scenecount", &intVal ) )
 	{
 		m_scenecount = intVal;
+		CreateSceneValues();
 	}
 }
 
@@ -163,7 +164,17 @@ bool CentralScene::HandleMsg
 	{
 		// Central Scene Set received so send notification
 		int32 when;
-		if( _data[2] == 0 )
+		//Table 32
+		//0x00 Key Pressed
+		//0x01 Key Released
+		//0x02 Key Held Down
+		//Table 34
+		//0x03 Key Pressed 2 times
+		//0x04 Key Pressed 3 times
+		//0x05 Key Pressed 4 times
+		//0x06 Key Pressed 5 times
+
+		if (_data[2] == 0)
 			when = 0;
 		else if( _data[2] <= 0x7F )
 			when = _data[2];
@@ -195,21 +206,8 @@ bool CentralScene::HandleMsg
 		{
 			value->OnValueRefreshed(m_scenecount);
 			value->Release();
-		} else {
-			Log::Write( LogLevel_Warning, GetNodeId(), "Can't find ValueID for SceneCount");
 		}
-
-		if( Node* node = GetNodeUnsafe() )
-		{
-				char lbl[64];
-				for (int i = 1; i <= m_scenecount; i++) {
-					snprintf(lbl, 64, "Scene %d", i);
-					node->CreateValueInt(ValueID::ValueGenre_User, GetCommandClassId(), _instance, i, lbl, "", true, false, 0, 0 );
-				}
-
-		} else {
-			Log::Write(LogLevel_Info, GetNodeId(), "CentralScene: Can't find Node!");
-		}
+		CreateSceneValues();
 	}
 
 	return false;
@@ -230,4 +228,22 @@ void CentralScene::CreateVars
 	}
 }
 
+//-----------------------------------------------------------------------------
+// <CentralScene::CreateSceneValues>
+// Create m_scenecount Scene Values
+//-----------------------------------------------------------------------------
+void CentralScene::CreateSceneValues()
+{
+	if (Node* node = GetNodeUnsafe())
+	{
+		char lbl[64];
+		for (int i = 1; i <= m_scenecount; i++) {
+			snprintf(lbl, 64, "Scene %d", i);
+			node->CreateValueInt(ValueID::ValueGenre_User, GetCommandClassId(), 1, i, lbl, "", true, false, 0, 0);
+		}
 
+	}
+	else {
+		Log::Write(LogLevel_Info, GetNodeId(), "CentralScene: Can't find Node!");
+	}
+}

--- a/cpp/src/command_classes/CentralScene.h
+++ b/cpp/src/command_classes/CentralScene.h
@@ -63,6 +63,9 @@ namespace OpenZWave
 	private:
 		CentralScene( uint32 const _homeId, uint8 const _nodeId );
 		int32 m_scenecount;
+		/** \brief Create m_scenecount scene values */
+		void CreateSceneValues();
+		int32 m_scenecount;
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
- CentralScene, Create Scene values when specified in configuration file
- Remotec zrc-90, included scene count

The changes in the CentralScene.cpp/HandleMsg file look a bit weird in this compare, best to display the whole file 

Basically the value creation is now in a new function 'CreateSceneValues' and is called from HandleMsg

With this patch, hardware that does not report the amount of scenes supported, and having the 'scenecount' set in the configuration file, will now work.
Before, only the first scene button worked, and when pressing the other buttons gave the "Can't find ValueID for SceneCount" warning message