### PR TITLE
Add Leviton DZ15S Switch

### DIFF
--- a/config/leviton/dz15s.xml
+++ b/config/leviton/dz15s.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+	<CommandClass id="112">
+		<Value type="byte" index="7" genre="config" label="Locator LED Status" units="" min="0" max="255" size="1" value="255">
+			<Help>Change the mode of the LED to Status Mode where the LED is illuminated when the load is On, Locator Mode where the LED is illuminated when the Load is Off, or turns off the LED completely for any other setting values.</Help>
+			<Item label="Status Mode" value="254"/>
+			<Item label="Locator Mode" value="255"/>
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<Group index="1" max_associations="5" label="Lifeline"/>
+		</Associations>
+	</CommandClass>
+	<CommandClass id="134" classgetsupported="false" />
+</Product>

--- a/config/leviton/dz15s.xml
+++ b/config/leviton/dz15s.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Leviton Switch DZ15S 
+http://products.z-wavealliance.org/products/1957
+-->
 <Product xmlns='http://code.google.com/p/open-zwave/'>
 	<!-- Configuration Parameters -->
 	<CommandClass id="112">
-		<Value type="byte" index="7" genre="config" label="Locator LED Status" units="" min="0" max="255" size="1" value="255">
+		<Value type="list" index="7" genre="config" label="Locator LED Status" units="" min="0" max="255" size="1" value="255">
 			<Help>Change the mode of the LED to Status Mode where the LED is illuminated when the load is On, Locator Mode where the LED is illuminated when the Load is Off, or turns off the LED completely for any other setting values.</Help>
+			<Item label="Off" value="0"/>
 			<Item label="Status Mode" value="254"/>
 			<Item label="Locator Mode" value="255"/>
 		</Value>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -680,6 +680,7 @@
 		<Product type="1102" id="0243" name="VRCS2-MRZ 2-Button Scene Controller with Switches"/>
 		<Product type="1902" id="0334" name="DZPD3-1LW Plug-In Dimming Lamp Module"/>
 		<Product type="1a02" id="0334" name="DZPA1-1LW Plug-In Appliance Module"/>
+		<Product type="3401" id="0001" name="DZ15S-1BZ Decora Smart Switch" config="leviton/dz15s.xml"/>
 	</Manufacturer>
 	<Manufacturer id="014f" name="Linear">
 		<Product type="2002" id="0203" name="WAPIRZ-1 Motion Sensor" config="linear/WAPIRZ-1.xml"/>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -248,6 +248,7 @@ DISTFILES =	.gitignore \
 	config/leviton/vrf01.xml \
 	config/leviton/vri06.xml \
 	config/leviton/vri10.xml \
+	config/leviton/dz15s.xml \
 	config/linear/GC-TBZ48.xml \
 	config/linear/LB60Z-1.xml \
 	config/linear/PD300Z-2.xml \


### PR DESCRIPTION
    Add support for the Leviton Decora DZ15S Switch.  This includes
    configuration item 7, which allows changing the LED at the base of the
    switch to Status Mode, Locator Mode, or Off.  This been tested on the
    hardware, and basic functionality as well as the configuration option
    work correctly.