### PR TITLE
add gocontrol/linear thermostats

### DIFF
--- a/config/gocontrol/GC-TBZ48L.xml
+++ b/config/gocontrol/GC-TBZ48L.xml
@@ -240,22 +240,22 @@
         R1 Sensor Temperature Offset
       </Help>
     </Value>
-    <Value type="byte" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+    <Value type="short" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
       <Help>
         Timer to let know when to change or clean the filter
       </Help>
     </Value>
-    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
+    <Value type="short" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
       <Help>
         Maximum allowed value for filter timer
       </Help>
     </Value>
-    <Value type="byte" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
+    <Value type="short" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
       <Help>
         Heat Timer in hours
       </Help>
     </Value>
-    <Value type="byte" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
+    <Value type="short" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
       <Help>
         Cool Timer in hours
       </Help>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -1,215 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<Product xmlns="http://code.google.com/p/open-zwave/">
-	<CommandClass id="67" base="0"/>
-	<CommandClass id="112">
-		<Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
-      <Help>
-        0 = Standard, 1 = Heat Pump
-      </Help>
-			<Item label="Standard" value="0" />
-			<Item label="Head Pump" value="1" />
-		</Value>
-    <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
-      </Help>
-			<Item label="Gas" value="0" />
-			<Item label="Electric" value="1" />
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+  <CommandClass id="133" name="COMMAND_CLASS_ASSOCIATION" version="1" request_flags="4" create_vars="true">
+    <Instance index="1" />
+    <Associations num_groups="1">
+      <Group index="1" max_associations="5" label="Group 1" >
+        <Node id="1" />
+      </Group>
+    </Associations>
+  </CommandClass>
+
+  <!-- The thermostat does not properly report its operating modes -->
+  <CommandClass id="64" name="COMMAND_CLASS_THERMOSTAT_MODE" version="1" request_flags="4" create_vars="true">
+    <Value type="list" genre="user" instance="1" index="0" label="Mode" units="" read_only="false" write_only="false" min="0" max="0" value="0">
+      <Item label="Off" value="0" />
+      <Item label="Heat" value="1" />
+      <Item label="Cool" value="2" />
+      <Item label="Auto" value="3" />
+      <Item label="Aux Heat" value="4" />
     </Value>
-    <Value type="list" index="3" genre="config" label="Change Over Type" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = w/Cool, 1 = w/Heat
-      </Help>
-			<Item label="w/Cool" value="0" />
-			<Item label="w/Heat" value="1" />
-    </Value>
-    <Value type="list" index="4" genre="config" label="2nd Stage Heat Enable" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = no 2nd stage heat, 1 = 2nd stage heat
-      </Help>
-			<Item label="w/Cool" value="0" />
-			<Item label="w/Heat" value="1" />
-    </Value>
-    <Value type="list" index="5" genre="config" label="Aux Heat Enable" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = no aux heat, 1 = aux heat enabled
-      </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
-    </Value>
-    <Value type="list" index="6" genre="config" label="2nd Stage Cool Enable" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = no 2nd stage cool, 1 = 2nd stage cool
-      </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
-    </Value>
-    <Value type="list" index="7" genre="config" label="Temperature Unit" units="" min="0" max="1" value="1" size="1">
-      <Help>
-				0 = Celsius, 1 = Fahrenheit
-      </Help>
-			<Item label="Celsius" value="0" />
-			<Item label="Fahrenheit" value="1" />
-    </Value>
-    <Value type="byte" index="8" genre="config" label="Minimum Off Time" units="minutes" min="5" max="9" value="5" size="1">
-      <Help>
-        Sets the Minimum Off Time (MOT) delay before another heating/cooling cycle can begin
-      </Help>
-    </Value>
-    <Value type="byte" index="9" genre="config" label="Minimum Run Time" units="minutes" min="3" max="9" value="3" size="1">
-      <Help>
-        Sets the Minimum Run Time (MRT) delay before a heating/cooling cycle can turn of
-      </Help>
-    </Value>
-    <Value type="byte" index="10" genre="config" label="Setpoint H/C Delta" units="fahrenheit" min="3" max="15" value="3" size="1">
-      <Help>
-        Sets the minimum separation between heating and cooling setpoints
-      </Help>
-    </Value>
-    <Value type="byte" index="11" genre="config" label="H Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
-      <Help>
-        Sets the delta from setpoint that stage 1 heating starts
-      </Help>
-    </Value>
-    <Value type="byte" index="12" genre="config" label="H Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
-      <Help>
-        Sets the delta from setpoint that stage 1 heating stops
-      </Help>
-    </Value>
-    <Value type="byte" index="13" genre="config" label="H Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
-      <Help>
-        Sets the delta from setpoint that stage 2 heating starts
-      </Help>
-    </Value>
-    <Value type="byte" index="14" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
-      <Help>
-        Sets the delay from setpoint that stage 2 heating stops
-      </Help>
-    </Value>
-    <Value type="byte" index="15" genre="config" label="H Delta Aux ON" units="fahrenheit" min="3" max="8" value="3" size="1">
-      <Help>
-        Sets the delta from setpoint that stage 3 heating starts
-      </Help>
-    </Value>
-    <Value type="byte" index="16" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="7" value="0" size="1">
-      <Help>
-        Sets the delta from setpoint that stage 3 heating stops
-      </Help>
-    </Value>
-    <Value type="byte" index="17" genre="config" label="C Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
-      <Help>
-				Sets the delta from setpoint that stage 1 cooling starts
-      </Help>
-    </Value>
-    <Value type="byte" index="18" genre="config" label="C Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
-      <Help>
-				Sets the delta from setpoint that stage 1 cooling stops
-      </Help>
-    </Value>
-    <Value type="byte" index="19" genre="config" label="C Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
-      <Help>
-				Sets the delta from setpoint that stage 2 cooling starts
-      </Help>
-    </Value>
-    <Value type="byte" index="20" genre="config" label="C Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
-      <Help>
-				Sets the delta from setpoint that stage 2 cooling stops
-      </Help>
-    </Value>
-    <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
-      <Help>
-				Mechanical Status
-      </Help>
-			<Item label="MECH_H1" value="1" />
-			<Item label="MECH_H2" value="2" />
-			<Item label="MECH_H3" value="4" />
-			<Item label="MECH_C1" value="8" />
-			<Item label="MECH_C2" value="16" />
-			<Item label="PHANTOM_F" value="32" />
-			<Item label="MECH_F" value="64" />
-			<Item label="MANUAL_F" value="128" />
-			<Item label="reserved" value="256" />
-    </Value>
-    <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
-      <Help>
-				SCP Status
-      </Help>
-			<Item label="STATE_HEAT" value="1" />
-			<Item label="STATE_COOL" value="2" />
-			<Item label="STATE_2ND" value="4" />
-			<Item label="STATE_3RD" value="8" />
-			<Item label="STATE_FAN" value="16" />
-			<Item label="STATE_LAST" value="32" />
-			<Item label="STATE_MOT" value="64" />
-			<Item label="STATE_MRT" value="128" />
-    </Value>
-    <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
-      <Help>
-				Autosend Enable Bits
-      </Help>
-			<Item label="Temperature" value="1" />
-			<Item label="Setpoint H" value="2" />
-			<Item label="Setpoint C" value="4" />
-			<Item label="Mode" value="8" />
-			<Item label="Fan Mode" value="16" />
-			<Item label="Fan State" value="32" />
-			<Item label="Operating State" value="64" />
-			<Item label="Schedule Enable" value="128" />
-			<Item label="Setback" value="256" />
-			<Item label="Runhold" value="512" />
-			<Item label="Display Lock" value="1024" />
-			<Item label="Battery" value="8192" />
-			<Item label="Mechanical Status" value="16384" />
-			<Item label="SCP Status" value="32768" />
-    </Value>
-    <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
-      <Help>
-				Display Lock
-      </Help>
-			<Item label="Unlocked" value="0" />
-			<Item label="Locked" value="1" />
-    </Value>
-    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="10" size="1">
-      <Help>
-				Sets the time from last button press that the backlight will turn OFF
-      </Help>
-    </Value>
-    <Value type="byte" index="33" genre="config" label="Max Heat Setpoint" units="degrees" min="30" max="109" value="90" size="1">
-      <Help>
-        Sets the maximum heating setpoint value
-      </Help>
-    </Value>
-    <Value type="byte" index="34" genre="config" label="Min Cool Setpoint" units="degrees" min="33" max="112" value="60" size="1">
-      <Help>
-        Sets the minimum cooling setpoint value
-      </Help>
-    </Value>
-    <Value type="list" index="38" genre="config" label="Schedule Enable" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				Enable or disable thermostat's local scheduler
-      </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
-    </Value>
-    <Value type="list" index="39" genre="config" label="Run/Hold Mode" units="" min="0" max="1" value="0" size="1">
-      <Help>
-				0 = Hold, 1 = Run
-      </Help>
-			<Item label="Hold" value="0" />
-			<Item label="Run" value="1" />
-    </Value>
-    <Value type="list" index="40" genre="config" label="Setback Mode" units="" min="0" max="2" value="0" size="1">
-      <Help>
-				0 = No setback, 2 = Un-occupied mode
-      </Help>
-			<Item label="No Setback" value="0" />
-			<Item label="Unoccupied Mode" value="2" />
-    </Value>
-    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
-      <Help>
-				Heat Setpoint for Unoccupied mode
-      </Help>
-    </Value>
-	</CommandClass>
+    <SupportedModes>
+      <Mode index="0" label="Off" />
+      <Mode index="1" label="Heat" />
+      <Mode index="2" label="Cool" />
+      <Mode index="3" label="Auto" />
+      <Mode index="4" label="Aux Heat" />
+    </SupportedModes>
+  </CommandClass>
+
+  <CommandClass id="67" name="COMMAND_CLASS_THERMOSTAT_SETPOINT" version="1" request_flags="4" create_vars="true" base="0">
+    <Instance index="1" />
+    <Value type="decimal" genre="user" instance="1" index="1" label="Heating 1" read_only="false" write_only="false" />
+    <Value type="decimal" genre="user" instance="1" index="2" label="Cooling 1" read_only="false" write_only="false" />
+  </CommandClass>
 </Product>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -121,52 +121,6 @@
         Sets the delta from setpoint that stage 2 cooling stops
       </Help>
     </Value>
