### PR TITLE
Usercode support BeNext Tagreader500 secutrity panel

### DIFF
--- a/cpp/src/command_classes/UserCode.h
+++ b/cpp/src/command_classes/UserCode.h
@@ -99,11 +99,12 @@ namespace OpenZWave
 			}
 		}
 
-		bool		m_queryAll;				// True while we are requesting all the user codes.
-		uint8		m_currentCode;
-		uint8		m_userCodeCount;
-		uint8		m_userCodesStatus[256];
-		bool		m_refreshUserCodes;
+		bool 	m_queryAll;				// True while we are requesting all the user codes.
+		uint8 	m_currentCode;
+		uint8 	m_userCodeCount;
+		uint8 	m_userCodeLength;
+		uint8	m_userCodesStatus[256];
+		bool	m_refreshUserCodes;
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
Support for BeNext Tagreader500 security panel. This unit allows the user to present keytags to arm or disarm an alarm system. Besides that the user can type a code, using buttons on the keypad of the device to activate or deactivate the alarm system. The keytags work fine but the keypad is broken. This is because the produced code of the keypad is 4 to 10 digits long, depending on the entered code. Codes shorter than 10 digits fail on the current open-zwave Usercode implementation. This change makes the BeNext Tagreader 500 work. I am using the fixed code for 6 months now, it works fine.
 Side note: This PR was open for a while. After I rebased the code onto the top of the Dev branch I could not find the PR anymore so that is why I am opening it again.