### PR TITLE
Add additional identifier for the Fibaro FGMS001-ZW5 Sensor.

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -459,6 +459,7 @@
 		<!--<Product type="0801" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />-->
 		<Product type="0801" id="1001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
 		<Product type="0801" id="2001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
+		<Product type="0801" id="3001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
 		<Product type="0b00" id="3001" name="FGFS101 Flood Sensor" config="fibaro/fgfs101.xml" />
 		<Product type="0b00" id="4001" name="FGFS101 Flood Sensor" config="fibaro/fgfs101.xml" />
 		<Product type="0b00" id="1001" name="FGFS101 Flood Sensor" config="fibaro/fgfs101.xml" />


### PR DESCRIPTION
Add additional identifier for the Fibaro FGMS001-ZW5 Sensor.