-    <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
-      <Help>
-        Mechanical Status
-      </Help>
-      <Item label="MECH_H1" value="1" />
-      <Item label="MECH_H2" value="2" />
-      <Item label="MECH_H3" value="4" />
-      <Item label="MECH_C1" value="8" />
-      <Item label="MECH_C2" value="16" />
-      <Item label="PHANTOM_F" value="32" />
-      <Item label="MECH_F" value="64" />
-      <Item label="MANUAL_F" value="128" />
-      <Item label="reserved" value="256" />
-    </Value>
-    <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
-      <Help>
-        SCP Status
-      </Help>
-      <Item label="STATE_HEAT" value="1" />
-      <Item label="STATE_COOL" value="2" />
-      <Item label="STATE_2ND" value="4" />
-      <Item label="STATE_3RD" value="8" />
-      <Item label="STATE_FAN" value="16" />
-      <Item label="STATE_LAST" value="32" />
-      <Item label="STATE_MOT" value="64" />
-      <Item label="STATE_MRT" value="128" />
-    </Value>
-    <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
-      <Help>
-        Autosend Enable Bits
-      </Help>
-      <Item label="Temperature" value="1" />
-      <Item label="Setpoint H" value="2" />
-      <Item label="Setpoint C" value="4" />
-      <Item label="Mode" value="8" />
-      <Item label="Fan Mode" value="16" />
-      <Item label="Fan State" value="32" />
-      <Item label="Operating State" value="64" />
-      <Item label="Schedule Enable" value="128" />
-      <Item label="Setback" value="256" />
-      <Item label="Runhold" value="512" />
-      <Item label="Display Lock" value="1024" />
-      <Item label="Battery" value="8192" />
-      <Item label="Mechanical Status" value="16384" />
-      <Item label="SCP Status" value="32768" />
-    </Value>
     <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
       <Help>
         Display Lock

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -215,7 +215,7 @@
         Heat Setpoint for Unoccupied mode
       </Help>
     </Value>
-    <Value type="byte" index="42" genre="config" label="Un-Occupied CSP" units="degrees" min="33" max="112" value="70" size="1">
+    <Value type="byte" index="42" genre="config" label="Un-Occupied CSP" units="degrees" min="33" max="112" value="80" size="1">
       <Help>
         Cool Setpoint for Unoccupied mode
       </Help>
@@ -225,17 +225,17 @@
         Node number for Remote Sensor 1
       </Help>
     </Value>
-    <Value type="byte" index="46" genre="config" label="Remote Sensor 1 Temperature" units="degrees" min="0" max="0" value="0" size="1">
+    <Value type="byte" index="46" genre="config" label="Remote Sensor 1 Temperature" units="degrees" min="0" max="112" size="1">
       <Help>
         Temperature of Remote Sensor 1
       </Help>
     </Value>
-    <Value type="byte" index="48" genre="config" label="Internal Sensor Temp Offset" units="degrees" min="-7" max="7" value="7" size="1">
+    <Value type="byte" index="48" genre="config" label="Internal Sensor Temp Offset" units="degrees" min="-7" max="7" value="0" size="1">
       <Help>
         Internal Sensor Temperature Offset
       </Help>
     </Value>
-    <Value type="byte" index="49" genre="config" label="R1 Sensor Temp Offset" units="degrees" min="-7" max="7" value="7" size="1">
+    <Value type="byte" index="49" genre="config" label="R1 Sensor Temp Offset" units="degrees" min="-7" max="7" value="0" size="1">
       <Help>
         R1 Sensor Temperature Offset
       </Help>
@@ -245,7 +245,7 @@
         Timer to let know when to change or clean the filter
       </Help>
     </Value>
-    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
       <Help>
         Maximum allowed value for filter timer
       </Help>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Product xmlns="http://code.google.com/p/open-zwave/">
