### PR TITLE
Added missing `ManufacturerProprietary` files to Windows builds

### DIFF
--- a/cpp/build/winRT/vs2015/OpenZWave.vcxproj
+++ b/cpp/build/winRT/vs2015/OpenZWave.vcxproj
@@ -59,6 +59,7 @@
     <ClInclude Include="..\..\..\src\command_classes\Indicator.h" />
     <ClInclude Include="..\..\..\src\command_classes\Language.h" />
     <ClInclude Include="..\..\..\src\command_classes\Lock.h" />
+    <ClInclude Include="..\..\..\src\command_classes\ManufacturerProprietary.h" />
     <ClInclude Include="..\..\..\src\command_classes\ManufacturerSpecific.h" />
     <ClInclude Include="..\..\..\src\command_classes\Meter.h" />
     <ClInclude Include="..\..\..\src\command_classes\MeterPulse.h" />
@@ -202,6 +203,7 @@
     <ClCompile Include="..\..\..\src\command_classes\Indicator.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\Language.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\Lock.cpp" />
+    <ClCompile Include="..\..\..\src\command_classes\ManufacturerProprietary.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\ManufacturerSpecific.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\Meter.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\MeterPulse.cpp" />

--- a/cpp/build/winRT/vs2015/OpenZWave.vcxproj.filters
+++ b/cpp/build/winRT/vs2015/OpenZWave.vcxproj.filters
@@ -379,6 +379,9 @@
     <ClInclude Include="..\..\..\src\platform\HttpClient.h">
       <Filter>Platform</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\command_classes\ManufacturerProprietary.h">
+      <Filter>Command Classes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\aes\aes_modes.c">
@@ -716,6 +719,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\src\platform\HttpClient.cpp">
       <Filter>Platform</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\command_classes\ManufacturerProprietary.cpp">
+      <Filter>Command Classes</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cpp/build/windows/vs2010/OpenZWave.vcxproj
+++ b/cpp/build/windows/vs2010/OpenZWave.vcxproj
@@ -211,6 +211,7 @@ exit 0</Command>
     <ClInclude Include="..\..\..\src\command_classes\DeviceResetLocally.h" />
     <ClInclude Include="..\..\..\src\command_classes\DoorLock.h" />
     <ClInclude Include="..\..\..\src\command_classes\DoorLockLogging.h" />
+    <ClInclude Include="..\..\..\src\command_classes\ManufacturerProprietary.h" />
     <ClInclude Include="..\..\..\src\command_classes\NoOperation.h" />
     <ClInclude Include="..\..\..\src\command_classes\SceneActivation.h" />
     <ClInclude Include="..\..\..\src\command_classes\Security.h" />
@@ -326,6 +327,7 @@ exit 0</Command>
     <ClCompile Include="..\..\..\src\command_classes\DeviceResetLocally.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\DoorLock.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\DoorLockLogging.cpp" />
+    <ClCompile Include="..\..\..\src\command_classes\ManufacturerProprietary.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\NoOperation.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\SceneActivation.cpp" />
     <ClCompile Include="..\..\..\src\command_classes\Security.cpp" />

--- a/cpp/build/windows/vs2010/OpenZWave.vcxproj.filters
+++ b/cpp/build/windows/vs2010/OpenZWave.vcxproj.filters
@@ -378,6 +378,9 @@
     <ClInclude Include="..\..\..\src\command_classes\BarrierOperator.h">
       <Filter>Command Classes</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\command_classes\ManufacturerProprietary.h">
+      <Filter>Command Classes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\Driver.cpp">
@@ -720,6 +723,9 @@
       <Filter>Main</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\command_classes\BarrierOperator.cpp">
+      <Filter>Command Classes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\command_classes\ManufacturerProprietary.cpp">
       <Filter>Command Classes</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
These files were missing from the Windows build, causing linker errors to occur

/CC @Fishwaldo 