### PR TITLE
Added additional config entry for 2GIG CT-30 Radio Thermostat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -522,3 +522,4 @@ Version 1.1
  - Remove the hidapi.h include from our headers so we don't have to
    distribute the hidapi header files (Justin)
  - Fixed Issue 375 - Add Ecolink Garage Door Sensor - (Justin)
+ - Add additional CT30 Thermostat config entry to manufacturer specific list

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -4,6 +4,7 @@
 	</Manufacturer>
 	<Manufacturer id="0098" name="2GIG Technologies">
 		<Product type="3200" id="015e" name="CT50e Thermostat" config="2gig/ct50e.xml"/>
+		<Product type="1e10" id="0158" name="CT30 Thermostat" config="2gig/ct30.xml"/>
 		<Product type="1e12" id="015c" name="CT30 Thermostat" config="2gig/ct30.xml"/>
 		<Product type="1e12" id="015e" name="CT30 Thermostat" config="2gig/ct30.xml"/>
 		<Product type="6401" id="0105" name="CT100 Thermostat" config="2gig/ct100.xml"/>


### PR DESCRIPTION
The values for the CT30 thermostat that I have were not present in the manufacturer specific list, so I added them in.  Let me know if anything is missing.