+	<CommandClass id="67" base="0"/>
+	<CommandClass id="112">
+		<Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = Standard, 1 = Heat Pump
+      </Help>
+			<Item label="Standard" value="0" />
+			<Item label="Head Pump" value="1" />
+		</Value>
+    <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
+      </Help>
+			<Item label="Gas" value="0" />
+			<Item label="Electric" value="1" />
+    </Value>
+    <Value type="list" index="3" genre="config" label="Change Over Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = w/Cool, 1 = w/Heat
+      </Help>
+			<Item label="w/Cool" value="0" />
+			<Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="4" genre="config" label="2nd Stage Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no 2nd stage heat, 1 = 2nd stage heat
+      </Help>
+			<Item label="w/Cool" value="0" />
+			<Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="5" genre="config" label="Aux Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no aux heat, 1 = aux heat enabled
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="6" genre="config" label="2nd Stage Cool Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no 2nd stage cool, 1 = 2nd stage cool
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="7" genre="config" label="Temperature Unit" units="" min="0" max="1" value="1" size="1">
+      <Help>
+				0 = Celsius, 1 = Fahrenheit
+      </Help>
+			<Item label="Celsius" value="0" />
+			<Item label="Fahrenheit" value="1" />
+    </Value>
+    <Value type="byte" index="8" genre="config" label="Minimum Off Time" units="minutes" min="5" max="9" value="5" size="1">
+      <Help>
+        Sets the Minimum Off Time (MOT) delay before another heating/cooling cycle can begin
+      </Help>
+    </Value>
+    <Value type="byte" index="9" genre="config" label="Minimum Run Time" units="minutes" min="3" max="9" value="3" size="1">
+      <Help>
+        Sets the Minimum Run Time (MRT) delay before a heating/cooling cycle can turn of
+      </Help>
+    </Value>
+    <Value type="byte" index="10" genre="config" label="Setpoint H/C Delta" units="fahrenheit" min="3" max="15" value="3" size="1">
+      <Help>
+        Sets the minimum separation between heating and cooling setpoints
+      </Help>
+    </Value>
+    <Value type="byte" index="11" genre="config" label="H Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="12" genre="config" label="H Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="13" genre="config" label="H Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 2 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="14" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+        Sets the delay from setpoint that stage 2 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="15" genre="config" label="H Delta Aux ON" units="fahrenheit" min="3" max="8" value="3" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="16" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="7" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="17" genre="config" label="C Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 1 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="18" genre="config" label="C Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 1 cooling stops
+      </Help>
+    </Value>
+    <Value type="byte" index="19" genre="config" label="C Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 2 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="20" genre="config" label="C Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 2 cooling stops
+      </Help>
+    </Value>
+    <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
+      <Help>
+				Mechanical Status
+      </Help>
+			<Item label="MECH_H1" value="1" />
+			<Item label="MECH_H2" value="2" />
+			<Item label="MECH_H3" value="4" />
+			<Item label="MECH_C1" value="8" />
+			<Item label="MECH_C2" value="16" />
+			<Item label="PHANTOM_F" value="32" />
+			<Item label="MECH_F" value="64" />
+			<Item label="MANUAL_F" value="128" />
+			<Item label="reserved" value="256" />
+    </Value>
+    <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
+      <Help>
+				SCP Status
+      </Help>
+			<Item label="STATE_HEAT" value="1" />
+			<Item label="STATE_COOL" value="2" />
+			<Item label="STATE_2ND" value="4" />
+			<Item label="STATE_3RD" value="8" />
+			<Item label="STATE_FAN" value="16" />
+			<Item label="STATE_LAST" value="32" />
+			<Item label="STATE_MOT" value="64" />
+			<Item label="STATE_MRT" value="128" />
+    </Value>
+    <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
+      <Help>
+				Autosend Enable Bits
+      </Help>
+			<Item label="Temperature" value="1" />
+			<Item label="Setpoint H" value="2" />
+			<Item label="Setpoint C" value="4" />
+			<Item label="Mode" value="8" />
+			<Item label="Fan Mode" value="16" />
+			<Item label="Fan State" value="32" />
+			<Item label="Operating State" value="64" />
+			<Item label="Schedule Enable" value="128" />
+			<Item label="Setback" value="256" />
+			<Item label="Runhold" value="512" />
+			<Item label="Display Lock" value="1024" />
+			<Item label="Battery" value="8192" />
+			<Item label="Mechanical Status" value="16384" />
+			<Item label="SCP Status" value="32768" />
+    </Value>
+    <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
+      <Help>
+				Display Lock
+      </Help>
+			<Item label="Unlocked" value="0" />
+			<Item label="Locked" value="1" />
+    </Value>
+    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="10" size="1">
+      <Help>
+				Sets the time from last button press that the backlight will turn OFF
+      </Help>
+    </Value>
+    <Value type="byte" index="33" genre="config" label="Max Heat Setpoint" units="degrees" min="30" max="109" value="90" size="1">
+      <Help>
+        Sets the maximum heating setpoint value
+      </Help>
+    </Value>
+    <Value type="byte" index="34" genre="config" label="Min Cool Setpoint" units="degrees" min="33" max="112" value="60" size="1">
+      <Help>
+        Sets the minimum cooling setpoint value
+      </Help>
+    </Value>
+    <Value type="list" index="38" genre="config" label="Schedule Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				Enable or disable thermostat's local scheduler
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+	</CommandClass>
+</Product>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -192,5 +192,24 @@
 			<Item label="Disabled" value="0" />
 			<Item label="Enabled" value="1" />
     </Value>
+    <Value type="list" index="39" genre="config" label="Run/Hold Mode" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = Hold, 1 = Run
+      </Help>
+			<Item label="Hold" value="0" />
+			<Item label="Run" value="1" />
+    </Value>
+    <Value type="list" index="40" genre="config" label="Setback Mode" units="" min="0" max="2" value="0" size="1">
+      <Help>
+				0 = No setback, 2 = Un-occupied mode
+      </Help>
+			<Item label="No Setback" value="0" />
+			<Item label="Unoccupied Mode" value="2" />
+    </Value>
+    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
+      <Help>
+				Heat Setpoint for Unoccupied mode
+      </Help>
+    </Value>
 	</CommandClass>
 </Product>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -194,22 +194,22 @@
         R1 Sensor Temperature Offset
       </Help>
     </Value>
-    <Value type="byte" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+    <Value type="short" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
       <Help>
         Timer to let know when to change or clean the filter
       </Help>
     </Value>
-    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
+    <Value type="short" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
       <Help>
         Maximum allowed value for filter timer
       </Help>
     </Value>
-    <Value type="byte" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
+    <Value type="short" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
       <Help>
         Heat Timer in hours
       </Help>
     </Value>
-    <Value type="byte" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
+    <Value type="short" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
       <Help>
         Cool Timer in hours
       </Help>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -1,33 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<Product xmlns='http://code.google.com/p/open-zwave/'>
-  <CommandClass id="133" name="COMMAND_CLASS_ASSOCIATION" version="1" request_flags="4" create_vars="true">
-    <Instance index="1" />
-    <Associations num_groups="1">
-      <Group index="1" max_associations="5" label="Group 1" >
-        <Node id="1" />
-      </Group>
-    </Associations>
-  </CommandClass>
-
-  <!-- The thermostat does not properly report its operating modes -->
-  <CommandClass id="64" name="COMMAND_CLASS_THERMOSTAT_MODE" version="1" request_flags="4" create_vars="true">
-    <Value type="list" genre="user" instance="1" index="0" label="Mode" units="" read_only="false" write_only="false" min="0" max="0" value="0">
-      <Item label="Off" value="0" />
-      <Item label="Heat" value="1" />
-      <Item label="Cool" value="2" />
-      <Item label="Auto" value="3" />
-      <Item label="Aux Heat" value="4" />
-    </Value>
-    <SupportedModes>
-      <Mode index="0" label="Off" />
-      <Mode index="1" label="Heat" />
-      <Mode index="2" label="Cool" />
-      <Mode index="3" label="Auto" />
-      <Mode index="4" label="Aux Heat" />
-    </SupportedModes>
-  </CommandClass>
-
+<Product xmlns="http://code.google.com/p/open-zwave/">
   <CommandClass id="67" name="COMMAND_CLASS_THERMOSTAT_SETPOINT" version="1" request_flags="4" create_vars="true" base="0">
     <Instance index="1" />
     <Value type="decimal" genre="user" instance="1" index="1" label="Heating 1" read_only="false" write_only="false" />

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -210,9 +210,64 @@
       <Item label="No Setback" value="0" />
       <Item label="Unoccupied Mode" value="2" />
     </Value>
