### PR TITLE
added new command class ManufacturerProprietary for Fibaro FGRM-222 (part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ OZWForm.vshost.exe.manifest
 ozw_config
 .project
 *~
+/.cproject
+/zwscene.xml
+/ozwcache_*.xml

--- a/config/fibaro/fgrm222.xml
+++ b/config/fibaro/fgrm222.xml
@@ -22,7 +22,7 @@
        <Help>Parameters value shoud be set to 1 if the module operates in Venetian Blind mode.
 	       Default setting: 0</Help>
        <Item label="Blind position reports sent to the main controller using Z-Wave Command Class" value="0" />
-       <Item label="Blind position reports sent to the main controller using Fibar Command Class" value="1" />      
+       <Item label="Blind position reports sent to the main controller using Fibaro Command Class" value="1" />      
      </Value>	
     
     <Value type="list" genre="config" instance="1" index="10" label="Roller Shutter operating modes" value="0" size="1">
@@ -168,5 +168,10 @@
       <Group index="2" max_associations="16" label="Switch hold"  />
       <Group index="3" max_associations="1" label="Lifeline" auto="true"/>
     </Associations>
+  </CommandClass>
+  <!-- Manufacturer Proprietary, sent when configuring "Fibaro Command Class" -->
+  <CommandClass id="145">
+    <Value genre="user" type="byte" instance="1" index="0" label="Venetian Blind slat position" value="0" min="0" max="100" units="%" />
+    <Value genre="user" type="byte" instance="1" index="1" label="Venetian blind tilt position" value="0" min="0" max="100" units="%" />
   </CommandClass>
 </Product>

--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -137,6 +137,21 @@ void Msg::Append
 }
 
 //-----------------------------------------------------------------------------
+// <Msg::AppendArray>
+// Add a byte array to the message
+//-----------------------------------------------------------------------------
+void Msg::AppendArray
+(
+		const uint8* const _data,
+		const uint8 _length
+)
+{
+	for (uint8 i=0 ; i<_length ; i++) {
+		this->Append( _data[i] );
+	}
+}
+
+//-----------------------------------------------------------------------------
 // <Msg::Finalize>
 // Fill in the length and checksum values for the message
 //-----------------------------------------------------------------------------

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -56,6 +56,7 @@ namespace OpenZWave
 		void SetInstance( CommandClass* _cc, uint8 const _instance );	// Used to enable wrapping with MultiInstance/MultiChannel during finalize.
 
 		void Append( uint8 const _data );
+		void AppendArray( const uint8* const _data, const uint8 _length );
 		void Finalize();
 		void UpdateCallbackId();
 

--- a/cpp/src/command_classes/CommandClasses.cpp
+++ b/cpp/src/command_classes/CommandClasses.cpp
@@ -54,6 +54,7 @@ using namespace OpenZWave;
 #include "command_classes/Indicator.h"
 #include "command_classes/Language.h"
 #include "command_classes/Lock.h"
+#include "command_classes/ManufacturerProprietary.h"
 #include "command_classes/ManufacturerSpecific.h"
 #include "command_classes/Meter.h"
 #include "command_classes/MeterPulse.h"
@@ -207,6 +208,7 @@ void CommandClasses::RegisterCommandClasses
 	cc.Register( Indicator::StaticGetCommandClassId(), Indicator::StaticGetCommandClassName(), Indicator::Create );
 	cc.Register( Language::StaticGetCommandClassId(), Language::StaticGetCommandClassName(), Language::Create );
 	cc.Register( Lock::StaticGetCommandClassId(), Lock::StaticGetCommandClassName(), Lock::Create );
+	cc.Register( ManufacturerProprietary::StaticGetCommandClassId(), ManufacturerProprietary::StaticGetCommandClassName(), ManufacturerProprietary::Create );
 	cc.Register( ManufacturerSpecific::StaticGetCommandClassId(), ManufacturerSpecific::StaticGetCommandClassName(), ManufacturerSpecific::Create );
 	cc.Register( Meter::StaticGetCommandClassId(), Meter::StaticGetCommandClassName(), Meter::Create );
 	cc.Register( MeterPulse::StaticGetCommandClassId(), MeterPulse::StaticGetCommandClassName(), MeterPulse::Create );

