### PR TITLE
Added LED policy config settings to HomeSeer HS-WS100+ switch

### DIFF
--- a/config/homeseer/hs-ws100plus.xml
+++ b/config/homeseer/hs-ws100plus.xml
@@ -7,7 +7,13 @@
             <Item label="No" value="0"/>
             <Item label="Yes" value="1"/>
         </Value>
-    </CommandClass>
+        <Value type="list" index="3" genre="config" label="LED Status" min="0" max="2" size="1" value="0">
+            <Help>Set the LED policy: on if the load is on, off if the load is on, or off all the time </Help>
+            <Item label="LED off if load on" value="0"/>
+            <Item label="LED on if load on" value="1"/>
+	    <Item label="LED off all the time" value="2"/>
+        </Value>
+</CommandClass>
     <!-- Association Groups -->
     <CommandClass id="133">
         <Associations num_groups="1">


### PR DESCRIPTION
Tested via Open-zwave-control-panel on a live switch. All 3 defined
states work as expected.

Reference for these config parameters / values is here:
http://products.z-wavealliance.org/products/1731/configs

Also verified with HomeSeer Inc via support email.