-    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
+    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="62" size="1">
       <Help>
         Heat Setpoint for Unoccupied mode
+      </Help>
+    </Value>
+    <Value type="byte" index="42" genre="config" label="Un-Occupied CSP" units="degrees" min="33" max="112" value="70" size="1">
+      <Help>
+        Cool Setpoint for Unoccupied mode
+      </Help>
+    </Value>
+    <Value type="byte" index="43" genre="config" label="Remote Sensor 1 Node Number" units="" min="0" max="252" size="1">
+      <Help>
+        Node number for Remote Sensor 1
+      </Help>
+    </Value>
+    <Value type="byte" index="46" genre="config" label="Remote Sensor 1 Temperature" units="degrees" min="0" max="0" value="0" size="1">
+      <Help>
+        Temperature of Remote Sensor 1
+      </Help>
+    </Value>
+    <Value type="byte" index="48" genre="config" label="Internal Sensor Temp Offset" units="degrees" min="-7" max="7" value="7" size="1">
+      <Help>
+        Internal Sensor Temperature Offset
+      </Help>
+    </Value>
+    <Value type="byte" index="49" genre="config" label="R1 Sensor Temp Offset" units="degrees" min="-7" max="7" value="7" size="1">
+      <Help>
+        R1 Sensor Temperature Offset
+      </Help>
+    </Value>
+    <Value type="byte" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+      <Help>
+        Timer to let know when to change or clean the filter
+      </Help>
+    </Value>
+    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+      <Help>
+        Maximum allowed value for filter timer
+      </Help>
+    </Value>
+    <Value type="byte" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
+      <Help>
+        Heat Timer in hours
+      </Help>
+    </Value>
+    <Value type="byte" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
+      <Help>
+        Cool Timer in hours
+      </Help>
+    </Value>
+    <Value type="byte" index="61" genre="config" label="Fan Purge Heat" units="seconds" min="0" max="90" value="0" size="1">
+      <Help>
+        Fan purge period for Heat mode
+      </Help>
+    </Value>
+    <Value type="byte" index="62" genre="config" label="Fan Purge Cool" units="hours" min="0" max="90" value="0" size="1">
+      <Help>
+        Fan purge period for Cool mode
       </Help>
     </Value>
   </CommandClass>

--- a/config/linear/GC-TBZ48.xml
+++ b/config/linear/GC-TBZ48.xml
@@ -6,4 +6,214 @@
     <Value type="decimal" genre="user" instance="1" index="1" label="Heating 1" read_only="false" write_only="false" />
     <Value type="decimal" genre="user" instance="1" index="2" label="Cooling 1" read_only="false" write_only="false" />
   </CommandClass>
+  <CommandClass id="112">
+    <Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = Standard, 1 = Heat Pump
+      </Help>
+      <Item label="Standard" value="0" />
+      <Item label="Heat Pump" value="1" />
+    </Value>
+    <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
+      </Help>
+      <Item label="Gas" value="0" />
+      <Item label="Electric" value="1" />
+    </Value>
+    <Value type="list" index="3" genre="config" label="Change Over Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = w/Cool, 1 = w/Heat
+      </Help>
+      <Item label="w/Cool" value="0" />
+      <Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="4" genre="config" label="2nd Stage Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = no 2nd stage heat, 1 = 2nd stage heat
+      </Help>
+      <Item label="w/Cool" value="0" />
+      <Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="5" genre="config" label="Aux Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = no aux heat, 1 = aux heat enabled
+      </Help>
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="6" genre="config" label="2nd Stage Cool Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = no 2nd stage cool, 1 = 2nd stage cool
+      </Help>
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="7" genre="config" label="Temperature Unit" units="" min="0" max="1" value="1" size="1">
+      <Help>
+        0 = Celsius, 1 = Fahrenheit
+      </Help>
+      <Item label="Celsius" value="0" />
+      <Item label="Fahrenheit" value="1" />
+    </Value>
+    <Value type="byte" index="8" genre="config" label="Minimum Off Time" units="minutes" min="5" max="9" value="5" size="1">
+      <Help>
+        Sets the Minimum Off Time (MOT) delay before another heating/cooling cycle can begin
+      </Help>
+    </Value>
+    <Value type="byte" index="9" genre="config" label="Minimum Run Time" units="minutes" min="3" max="9" value="3" size="1">
+      <Help>
+        Sets the Minimum Run Time (MRT) delay before a heating/cooling cycle can turn of
+      </Help>
+    </Value>
+    <Value type="byte" index="10" genre="config" label="Setpoint H/C Delta" units="fahrenheit" min="3" max="15" value="3" size="1">
+      <Help>
+        Sets the minimum separation between heating and cooling setpoints
+      </Help>
+    </Value>
+    <Value type="byte" index="11" genre="config" label="H Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="12" genre="config" label="H Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="13" genre="config" label="H Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 2 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="14" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+        Sets the delay from setpoint that stage 2 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="15" genre="config" label="H Delta Aux ON" units="fahrenheit" min="3" max="8" value="3" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="16" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="7" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="17" genre="config" label="C Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="18" genre="config" label="C Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 cooling stops
+      </Help>
+    </Value>
+    <Value type="byte" index="19" genre="config" label="C Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 2 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="20" genre="config" label="C Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 2 cooling stops
+      </Help>
+    </Value>
+    <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
+      <Help>
+        Mechanical Status
+      </Help>
+      <Item label="MECH_H1" value="1" />
+      <Item label="MECH_H2" value="2" />
+      <Item label="MECH_H3" value="4" />
+      <Item label="MECH_C1" value="8" />
+      <Item label="MECH_C2" value="16" />
+      <Item label="PHANTOM_F" value="32" />
+      <Item label="MECH_F" value="64" />
+      <Item label="MANUAL_F" value="128" />
+      <Item label="reserved" value="256" />
+    </Value>
+    <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
+      <Help>
+        SCP Status
+      </Help>
+      <Item label="STATE_HEAT" value="1" />
+      <Item label="STATE_COOL" value="2" />
+      <Item label="STATE_2ND" value="4" />
+      <Item label="STATE_3RD" value="8" />
+      <Item label="STATE_FAN" value="16" />
+      <Item label="STATE_LAST" value="32" />
+      <Item label="STATE_MOT" value="64" />
+      <Item label="STATE_MRT" value="128" />
+    </Value>
+    <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
+      <Help>
+        Autosend Enable Bits
+      </Help>
+      <Item label="Temperature" value="1" />
+      <Item label="Setpoint H" value="2" />
+      <Item label="Setpoint C" value="4" />
+      <Item label="Mode" value="8" />
+      <Item label="Fan Mode" value="16" />
+      <Item label="Fan State" value="32" />
+      <Item label="Operating State" value="64" />
+      <Item label="Schedule Enable" value="128" />
+      <Item label="Setback" value="256" />
+      <Item label="Runhold" value="512" />
+      <Item label="Display Lock" value="1024" />
+      <Item label="Battery" value="8192" />
+      <Item label="Mechanical Status" value="16384" />
+      <Item label="SCP Status" value="32768" />
+    </Value>
+    <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
+      <Help>
+        Display Lock
+      </Help>
+      <Item label="Unlocked" value="0" />
+      <Item label="Locked" value="1" />
+    </Value>
+    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="20" size="1">
+      <Help>
+        Sets the time from last button press that the backlight will turn OFF
+      </Help>
+    </Value>
+    <Value type="byte" index="33" genre="config" label="Max Heat Setpoint" units="degrees" min="30" max="109" value="90" size="1">
+      <Help>
+        Sets the maximum heating setpoint value
+      </Help>
+    </Value>
+    <Value type="byte" index="34" genre="config" label="Min Cool Setpoint" units="degrees" min="33" max="112" value="61" size="1">
+      <Help>
+        Sets the minimum cooling setpoint value
+      </Help>
+    </Value>
+    <Value type="list" index="38" genre="config" label="Schedule Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        Enable or disable thermostat's local scheduler
+      </Help>
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="39" genre="config" label="Run/Hold Mode" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = Hold, 1 = Run
+      </Help>
+      <Item label="Hold" value="0" />
+      <Item label="Run" value="1" />
+    </Value>
+    <Value type="list" index="40" genre="config" label="Setback Mode" units="" min="0" max="2" value="0" size="1">
+      <Help>
+        0 = No setback, 2 = Un-occupied mode
+      </Help>
+      <Item label="No Setback" value="0" />
+      <Item label="Unoccupied Mode" value="2" />
+    </Value>
+    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
+      <Help>
+        Heat Setpoint for Unoccupied mode
+      </Help>
+    </Value>
+  </CommandClass>
 </Product>

