### PR TITLE
Updated UWP SDK target version to be compiled against 14393 instead of 10240

### DIFF
--- a/cpp/build/winRT/vs2015/OpenZWave.vcxproj
+++ b/cpp/build/winRT/vs2015/OpenZWave.vcxproj
@@ -501,7 +501,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>


### PR DESCRIPTION
Visual Studio doesn't install v10240 SDK by default any longer, so most people will experience problems with opening this project. 
The MinVersion is still 10240 and is still supported to run on, so there's no breaking changes from this.
The only difference is you will now have to have the 14393 SDK installed on your PC, instead of 10240 (which has now been standard for VS for a long time)