### PR TITLE
Fix MultiInstance handling for CapabilityReport

### DIFF
--- a/cpp/src/command_classes/MultiInstance.cpp
+++ b/cpp/src/command_classes/MultiInstance.cpp
@@ -533,6 +533,15 @@ void MultiInstance::HandleMultiChannelCapabilityReport
 				CommandClass* cc = node->GetCommandClass( commandClassId );
 				if( cc )
 				{
+					// get instance gets an instance for an endpoint
+					// but i'm only interested if there is a related instance for an endpoint and not in the actual result
+					// soo if the result is != 0, the endpoint is already handled
+					bool endpointAlreadyHandled = cc->GetInstance( endPoint ) != 0 ; 
+					if ( endpointAlreadyHandled )
+					{
+						Log::Write( LogLevel_Warning, GetNodeId(), "Received MultiChannelCapabilityReport from node %d for endpoint %d - Endpoint already handled for CommandClass %d", GetNodeId(), endPoint, cc->GetCommandClassId() );
+						continue;
+					}
 					uint8 i;
 					// Find the next free instance of this class
 					for( i = 1; i <= 127; i++ )


### PR DESCRIPTION
It happened sometimes that the MultiChannelCapabilityReport for the same endpoint came in more than once. In this case a additional Instance for the same endpoint gets created. By checking if there is a instance for the given endpoint and CommandClass, this can be prevented.

I'm not sure if this also needs to go into the "all endpoints are the same" part?

zwcfg_0xXXXXXXX.xml with this error
```
<CommandClass id="38" name="COMMAND_CLASS_SWITCH_MULTILEVEL" version="3" issecured="true">
	<Instance index="1" endpoint="1" />
	<Instance index="2" endpoint="1" />
	<Instance index="3" endpoint="2" />
```
Log of 2 MultiChannelCapabilityReport for endpoint 1
[multiinstance_for_endpoint.txt](https://github.com/OpenZWave/open-zwave/files/1200414/multiinstance_for_endpoint.txt)