--- a/config/linear/GC-TBZ48L.xml
+++ b/config/linear/GC-TBZ48L.xml
@@ -1,56 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Product xmlns="http://code.google.com/p/open-zwave/">
-	<CommandClass id="67" base="0"/>
-	<CommandClass id="112">
-		<Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
+  <CommandClass id="67" base="0"/>
+  <CommandClass id="112">
+    <Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
       <Help>
         0 = Standard, 1 = Heat Pump
       </Help>
-			<Item label="Standard" value="0" />
-			<Item label="Head Pump" value="1" />
-		</Value>
+      <Item label="Standard" value="0" />
+      <Item label="Head Pump" value="1" />
+    </Value>
     <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
       <Help>
-				0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
+        0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
       </Help>
-			<Item label="Gas" value="0" />
-			<Item label="Electric" value="1" />
+      <Item label="Gas" value="0" />
+      <Item label="Electric" value="1" />
     </Value>
     <Value type="list" index="3" genre="config" label="Change Over Type" units="" min="0" max="1" value="0" size="1">
       <Help>
-				0 = w/Cool, 1 = w/Heat
+        0 = w/Cool, 1 = w/Heat
       </Help>
-			<Item label="w/Cool" value="0" />
-			<Item label="w/Heat" value="1" />
+      <Item label="w/Cool" value="0" />
+      <Item label="w/Heat" value="1" />
     </Value>
     <Value type="list" index="4" genre="config" label="2nd Stage Heat Enable" units="" min="0" max="1" value="0" size="1">
       <Help>
-				0 = no 2nd stage heat, 1 = 2nd stage heat
+        0 = no 2nd stage heat, 1 = 2nd stage heat
       </Help>
-			<Item label="w/Cool" value="0" />
-			<Item label="w/Heat" value="1" />
+      <Item label="w/Cool" value="0" />
+      <Item label="w/Heat" value="1" />
     </Value>
     <Value type="list" index="5" genre="config" label="Aux Heat Enable" units="" min="0" max="1" value="0" size="1">
       <Help>
-				0 = no aux heat, 1 = aux heat enabled
+        0 = no aux heat, 1 = aux heat enabled
       </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
     </Value>
     <Value type="list" index="6" genre="config" label="2nd Stage Cool Enable" units="" min="0" max="1" value="0" size="1">
       <Help>
-				0 = no 2nd stage cool, 1 = 2nd stage cool
+        0 = no 2nd stage cool, 1 = 2nd stage cool
       </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
     </Value>
     <Value type="list" index="7" genre="config" label="Temperature Unit" units="" min="0" max="1" value="1" size="1">
       <Help>
-				0 = Celsius, 1 = Fahrenheit
+        0 = Celsius, 1 = Fahrenheit
       </Help>
-			<Item label="Celsius" value="0" />
-			<Item label="Fahrenheit" value="1" />
+      <Item label="Celsius" value="0" />
+      <Item label="Fahrenheit" value="1" />
     </Value>
     <Value type="byte" index="8" genre="config" label="Minimum Off Time" units="minutes" min="5" max="9" value="5" size="1">
       <Help>
@@ -99,80 +99,80 @@
     </Value>
     <Value type="byte" index="17" genre="config" label="C Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
       <Help>
-				Sets the delta from setpoint that stage 1 cooling starts
+        Sets the delta from setpoint that stage 1 cooling starts
       </Help>
     </Value>
     <Value type="byte" index="18" genre="config" label="C Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
       <Help>
-				Sets the delta from setpoint that stage 1 cooling stops
+        Sets the delta from setpoint that stage 1 cooling stops
       </Help>
     </Value>
     <Value type="byte" index="19" genre="config" label="C Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
       <Help>
-				Sets the delta from setpoint that stage 2 cooling starts
+        Sets the delta from setpoint that stage 2 cooling starts
       </Help>
     </Value>
     <Value type="byte" index="20" genre="config" label="C Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
       <Help>
-				Sets the delta from setpoint that stage 2 cooling stops
+        Sets the delta from setpoint that stage 2 cooling stops
       </Help>
     </Value>
     <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
       <Help>
-				Mechanical Status
+        Mechanical Status
       </Help>
-			<Item label="MECH_H1" value="1" />
-			<Item label="MECH_H2" value="2" />
-			<Item label="MECH_H3" value="4" />
-			<Item label="MECH_C1" value="8" />
-			<Item label="MECH_C2" value="16" />
-			<Item label="PHANTOM_F" value="32" />
-			<Item label="MECH_F" value="64" />
-			<Item label="MANUAL_F" value="128" />
-			<Item label="reserved" value="256" />
+      <Item label="MECH_H1" value="1" />
+      <Item label="MECH_H2" value="2" />
+      <Item label="MECH_H3" value="4" />
+      <Item label="MECH_C1" value="8" />
+      <Item label="MECH_C2" value="16" />
+      <Item label="PHANTOM_F" value="32" />
+      <Item label="MECH_F" value="64" />
+      <Item label="MANUAL_F" value="128" />
+      <Item label="reserved" value="256" />
     </Value>
     <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
       <Help>
-				SCP Status
+        SCP Status
       </Help>
-			<Item label="STATE_HEAT" value="1" />
-			<Item label="STATE_COOL" value="2" />
-			<Item label="STATE_2ND" value="4" />
-			<Item label="STATE_3RD" value="8" />
-			<Item label="STATE_FAN" value="16" />
-			<Item label="STATE_LAST" value="32" />
-			<Item label="STATE_MOT" value="64" />
-			<Item label="STATE_MRT" value="128" />
+      <Item label="STATE_HEAT" value="1" />
+      <Item label="STATE_COOL" value="2" />
+      <Item label="STATE_2ND" value="4" />
+      <Item label="STATE_3RD" value="8" />
+      <Item label="STATE_FAN" value="16" />
+      <Item label="STATE_LAST" value="32" />
+      <Item label="STATE_MOT" value="64" />
+      <Item label="STATE_MRT" value="128" />
     </Value>
     <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
       <Help>
-				Autosend Enable Bits
+        Autosend Enable Bits
       </Help>
