### PR TITLE
Fix logging for byte values

### DIFF
--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -81,7 +81,7 @@ string const ValueByte::GetAsString
 ) const
 {
 	stringstream ss;
-	ss << GetValue();
+	ss << (uint32)GetValue();
 	return ss.str();
 }
 


### PR DESCRIPTION
Writing a byte to the string stream ends up converting it as a character. It's cast to an integer here since it's the numeric value we want to see.

Fixes #466 