### PR TITLE
Updated MinGW compilation

### DIFF
--- a/cpp/build/windows/mingw32/Makefile
+++ b/cpp/build/windows/mingw32/Makefile
@@ -22,12 +22,12 @@ LDFLAGS	:= $(DEBUG_LDFLAGS)
 
 LIBDIR	:= ../../../lib/windows-mingw32
 
-INCLUDES	:= -I ../../../src -I ../../../src/command_classes/ -I ../../../src/value_classes/ \
+INCLUDES	:= -I ../../../src -I ../../../src/command_classes/ -I ../../../src/aes/ -I ../../../src/value_classes/ \
 	-I ../../../src/platform/ -I ../../../src/platform/windows -I ../../../tinyxml/ -I ../../../hidapi/hidapi/
-SOURCES		:= ../../../src ../../../src/command_classes ../../../tinyxml ../../../hidapi/windows \
+SOURCES		:= ../../../src ../../../src/command_classes ../../../src/aes ../../../tinyxml ../../../hidapi/windows \
 	../../../src/value_classes ../../../src/platform ../../../src/platform/windows
 
-VPATH = ../../../src:../../../src/command_classes:../../../tinyxml:../../../hidapi/windows:\
+VPATH = ../../../src:../../../src/command_classes:../../../src/aes:../../../tinyxml:../../../hidapi/windows:\
 	../../../src/value_classes:../../../src/platform:../../../src/platform/windows
 
 %.d : %.cpp
@@ -40,6 +40,7 @@ tinyxml := $(notdir $(wildcard ../../../tinyxml/*.cpp))
 hidapi := $(notdir $(wildcard ../../../hidapi/linux/hid.c)) # we do not want the libusb version
 cclasses := $(notdir $(wildcard ../../../src/command_classes/*.cpp))
 vclasses := $(notdir $(wildcard ../../../src/value_classes/*.cpp))
+aes := $(notdir $(wildcard ../../../src/aes/*.c))
 pform := $(notdir $(wildcard ../../../src/platform/*.cpp)) \
 	$(notdir $(wildcard ../../../src/platform/windows/*.cpp))
 indep := $(notdir $(wildcard ../../../src/*.cpp))
@@ -59,6 +60,7 @@ clean:
 -include $(hidapi:.c=.d)
 -include $(cclasses:.cpp=.d)
 -include $(vclasses:.cpp=.d)
+-include $(aes:.c=.d)
 -include $(pform:.cpp=.d)
 -include $(indep:.cpp=.d)
 
@@ -71,6 +73,7 @@ $(LIBDIR)/openzwave.a:	$(patsubst %.cpp,%.o,$(tinyxml)) \
 			$(patsubst %.c,%.o,$(hidapi)) \
 			$(patsubst %.cpp,%.o,$(cclasses)) \
 			$(patsubst %.cpp,%.o,$(vclasses)) \
+			$(patsubst %.c,%.o,$(aes)) \
 			$(patsubst %.cpp,%.o,$(pform)) \
 			$(patsubst %.cpp,%.o,$(indep)) vers.o
 	$(AR) $@ $?

--- a/cpp/src/platform/windows/EventImpl.h
+++ b/cpp/src/platform/windows/EventImpl.h
@@ -28,7 +28,7 @@
 #ifndef _EventImpl_H
 #define _EventImpl_H
 
-#include <Windows.h>
+#include <windows.h>
 #include "Defs.h"
 
 namespace OpenZWave

--- a/cpp/src/platform/windows/LogImpl.h
+++ b/cpp/src/platform/windows/LogImpl.h
@@ -31,7 +31,7 @@
 #include "Defs.h"
 #include <string>
 #include "platform/Log.h"
-#include "Windows.h"
+#include <windows.h>
 
 namespace OpenZWave
 {

--- a/cpp/src/platform/windows/SerialControllerImpl.h
+++ b/cpp/src/platform/windows/SerialControllerImpl.h
@@ -28,7 +28,7 @@
 #ifndef _SerialControllerImpl_H
 #define _SerialControllerImpl_H
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "Defs.h"
 #include "platform/SerialController.h"

--- a/cpp/src/platform/windows/TimeStampImpl.cpp
+++ b/cpp/src/platform/windows/TimeStampImpl.cpp
@@ -26,7 +26,7 @@
 //
 //-----------------------------------------------------------------------------
 #include <string>
-#include <Windows.h>
+#include <windows.h>
 #include "Defs.h"
 #include "TimeStampImpl.h"
 


### PR DESCRIPTION
Updated MinGW Makefile - added AES files to compilation.
Fixed inclusion on windows header file to lower case to be able to compile this under Linux (cross compilation).