-			<Item label="Temperature" value="1" />
-			<Item label="Setpoint H" value="2" />
-			<Item label="Setpoint C" value="4" />
-			<Item label="Mode" value="8" />
-			<Item label="Fan Mode" value="16" />
-			<Item label="Fan State" value="32" />
-			<Item label="Operating State" value="64" />
-			<Item label="Schedule Enable" value="128" />
-			<Item label="Setback" value="256" />
-			<Item label="Runhold" value="512" />
-			<Item label="Display Lock" value="1024" />
-			<Item label="Battery" value="8192" />
-			<Item label="Mechanical Status" value="16384" />
-			<Item label="SCP Status" value="32768" />
+      <Item label="Temperature" value="1" />
+      <Item label="Setpoint H" value="2" />
+      <Item label="Setpoint C" value="4" />
+      <Item label="Mode" value="8" />
+      <Item label="Fan Mode" value="16" />
+      <Item label="Fan State" value="32" />
+      <Item label="Operating State" value="64" />
+      <Item label="Schedule Enable" value="128" />
+      <Item label="Setback" value="256" />
+      <Item label="Runhold" value="512" />
+      <Item label="Display Lock" value="1024" />
+      <Item label="Battery" value="8192" />
+      <Item label="Mechanical Status" value="16384" />
+      <Item label="SCP Status" value="32768" />
     </Value>
     <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
       <Help>
-				Display Lock
+        Display Lock
       </Help>
-			<Item label="Unlocked" value="0" />
-			<Item label="Locked" value="1" />
+      <Item label="Unlocked" value="0" />
+      <Item label="Locked" value="1" />
     </Value>
     <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="10" size="1">
       <Help>
-				Sets the time from last button press that the backlight will turn OFF
+        Sets the time from last button press that the backlight will turn OFF
       </Help>
     </Value>
     <Value type="byte" index="33" genre="config" label="Max Heat Setpoint" units="degrees" min="30" max="109" value="90" size="1">
@@ -187,29 +187,29 @@
     </Value>
     <Value type="list" index="38" genre="config" label="Schedule Enable" units="" min="0" max="1" value="0" size="1">
       <Help>
-				Enable or disable thermostat's local scheduler
+        Enable or disable thermostat's local scheduler
       </Help>
-			<Item label="Disabled" value="0" />
-			<Item label="Enabled" value="1" />
+      <Item label="Disabled" value="0" />
+      <Item label="Enabled" value="1" />
     </Value>
     <Value type="list" index="39" genre="config" label="Run/Hold Mode" units="" min="0" max="1" value="0" size="1">
       <Help>
-				0 = Hold, 1 = Run
+        0 = Hold, 1 = Run
       </Help>
-			<Item label="Hold" value="0" />
-			<Item label="Run" value="1" />
+      <Item label="Hold" value="0" />
+      <Item label="Run" value="1" />
     </Value>
     <Value type="list" index="40" genre="config" label="Setback Mode" units="" min="0" max="2" value="0" size="1">
       <Help>
-				0 = No setback, 2 = Un-occupied mode
+        0 = No setback, 2 = Un-occupied mode
       </Help>
-			<Item label="No Setback" value="0" />
-			<Item label="Unoccupied Mode" value="2" />
+      <Item label="No Setback" value="0" />
+      <Item label="Unoccupied Mode" value="2" />
     </Value>
     <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
       <Help>
-				Heat Setpoint for Unoccupied mode
+        Heat Setpoint for Unoccupied mode
       </Help>
     </Value>
-	</CommandClass>
+  </CommandClass>
 </Product>

