### PR TITLE
Fixes for MinGW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ libopenzwave.so
 /cpp/build/windows/vs2010/Debug/*.log
 /cpp/build/windows/vs2010/Debug/OpenZWave.tlog/*.tlog
 /cpp/build/windows/vs2010/Debug/OpenZWave.tlog/*.lastbuildstate
+/cpp/build/windows/mingw32/*.o
+/cpp/build/windows/mingw32/*.d
+/cpp/build/windows/mingw32/*.d.*
+/cpp/build/windows/mingw32/vers.c
+/cpp/lib/windows-mingw32
 *.idb
 *.pdb
 *.log

--- a/cpp/build/windows/mingw32/Makefile
+++ b/cpp/build/windows/mingw32/Makefile
@@ -11,13 +11,13 @@ LD     := $(CROSS_COMPILE)g++
 AR     := $(CROSS_COMPILE)ar rc
 RANLIB := $(CROSS_COMPILE)ranlib
 
-DEBUG_CFLAGS    := -Wall -Wno-format -g -DDEBUG -DLOG_STDERR -DMINGW
-RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -Wno-format -O3 -DMINGW
+DEBUG_CFLAGS    := -DDEBUG -DLOG_STDERR
+RELEASE_CFLAGS  := -O3
 
 DEBUG_LDFLAGS	:= -g
 
 # Change for DEBUG or RELEASE
-CFLAGS	:= -c $(DEBUG_CFLAGS)
+CFLAGS	:= -c -Wall -Wno-unknown-pragmas -Wno-format -DMINGW $(DEBUG_CFLAGS)
 LDFLAGS	:= $(DEBUG_LDFLAGS)
 
 LIBDIR	:= ../../../lib/windows-mingw32

--- a/cpp/build/windows/mingw32/Makefile
+++ b/cpp/build/windows/mingw32/Makefile
@@ -72,5 +72,9 @@ $(LIBDIR)/openzwave.a:	$(patsubst %.cpp,%.o,$(tinyxml)) \
 			$(patsubst %.cpp,%.o,$(cclasses)) \
 			$(patsubst %.cpp,%.o,$(vclasses)) \
 			$(patsubst %.cpp,%.o,$(pform)) \
-			$(patsubst %.cpp,%.o,$(indep)) vers.o
+			$(patsubst %.cpp,%.o,$(indep)) vers.o \
+			| $(LIBDIR)/
 	$(AR) $@ $?
+
+$(LIBDIR)/:
+	mkdir -p $@

--- a/cpp/src/platform/windows/EventImpl.h
+++ b/cpp/src/platform/windows/EventImpl.h
@@ -28,7 +28,7 @@
 #ifndef _EventImpl_H
 #define _EventImpl_H
 
-#include <Windows.h>
+#include <windows.h>
 #include "Defs.h"
 
 namespace OpenZWave

--- a/cpp/src/platform/windows/LogImpl.cpp
+++ b/cpp/src/platform/windows/LogImpl.cpp
@@ -26,6 +26,7 @@
 //
 //-----------------------------------------------------------------------------
 #include <windows.h>
+#include <cerrno>
 #include <list>
 
 #include "Defs.h"

--- a/cpp/src/platform/windows/LogImpl.h
+++ b/cpp/src/platform/windows/LogImpl.h
@@ -31,7 +31,7 @@
 #include "Defs.h"
 #include <string>
 #include "platform/Log.h"
-#include "Windows.h"
+#include "windows.h"
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/windows/SerialControllerImpl.h
+++ b/cpp/src/platform/windows/SerialControllerImpl.h
@@ -28,7 +28,7 @@
 #ifndef _SerialControllerImpl_H
 #define _SerialControllerImpl_H
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "Defs.h"
 #include "platform/SerialController.h"

--- a/cpp/src/platform/windows/TimeStampImpl.cpp
+++ b/cpp/src/platform/windows/TimeStampImpl.cpp
@@ -26,7 +26,7 @@
 //
 //-----------------------------------------------------------------------------
 #include <string>
-#include <Windows.h>
+#include <windows.h>
 #include "Defs.h"
 #include "TimeStampImpl.h"
 


### PR DESCRIPTION
Several fixes for the MinGW Makefile and some source files to make the project build cleanly (again?) with MinGW, including cross builds from Linux and FreeBSD.

See the commit titles and descriptions for details.