### PR TITLE
Add BSDmakefile

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,6 @@
+all: .DEFAULT
+
+.DEFAULT:
+	gmake ${.MAKEFLAGS} ${.TARGETS}
+
+.PHONY:	all


### PR DESCRIPTION
The default BSD make (at least on FreeBSD) is not GNU make, nor is it compatible with it. This new BSDmakefile will case BSD make to invoke GNU make.