--- a/cpp/src/command_classes/ManufacturerProprietary.cpp
+++ b/cpp/src/command_classes/ManufacturerProprietary.cpp
@@ -1,0 +1,96 @@
+//-----------------------------------------------------------------------------
+//
+//	Proprietary.cpp
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_PROPRIETARY
+//
+//	Copyright (c) 2010 Mal Lansell <openzwave@lansell.org>
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#include "command_classes/CommandClasses.h"
+#include "command_classes/ManufacturerProprietary.h"
+#include "Defs.h"
+#include "Msg.h"
+#include "Driver.h"
+#include "platform/Log.h"
+
+#include "value_classes/ValueByte.h"
+
+using namespace OpenZWave;
+
+
+const uint8 MANUFACTURER_ID_FIBARO[2] = { 0x01, 0x0f };
+//manufacturer proprietary message identifier for venetian blinds reports
+const uint8 FIBARO_VENETIEN_BLINDS_REPORT_ID[3] = {0x26, 0x03, 0x03};
+
+enum FibaroVenetianBlindsValueIds
+{
+		FibaroVenetianBlindsValueIds_Blinds = 0,
+		FibaroVenetianBlindsValueIds_Slats = 1
+};
+
+//-----------------------------------------------------------------------------
+// <ManufacturerProprietary::HandleMsg>
+// Handle a message from the Z-Wave network
+//-----------------------------------------------------------------------------
+bool ManufacturerProprietary::HandleMsg
+(
+	uint8 const* _data,
+	uint32 const _length,
+	uint32 const _instance	// = 1
+)
+{
+	uint8 const* payload = _data+2;
+	if( MANUFACTURER_ID_FIBARO[0] == _data[0] &&
+			MANUFACTURER_ID_FIBARO[1] == _data[1] )
+	{
+
+		if( FIBARO_VENETIEN_BLINDS_REPORT_ID[0] == payload[0] &&
+				FIBARO_VENETIEN_BLINDS_REPORT_ID[1] == payload[1] &&
+				FIBARO_VENETIEN_BLINDS_REPORT_ID[2] == payload[2] )
+		{
+			uint8 blinds = payload[3];
+			uint8 slats = payload[4];
+			ValueByte* blindsValue = static_cast<ValueByte*>( GetValue( _instance, FibaroVenetianBlindsValueIds_Blinds ) );
+			ValueByte* slatsValue = static_cast<ValueByte*>( GetValue( _instance, FibaroVenetianBlindsValueIds_Slats ) );
+
+			Log::Write( LogLevel_Info, GetNodeId(), "Received Fibaro proprietary blind/slat position for node %d: Blinds: %d Slats: %d",
+						    GetNodeId(), blinds, slats);
+
+			blindsValue->OnValueRefreshed(blinds);
+			blindsValue->Release();
+			slatsValue->OnValueRefreshed(slats);
+			slatsValue->Release();
+
+			return true;
+		}
+		else
+		{
+			Log::Write( LogLevel_Warning, GetNodeId(), "Received unknown Fibaro proprietary message for node %d.",
+						    GetNodeId());
+			return false;
+		}
+	}
+	Log::Write( LogLevel_Warning, GetNodeId(), "Received unknown manufacturer proprietary message for node %d.",
+					GetNodeId());
+	return false;
+}
+

--- a/cpp/src/command_classes/ManufacturerProprietary.cpp
+++ b/cpp/src/command_classes/ManufacturerProprietary.cpp
@@ -37,18 +37,18 @@
 using namespace OpenZWave;
 
 
-const uint8 const MANUFACTURER_ID_FIBARO[2] = { 0x01, 0x0f };
+const uint8 MANUFACTURER_ID_FIBARO[2] = { 0x01, 0x0f };
 //manufacturer proprietary message identifier for venetian blinds reports and get/set