--- a/config/linear/GC-TBZ48L.xml
+++ b/config/linear/GC-TBZ48L.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Product xmlns="http://code.google.com/p/open-zwave/">
+	<CommandClass id="67" base="0"/>
+	<CommandClass id="112">
+		<Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+        0 = Standard, 1 = Heat Pump
+      </Help>
+			<Item label="Standard" value="0" />
+			<Item label="Head Pump" value="1" />
+		</Value>
+    <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = Gas (no fan w/Heat), 1 = Electric (Fan w/Heat)
+      </Help>
+			<Item label="Gas" value="0" />
+			<Item label="Electric" value="1" />
+    </Value>
+    <Value type="list" index="3" genre="config" label="Change Over Type" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = w/Cool, 1 = w/Heat
+      </Help>
+			<Item label="w/Cool" value="0" />
+			<Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="4" genre="config" label="2nd Stage Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no 2nd stage heat, 1 = 2nd stage heat
+      </Help>
+			<Item label="w/Cool" value="0" />
+			<Item label="w/Heat" value="1" />
+    </Value>
+    <Value type="list" index="5" genre="config" label="Aux Heat Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no aux heat, 1 = aux heat enabled
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="6" genre="config" label="2nd Stage Cool Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = no 2nd stage cool, 1 = 2nd stage cool
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="7" genre="config" label="Temperature Unit" units="" min="0" max="1" value="1" size="1">
+      <Help>
+				0 = Celsius, 1 = Fahrenheit
+      </Help>
+			<Item label="Celsius" value="0" />
+			<Item label="Fahrenheit" value="1" />
+    </Value>
+    <Value type="byte" index="8" genre="config" label="Minimum Off Time" units="minutes" min="5" max="9" value="5" size="1">
+      <Help>
+        Sets the Minimum Off Time (MOT) delay before another heating/cooling cycle can begin
+      </Help>
+    </Value>
+    <Value type="byte" index="9" genre="config" label="Minimum Run Time" units="minutes" min="3" max="9" value="3" size="1">
+      <Help>
+        Sets the Minimum Run Time (MRT) delay before a heating/cooling cycle can turn of
+      </Help>
+    </Value>
+    <Value type="byte" index="10" genre="config" label="Setpoint H/C Delta" units="fahrenheit" min="3" max="15" value="3" size="1">
+      <Help>
+        Sets the minimum separation between heating and cooling setpoints
+      </Help>
+    </Value>
+    <Value type="byte" index="11" genre="config" label="H Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="12" genre="config" label="H Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 1 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="13" genre="config" label="H Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 2 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="14" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+        Sets the delay from setpoint that stage 2 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="15" genre="config" label="H Delta Aux ON" units="fahrenheit" min="3" max="8" value="3" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating starts
+      </Help>
+    </Value>
+    <Value type="byte" index="16" genre="config" label="H Delta Stage 2 OFF" units="fahrenheit" min="0" max="7" value="0" size="1">
+      <Help>
+        Sets the delta from setpoint that stage 3 heating stops
+      </Help>
+    </Value>
+    <Value type="byte" index="17" genre="config" label="C Delta Stage 1 ON" units="fahrenheit" min="1" max="6" value="1" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 1 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="18" genre="config" label="C Delta Stage 1 OFF" units="fahrenheit" min="0" max="5" value="0" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 1 cooling stops
+      </Help>
+    </Value>
+    <Value type="byte" index="19" genre="config" label="C Delta Stage 2 ON" units="fahrenheit" min="2" max="7" value="2" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 2 cooling starts
+      </Help>
+    </Value>
+    <Value type="byte" index="20" genre="config" label="C Delta Stage 2 OFF" units="fahrenheit" min="0" max="6" value="0" size="1">
+      <Help>
+				Sets the delta from setpoint that stage 2 cooling stops
+      </Help>
+    </Value>
+    <Value type="list" index="21" genre="config" label="Mechanical Status" units="" min="1" max="256" size="2">
+      <Help>
+				Mechanical Status
+      </Help>
+			<Item label="MECH_H1" value="1" />
+			<Item label="MECH_H2" value="2" />
+			<Item label="MECH_H3" value="4" />
+			<Item label="MECH_C1" value="8" />
+			<Item label="MECH_C2" value="16" />
+			<Item label="PHANTOM_F" value="32" />
+			<Item label="MECH_F" value="64" />
+			<Item label="MANUAL_F" value="128" />
+			<Item label="reserved" value="256" />
+    </Value>
+    <Value type="list" index="22" genre="config" label="SCP Status" units="" min="1" max="128" size="1">
+      <Help>
+				SCP Status
+      </Help>
+			<Item label="STATE_HEAT" value="1" />
+			<Item label="STATE_COOL" value="2" />
+			<Item label="STATE_2ND" value="4" />
+			<Item label="STATE_3RD" value="8" />
+			<Item label="STATE_FAN" value="16" />
+			<Item label="STATE_LAST" value="32" />
+			<Item label="STATE_MOT" value="64" />
+			<Item label="STATE_MRT" value="128" />
+    </Value>
+    <Value type="list" index="23" genre="config" label="Autosend Enable Bits" units="" min="1" max="32768" size="2">
+      <Help>
+				Autosend Enable Bits
+      </Help>
+			<Item label="Temperature" value="1" />
+			<Item label="Setpoint H" value="2" />
+			<Item label="Setpoint C" value="4" />
+			<Item label="Mode" value="8" />
+			<Item label="Fan Mode" value="16" />
+			<Item label="Fan State" value="32" />
+			<Item label="Operating State" value="64" />
+			<Item label="Schedule Enable" value="128" />
+			<Item label="Setback" value="256" />
+			<Item label="Runhold" value="512" />
+			<Item label="Display Lock" value="1024" />
+			<Item label="Battery" value="8192" />
+			<Item label="Mechanical Status" value="16384" />
+			<Item label="SCP Status" value="32768" />
+    </Value>
+    <Value type="list" index="24" genre="config" label="Display Lock" units="" min="1" max="1" value="0" size="1">
+      <Help>
+				Display Lock
+      </Help>
+			<Item label="Unlocked" value="0" />
+			<Item label="Locked" value="1" />
+    </Value>
+    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="10" size="1">
+      <Help>
+				Sets the time from last button press that the backlight will turn OFF
+      </Help>
+    </Value>
+    <Value type="byte" index="33" genre="config" label="Max Heat Setpoint" units="degrees" min="30" max="109" value="90" size="1">
+      <Help>
+        Sets the maximum heating setpoint value
+      </Help>
+    </Value>
+    <Value type="byte" index="34" genre="config" label="Min Cool Setpoint" units="degrees" min="33" max="112" value="60" size="1">
+      <Help>
+        Sets the minimum cooling setpoint value
+      </Help>
+    </Value>
+    <Value type="list" index="38" genre="config" label="Schedule Enable" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				Enable or disable thermostat's local scheduler
+      </Help>
+			<Item label="Disabled" value="0" />
+			<Item label="Enabled" value="1" />
+    </Value>
+    <Value type="list" index="39" genre="config" label="Run/Hold Mode" units="" min="0" max="1" value="0" size="1">
+      <Help>
+				0 = Hold, 1 = Run
+      </Help>
+			<Item label="Hold" value="0" />
+			<Item label="Run" value="1" />
+    </Value>
+    <Value type="list" index="40" genre="config" label="Setback Mode" units="" min="0" max="2" value="0" size="1">
+      <Help>
+				0 = No setback, 2 = Un-occupied mode
+      </Help>
+			<Item label="No Setback" value="0" />
+			<Item label="Unoccupied Mode" value="2" />
+    </Value>
+    <Value type="byte" index="41" genre="config" label="Un-Occupied HSP" units="degrees" min="30" max="109" value="70" size="1">
+      <Help>
+				Heat Setpoint for Unoccupied mode
+      </Help>
+    </Value>
+	</CommandClass>
+</Product>

--- a/config/linear/GC-TBZ48L.xml
+++ b/config/linear/GC-TBZ48L.xml
@@ -12,7 +12,7 @@
         0 = Standard, 1 = Heat Pump
       </Help>
       <Item label="Standard" value="0" />
-      <Item label="Head Pump" value="1" />
+      <Item label="Heat Pump" value="1" />
     </Value>
     <Value type="list" index="2" genre="config" label="Fan Type" units="fahrenheit" min="0" max="1" value="0" size="1">
       <Help>
@@ -174,7 +174,7 @@
       <Item label="Unlocked" value="0" />
       <Item label="Locked" value="1" />
     </Value>
-    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="10" size="1">
+    <Value type="byte" index="26" genre="config" label="Backlight Timer" units="seconds" min="10" max="30" value="20" size="1">
       <Help>
         Sets the time from last button press that the backlight will turn OFF
       </Help>

--- a/config/linear/GC-TBZ48L.xml
+++ b/config/linear/GC-TBZ48L.xml
@@ -215,5 +215,61 @@
         Heat Setpoint for Unoccupied mode
       </Help>
     </Value>
+    <Value type="byte" index="42" genre="config" label="Un-Occupied CSP" units="degrees" min="33" max="112" value="80" size="1">
+      <Help>
+        Cool Setpoint for Unoccupied mode
+      </Help>
+    </Value>
+    <Value type="byte" index="43" genre="config" label="Remote Sensor 1 Node Number" units="" min="0" max="252" size="1">
+      <Help>
+        Node number for Remote Sensor 1
+      </Help>
+    </Value>
+    <Value type="byte" index="46" genre="config" label="Remote Sensor 1 Temperature" units="degrees" min="0" max="112" size="1">
+      <Help>
+        Temperature of Remote Sensor 1
+      </Help>
+    </Value>
+    <Value type="byte" index="48" genre="config" label="Internal Sensor Temp Offset" units="degrees" min="-7" max="7" value="0" size="1">
+      <Help>
+        Internal Sensor Temperature Offset
+      </Help>
+    </Value>
+    <Value type="byte" index="49" genre="config" label="R1 Sensor Temp Offset" units="degrees" min="-7" max="7" value="0" size="1">
+      <Help>
+        R1 Sensor Temperature Offset
+      </Help>
+    </Value>
+    <Value type="byte" index="52" genre="config" label="Filter Timer" units="hours" min="0" max="4000" value="4000" size="2">
+      <Help>
+        Timer to let know when to change or clean the filter
+      </Help>
+    </Value>
+    <Value type="byte" index="53" genre="config" label="Max Filter Timer" units="hours" min="0" max="4000" value="44" size="2">
+      <Help>
+        Maximum allowed value for filter timer
+      </Help>
+    </Value>
+    <Value type="byte" index="54" genre="config" label="Heat Timer" units="hours" min="0" max="4000" value="0" size="2">
+      <Help>
+        Heat Timer in hours
+      </Help>
+    </Value>
+    <Value type="byte" index="55" genre="config" label="Cool Timer" units="hours" min="0" max="4000" value="0" size="2">
+      <Help>
+        Cool Timer in hours
+      </Help>
+    </Value>
+    <Value type="byte" index="61" genre="config" label="Fan Purge Heat" units="seconds" min="0" max="90" value="0" size="1">
+      <Help>
+        Fan purge period for Heat mode
+      </Help>
+    </Value>
+    <Value type="byte" index="62" genre="config" label="Fan Purge Cool" units="hours" min="0" max="90" value="0" size="1">
+      <Help>
+        Fan purge period for Cool mode
+      </Help>
+    </Value>
+
   </CommandClass>
 </Product>

