### PR TITLE
Support switch multilevel v4

### DIFF
--- a/cpp/src/command_classes/SwitchMultilevel.cpp
+++ b/cpp/src/command_classes/SwitchMultilevel.cpp
@@ -51,7 +51,7 @@ enum SwitchMultilevelCmd
 	SwitchMultilevelCmd_SupportedReport				= 0x07
 };
 
-enum
+enum SwitchMultilevelIndex
 {
 	SwitchMultilevelIndex_Level = 0,
 	SwitchMultilevelIndex_Bright,
@@ -61,7 +61,8 @@ enum
 	SwitchMultilevelIndex_Duration,
 	SwitchMultilevelIndex_Step,
 	SwitchMultilevelIndex_Inc,
-	SwitchMultilevelIndex_Dec
+	SwitchMultilevelIndex_Dec,
+	SwitchMultilevelIndex_TargetValue
 };
 
 static uint8 c_directionParams[] =
@@ -202,6 +203,26 @@ bool SwitchMultilevel::HandleMsg
 			value->OnValueRefreshed( _data[1] );
 			value->Release();
 		}
+
+		if( GetVersion() >= 4) {
+
+			// data[2] => target value
+			if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_TargetValue ) ) )
+			{
+				value->OnValueRefreshed( _data[2]);
+				value->Release();
+			}
+				
+			// data[3] might be duration
+			if(_length > 3) {
+				if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Duration ) ) )
+				{
+					value->OnValueRefreshed( _data[3] );
+					value->Release();
+				}
+			}
+		}
+
 		return true;
 	}
 
@@ -273,7 +294,7 @@ void SwitchMultilevel::SetVersion
 {
 	CommandClass::SetVersion( _version );
 
-	if( _version == 3 )
+	if( _version >= 3 )
 	{
 		// Request the supported switch types
 		Msg* msg = new Msg( "SwitchMultilevelCmd_SupportedGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
@@ -474,8 +495,9 @@ bool SwitchMultilevel::SetLevel
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );
 
-	if( ValueByte* durationValue = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Duration ) ) )
+	if( GetVersion() >= 2 )
 	{
+		ValueByte* durationValue = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Duration ) );
 		uint8 duration = durationValue->GetValue();
 		durationValue->Release();
 		if( duration == 0xff )
@@ -629,6 +651,11 @@ void SwitchMultilevel::CreateVars
 	{
 		switch( GetVersion() )
 		{
+			case 4:
+			{
+				node->CreateValueByte( ValueID::ValueGenre_System, GetCommandClassId(), _instance, SwitchMultilevelIndex_TargetValue, "Target Value", "", true, false, 0, 0 );
+				// Fall through to version 3
+			}
 			case 3:
 			{
 			  	node->CreateValueByte( ValueID::ValueGenre_User, GetCommandClassId(), _instance, SwitchMultilevelIndex_Step, "Step Size", "", false, false, 0, 0 );


### PR DESCRIPTION
Requested in https://github.com/OpenZWave/open-zwave/issues/1321 
Here's my take, as the changes are pretty similar to binary switch v2. Compiled without errors on Windows/VS2017.

Sadly, I still have to pass when it comes to changing Value::VerifyRefreshedValue.