### PR TITLE
Add Ecolink DW-ZWAVE2.5-ECO

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -336,6 +336,7 @@
 		<Product type="0001" id="0002" name="Door/Window Sensor" config="ecolink/doorwindow.xml"/>
 		<Product type="0001" id="0003" name="Tilt Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0004" id="0001" name="Motion Detector" config="ecolink/motion.xml"/>
+		<Product type="0004" id="0002" name="Door/Window Sensor" config="ecolink/motion.xml"/>
 		<Product type="0004" id="0003" name="Garage Door Tilt Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0005" id="000f" name="FireFighter" config="ecolink/firefighter.xml"/>
 	</Manufacturer>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -336,7 +336,7 @@
 		<Product type="0001" id="0002" name="Door/Window Sensor" config="ecolink/doorwindow.xml"/>
 		<Product type="0001" id="0003" name="Tilt Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0004" id="0001" name="Motion Detector" config="ecolink/motion.xml"/>
-		<Product type="0004" id="0002" name="Door/Window Sensor" config="ecolink/motion.xml"/>
+		<Product type="0004" id="0002" name="Door/Window Sensor" config="ecolink/doorwindow.xml"/>
 		<Product type="0004" id="0003" name="Garage Door Tilt Sensor" config="ecolink/sensor.xml"/>
 		<Product type="0005" id="000f" name="FireFighter" config="ecolink/firefighter.xml"/>
 	</Manufacturer>


### PR DESCRIPTION
This device sometimes uses Type 0004 ID 0002.  This change was tested with HASS and confirmed to work properly

See http://www.cd-jackson.com/index.php/zwave/zwave-device-database/zwave-device-list/devicesummary/138

Link to the product on Amazon: https://www.amazon.com/gp/product/B01N5HB4U5/