-const uint8 const FIBARO_VENETIEN_BLINDS_REPORT_ID[3] = { 0x26, 0x03, 0x03 };
-const uint8 const FIBARO_VENETIAN_BLINDS_GET_POSITION_TILT[5] = { 0x26, 0x02, 0x02, 0x00, 0x00 };
-const uint8 const FIBARO_VENETIAN_BLINDS_SET_TILT[3] =          { 0x26, 0x01, 0x01 };
-const uint8 const FIBARO_VENETIAN_BLINDS_SET_POSITION[3] =      { 0x26, 0x01, 0x02 };
+const uint8 FIBARO_VENETIEN_BLINDS_REPORT_ID[3] = { 0x26, 0x03, 0x03 };
+const uint8 FIBARO_VENETIAN_BLINDS_GET_POSITION_TILT[5] = { 0x26, 0x02, 0x02, 0x00, 0x00 };
+const uint8 FIBARO_VENETIAN_BLINDS_SET_TILT[4] =          { 0x26, 0x01, 0x01, 0x00 };
+const uint8 FIBARO_VENETIAN_BLINDS_SET_POSITION[3] =      { 0x26, 0x01, 0x02 };
 
 
 enum FibaroVenetianBlindsValueIds
 {
 		FibaroVenetianBlindsValueIds_Blinds = 0,
-		FibaroVenetianBlindsValueIds_Slats = 1
+		FibaroVenetianBlindsValueIds_Tilt = 1
 };
 
 //-----------------------------------------------------------------------------
@@ -74,15 +74,15 @@ bool ManufacturerProprietary::HandleMsg
 			uint8 blinds = payload[3];
 			uint8 slats = payload[4];
 			ValueByte* blindsValue = static_cast<ValueByte*>( GetValue( _instance, FibaroVenetianBlindsValueIds_Blinds ) );
-			ValueByte* slatsValue = static_cast<ValueByte*>( GetValue( _instance, FibaroVenetianBlindsValueIds_Slats ) );
+			ValueByte* tiltValue = static_cast<ValueByte*>( GetValue( _instance, FibaroVenetianBlindsValueIds_Tilt ) );
 
 			Log::Write( LogLevel_Info, GetNodeId(), "Received Fibaro proprietary blind/slat position for node %d: Blinds: %d Slats: %d",
 						    GetNodeId(), blinds, slats);
 
 			blindsValue->OnValueRefreshed(blinds);
 			blindsValue->Release();
-			slatsValue->OnValueRefreshed(slats);
-			slatsValue->Release();
+			tiltValue->OnValueRefreshed(slats);
+			tiltValue->Release();
 
 			return true;
 		}
