### PR TITLE
Fixed crash when data_length equals 0

### DIFF
--- a/cpp/src/command_classes/ManufacturerSpecific.cpp
+++ b/cpp/src/command_classes/ManufacturerSpecific.cpp
@@ -257,6 +257,8 @@ bool ManufacturerSpecific::HandleMsg
         uint8 deviceIDType = (_data[1] & 0x07);
         uint8 dataFormat = (_data[2] & 0xe0)>>0x05;
         uint8 data_length = (_data[2] & 0x1f);
+        if (data_length==0)
+			return false;
         uint8 const* deviceIDData = &_data[3];
         string deviceID = "";
         for (int i=0; i<data_length; i++) {


### PR DESCRIPTION
I experienced a crash on both Windows and Linux systems when the data_length was 0.
This causes 'OnValueRefreshed' to be called with an empty string, resulting in a crash.

Tested the 'Dev' branch with the 'config' folder from the master.
In the setup i disabled downloading/checking for the manufacturer file update

I suspect this has something to do with 'GreenWave PowerNode 6' node, or right after this node is queried

With this patch the library was able to query all nodes and continue