--- a/config/linear/GC-TBZ48L.xml
+++ b/config/linear/GC-TBZ48L.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Product xmlns="http://code.google.com/p/open-zwave/">
-  <CommandClass id="67" base="0"/>
+  <CommandClass id="67" name="COMMAND_CLASS_THERMOSTAT_SETPOINT" version="1" request_flags="4" create_vars="true" base="0">
+    <Instance index="1" />
+    <Value type="decimal" genre="user" instance="1" index="1" label="Heating 1" read_only="false" write_only="false" />
+    <Value type="decimal" genre="user" instance="1" index="2" label="Cooling 1" read_only="false" write_only="false" />
+  </CommandClass>
   <CommandClass id="112">
     <Value type="list" index="1" genre="config" label="System Type" units="" min="0" max="1" value="0" size="1">
       <Help>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -542,6 +542,9 @@
 		<Product type="4952" id="3033" name="12727 In-Wall Smart Switch (Toggle)"/>
 		<Product type="4953" id="3032" name="32563 Hinge Pin Smart Door Sensor" config="ge/hinge-pin.xml"/>
 	</Manufacturer>
+  <Manufacturer id="0014" name="GoControl">
+		<Product type="5442" id="5436" name="GC-TBZ48L Battery Powered Z-Wave Plus Thermostat" config="gocontrol/GC-TBZ48L.xml" />
+  </Manufacturer>
 	<Manufacturer id="0099" name="GreenWave">
 		<Product type="0001" id="0002" name="One Gateway"/>
 		<Product type="0002" id="0002" name="PowerNode 1 port" config="greenwave/powernode1.xml"/>
@@ -687,7 +690,6 @@
 		<Product type="5343" id="3132" name="WA00Z-1 Scene Switch" config="linear/WA00Z-1.xml"/>
 		<Product type="5457" id="3033" name="WT00Z-1 3-Way Wall Accessory Switch" config="linear/WT00Z-1.xml"/>
 		<Product type="5442" id="5431" name="GC-TBZ48 Battery Powered Z-Wave Thermostat" config="linear/GC-TBZ48.xml" />
-		<Product type="5442" id="5436" name="GC-TBZ48L Battery Powered Z-Wave Plus Thermostat" config="linear/GC-TBZ48L.xml" />
 	</Manufacturer>
 	<Manufacturer id="015e" name="Locstar">
         <Product type="8015" id="0001" name="LS-8015-ZW Single Latch Door Lock"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -687,6 +687,7 @@
 		<Product type="5343" id="3132" name="WA00Z-1 Scene Switch" config="linear/WA00Z-1.xml"/>
 		<Product type="5457" id="3033" name="WT00Z-1 3-Way Wall Accessory Switch" config="linear/WT00Z-1.xml"/>
 		<Product type="5442" id="5431" name="GC-TBZ48 Battery Powered Z-Wave Thermostat" config="linear/GC-TBZ48.xml" />
+		<Product type="5442" id="5436" name="GC-TBZ48L Battery Powered Z-Wave Plus Thermostat" config="linear/GC-TBZ48L.xml" />
 	</Manufacturer>
 	<Manufacturer id="015e" name="Locstar">
         <Product type="8015" id="0001" name="LS-8015-ZW Single Latch Door Lock"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -686,6 +686,7 @@
 		<Product type="5257" id="3533" name="WS15Z-1 Wall Switch" config="linear/WS15Z-1.xml"/>
 		<Product type="5343" id="3132" name="WA00Z-1 Scene Switch" config="linear/WA00Z-1.xml"/>
 		<Product type="5457" id="3033" name="WT00Z-1 3-Way Wall Accessory Switch" config="linear/WT00Z-1.xml"/>
+		<Product type="5442" id="5431" name="GC-TBZ48 Battery Powered Z-Wave Thermostat" config="linear/GC-TBZ48.xml" />
 	</Manufacturer>
 	<Manufacturer id="015e" name="Locstar">
         <Product type="8015" id="0001" name="LS-8015-ZW Single Latch Door Lock"/>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -99,16 +99,16 @@ DISTFILES =	.gitignore \
 	config/device_classes.xsd \
 	config/device_configuration.xsd \
 	config/devolo/connectz.xml \
+	config/devolo/mt02648.xml \
+	config/devolo/mt02755.xml \
+	config/devolo/mt02758.xml \
+	config/devolo/mt02792.xml \
 	config/devolo/mt2646.xml \
 	config/devolo/mt2647.xml \
 	config/devolo/mt2652.xml \
 	config/devolo/mt2653.xml \
 	config/devolo/mt2756.xml \
-	config/devolo/mt02648.xml \
-    config/devolo/mt02755.xml \
-    config/devolo/mt02758.xml \
-    config/devolo/mt02792.xml \
-    config/devolo/rs014G0159.xml \
+	config/devolo/rs014G0159.xml \
 	config/dlink/dch-z110.xml \
 	config/dlink/dch-z120.xml \
 	config/dlink/dch-z510.xml \
@@ -204,11 +204,13 @@ DISTFILES =	.gitignore \
 	config/ge/12724-dimmer.xml \
 	config/ge/14291-switch.xml \
 	config/ge/14294-dimmer.xml \
+	config/ge/26933-motion-dimmer.xml \
 	config/ge/dimmer.xml \
 	config/ge/dimmer_module.xml \
 	config/ge/hinge-pin.xml \
 	config/ge/receptacle.xml \
 	config/ge/relay.xml \
+	config/gocontrol/GC-TBZ48L.xml \
 	config/gr/gr105.xml \
 	config/gr/gr105n.xml \
 	config/greenwave/powernode1.xml \
@@ -245,6 +247,7 @@ DISTFILES =	.gitignore \
 	config/leviton/vrf01.xml \
 	config/leviton/vri06.xml \
 	config/leviton/vri10.xml \
+	config/linear/GC-TBZ48.xml \
 	config/linear/LB60Z-1.xml \
 	config/linear/PD300Z-2.xml \
 	config/linear/WA00Z-1.xml \
@@ -257,7 +260,7 @@ DISTFILES =	.gitignore \
 	config/manufacturer_specific.xsd \
 	config/mcohome/mh8fceu.xml \
 	config/mcohome/mh9co2.xml \
-    config/mcohome/mhp210.xml \
+	config/mcohome/mhp210.xml \
 	config/mcohome/mhs311.xml \
 	config/mcohome/mhs312.xml \
 	config/mcohome/mhs314.xml \
@@ -327,8 +330,10 @@ DISTFILES =	.gitignore \
 	config/qubino/ZMNHODx.xml \
 	config/qubino/ZMNHSDx.xml \
 	config/qubino/ZMNHTDx.xml \
+	config/qubino/ZMNHTDxS3.xml \
 	config/qubino/ZMNHUD1.xml \
 	config/qubino/ZMNHVDx.xml \
+	config/qubino/ZMNHWD1.xml \
 	config/qubino/ZMNHZDx.xml \
 	config/rcs/em52-zw.xml \
 	config/rcs/pm12-zw.xml \


### PR DESCRIPTION
this device description provides configuration parameters for http://products.z-wavealliance.org/products/2370/ and http://products.z-wavealliance.org/products/1286

The second one does not have any information on the config parameters but it seems that most of the config parameters work same way

For most part, they are similar but some of the parts are little different. The changes on distfile.mk were results of `make dist-update`.

Thanks!