@@ -113,7 +113,7 @@ bool ManufacturerProprietary::RequestValue
 	if ( IsGetSupported() )
 	{
 		Msg* msg = new Msg( "ManufacturerProprietary_RequestValue", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
-		if (FibaroVenetianBlindsValueIds_Blinds == _index || FibaroVenetianBlindsValueIds_Slats == _index){
+		if (FibaroVenetianBlindsValueIds_Blinds == _index || FibaroVenetianBlindsValueIds_Tilt == _index){
 			msg->SetInstance( this, _instance );
 			msg->Append( GetNodeId() );
 			msg->Append( 1+sizeof(MANUFACTURER_ID_FIBARO)+sizeof(FIBARO_VENETIAN_BLINDS_GET_POSITION_TILT) ); // length of data
@@ -132,3 +132,44 @@ bool ManufacturerProprietary::RequestValue
 	}
 	return false;
 }
+
+//-----------------------------------------------------------------------------
+// <ManufacturerProprietary::SetValue>
+// Set the lock's state
+//-----------------------------------------------------------------------------
+bool ManufacturerProprietary::SetValue
+(
+	Value const& _value
+)
+{
+	uint64 value_id = _value.GetID().GetIndex();
+	Msg* msg = new Msg( "ManufacturerProprietary_SetValue", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
+
+	if (FibaroVenetianBlindsValueIds_Blinds == value_id || FibaroVenetianBlindsValueIds_Tilt == value_id){
+		ValueByte const* value = static_cast<ValueByte const*>(&_value);
+
+		msg->SetInstance( this, _value.GetID().GetInstance() );
+		msg->Append( GetNodeId() );
+		msg->Append( 2 + // length of data
+				sizeof(MANUFACTURER_ID_FIBARO) +
+				sizeof(FIBARO_VENETIAN_BLINDS_GET_POSITION_TILT) );
+		msg->Append( GetCommandClassId() );
+		msg->AppendArray( MANUFACTURER_ID_FIBARO, sizeof(MANUFACTURER_ID_FIBARO) );
+		if (FibaroVenetianBlindsValueIds_Blinds == value_id) {
+			msg->AppendArray( FIBARO_VENETIAN_BLINDS_SET_POSITION, sizeof(FIBARO_VENETIAN_BLINDS_SET_POSITION) );
+			msg->Append( value->GetValue() );
+			msg->Append( 0x00 );
+		} else if (FibaroVenetianBlindsValueIds_Tilt == value_id) {
+			msg->AppendArray( FIBARO_VENETIAN_BLINDS_SET_TILT, sizeof(FIBARO_VENETIAN_BLINDS_SET_TILT) );
+			msg->Append( value->GetValue() );
+		}
+		msg->Append( GetDriver()->GetTransmitOptions() );
+		GetDriver()->SendMsg( msg, Driver::MsgQueue_Send );
+		return true;
+	} else {
+		Log::Write(  LogLevel_Info, GetNodeId(), "ManufacturerProprietary_SetValue %d not supported on node %d", value_id, GetNodeId());
+		return false;
+	}
+}
+
+

--- a/cpp/src/command_classes/ManufacturerProprietary.h
+++ b/cpp/src/command_classes/ManufacturerProprietary.h
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 //
-//	Proprietary.h
+//	ManufacturerProprietary.h
 //
 //	Implementation of the Z-Wave COMMAND_CLASS_PROPRIETARY
 //
@@ -47,6 +47,7 @@ namespace OpenZWave
 		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
+		virtual bool RequestValue( uint32 const _requestFlags, uint16 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
 
 	private:
 		ManufacturerProprietary( uint32 const _homeId, uint8 const _nodeId ): CommandClass( _homeId, _nodeId ){}

--- a/cpp/src/command_classes/ManufacturerProprietary.h
+++ b/cpp/src/command_classes/ManufacturerProprietary.h
@@ -48,6 +48,7 @@ namespace OpenZWave
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
 		virtual bool RequestValue( uint32 const _requestFlags, uint16 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
+		virtual bool SetValue( Value const& _value );
 
 	private:
 		ManufacturerProprietary( uint32 const _homeId, uint8 const _nodeId ): CommandClass( _homeId, _nodeId ){}

--- a/cpp/src/command_classes/ManufacturerProprietary.h
+++ b/cpp/src/command_classes/ManufacturerProprietary.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+//
+//	Proprietary.h
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_PROPRIETARY
+//
+//	Copyright (c) 2010 Mal Lansell <openzwave@lansell.org>
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#ifndef _ManufacturerProprietary_H
+#define _ManufacturerProprietary_H
+
+#include "command_classes/CommandClass.h"
+
+namespace OpenZWave
+{
+	/** \brief Implements COMMAND_CLASS_PROPRIETARY (0x91), a Z-Wave device command class.
+	 */
+	class ManufacturerProprietary: public CommandClass
+	{
+	public:
+		static CommandClass* Create( uint32 const _homeId, uint8 const _nodeId ){ return new ManufacturerProprietary( _homeId, _nodeId ); }
+		virtual ~ManufacturerProprietary(){}
+
+		static uint8 const StaticGetCommandClassId(){ return 0x91; }
+		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_MANUFACTURER_PROPRIETARY"; }
+
+		// From CommandClass
+		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
+		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
+		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
+
+	private:
+		ManufacturerProprietary( uint32 const _homeId, uint8 const _nodeId ): CommandClass( _homeId, _nodeId ){}
+	};
+
+} // namespace OpenZWave
+
+#endif
+


### PR DESCRIPTION
As discussed some time ago in the forum: The Fibaro FGRM-222 Roller Shutter 2 is using the COMMAND_CLASS_MANUFACTURER_PROPRIETARY to indicate the tilt angle of the slats. This is only transmitted when activating the venetian blind mode and setting the report type to "Fibaro Command class".

@Fishwaldo 
As I messed up my branch completely, it was easier to create a new, clean one. So this is the continuation of pull request https://github.com/OpenZWave/open-zwave/pull/1203