### PR TITLE
Add support for Ecolink Door/Window ZWave+

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -334,6 +334,7 @@
 	<Manufacturer id="014a" name="Ecolink">
 		<Product type="0001" id="0001" name="Motion Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0001" id="0002" name="Door/Window Sensor" config="ecolink/doorwindow.xml"/>
+		<Product type="0004" id="0002" name="Door/Window Sensor" config="ecolink/doorwindow.xml"/>
 		<Product type="0001" id="0003" name="Tilt Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0004" id="0001" name="Motion Detector" config="ecolink/motion.xml"/>
 		<Product type="0004" id="0003" name="Garage Door Tilt Sensor" config="ecolink/sensor.xml"/>


### PR DESCRIPTION
Ecolink Door/Window with Zwave plus has the type=0004 and id=0002

This should allow openzwave to identify this sensor now.