### PR TITLE
Add 'wakeupdelayms' attribute to <CommandClass id=132> to delay handling of wake up.

### DIFF
--- a/config/device_configuration.xsd
+++ b/config/device_configuration.xsd
@@ -132,6 +132,7 @@
      </xs:restriction>
     </xs:simpleType>
    </xs:attribute>
+   <xs:attribute name='wakeupdelayms' use='optional'/>
    <xs:attribute name='version' type='xs:string' use='optional'/>
    <xs:attribute name='request_flags' type='xs:string' use='optional'/>
    <xs:attribute name='endpoints' type='xs:string' use='optional'/>

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -51,6 +51,7 @@ namespace OpenZWave
 	class Thread;
 	class ControllerReplication;
 	class Notification;
+	class WakeUp;
 
 	/** \brief The Driver class handles communication between OpenZWave
 	 *  and a device attached via a serial port (typically a controller).
@@ -370,6 +371,30 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		Mutex*					m_pollMutex;								// Serialize access to the polling list
 		int32					m_pollInterval;								// Time interval during which all nodes must be polled
 		bool					m_bIntervalBetweenPolls;					// if true, the library intersperses m_pollInterval between polls; if false, the library attempts to complete all polls within m_pollInterval
+
+	//-----------------------------------------------------------------------------
+	//  Timer based actions
+	//-----------------------------------------------------------------------------
+	public:
+		void TimerSetWakeup( WakeUp *wakeup, int32 milliseconds );
+
+	private:
+		static void TimerThreadEntryPoint( Event* _exitEvent, void* _context );
+		void TimerThreadProc( Event* _exitEvent );
+
+		struct TimerWakeUpEntry
+		{
+			TimeStamp timestamp;
+			WakeUp *wakeup;
+		};
+OPENZWAVE_EXPORT_WARNINGS_OFF
+		list<TimerWakeUpEntry *> m_timerWakeUpList; // List of nodes that need to be polled
+OPENZWAVE_EXPORT_WARNINGS_ON
+
+		Thread*				m_timerThread;  // Thread for performing actions on a timer
+		Event*				m_timerEvent;   // Event to signal new timed action requested
+		Mutex*				m_timerMutex;   // Serialize access to the timeout members
+		int32					m_timerTimeout; // Time to wait until next event
 
 	//-----------------------------------------------------------------------------
 	//	Retrieving Node information

--- a/cpp/src/command_classes/WakeUp.h
+++ b/cpp/src/command_classes/WakeUp.h
@@ -57,6 +57,8 @@ namespace OpenZWave
 		void SetPollRequired(){ m_pollRequired = true; }
 
 		// From CommandClass
+		virtual void ReadXML( TiXmlElement const* _ccElement );
+		virtual void WriteXML( TiXmlElement* _ccElement );
 		virtual bool RequestState( uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue );
 		virtual bool RequestValue( uint32 const _requestFlags, uint8 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
 		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
@@ -77,6 +79,7 @@ namespace OpenZWave
 		list<Driver::MsgQueueItem>	m_pendingQueue;		// Messages waiting to be sent when the device wakes up
 		bool						m_awake;
 		bool						m_pollRequired;
+		int             m_delayWakeupMilli; // Wait this many milliseconds before handling wakeup.
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
A workaround for issue: https://github.com/OpenZWave/open-zwave/issues/1083
Also discussed here: https://groups.google.com/forum/#!topic/openzwave/CfeyxHFOf1s

Creates a 'wakeupdelayms' attribute which combines with a timer thread to delay the handling of wakes up. This workaround gives an application more chance to respond to certain events.