### PR TITLE
Fix high CPU load when adding nodes

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1108,8 +1108,8 @@ bool Driver::WriteNextMsg
 			if( m_currentControllerCommand->m_controllerCallback )
 			{
 				m_currentControllerCommand->m_controllerCallback( m_currentControllerCommand->m_controllerState, m_currentControllerCommand->m_controllerReturnError, m_currentControllerCommand->m_controllerCallbackContext );
-				m_currentControllerCommand->m_controllerStateChanged = false;
 			}
+			m_currentControllerCommand->m_controllerStateChanged = false;
 		}
 		else
 		{


### PR DESCRIPTION
The `m_currentControllerCommand->m_controllerStateChanged` was only reset when there is a callback, but all the ControllerCommands called by the manager don't supply a callback method (except the one for custom Controller Commands, where a Callback could be given).
This caused the DriverThreadProc loop to always read that command (e.g. AddNode) from the loop, go into the `WriteNextMsg` and run into the if( `m_currentControllerCommand->m_controllerStateChanged` ), doing nothing and return again and again and again... -> high cpu load because of endless loop until canceled or finished.

