### PR TITLE
Allow LED on GE 12721 Smart Outlet to be turned off

### DIFF
--- a/config/ge/receptacle.xml
+++ b/config/ge/receptacle.xml
@@ -2,10 +2,11 @@
 <Product xmlns='http://code.google.com/p/open-zwave/'>
 	<!-- Configuration Parameters -->
 	<CommandClass id="112">
-		<Value type="list" index="3" genre="config" label="Night Light" size="1" value="0">
-			<Help>In night-light mode the LED on the switch will turn ON when the switch is turned OFF.</Help>
-			<Item label="No" value="0" />
-			<Item label="Yes" value="1" />
+		<Value type="list" index="3" genre="config" label="LED Light" min="0" max="2" size="1" value="0">
+			<Help>Sets when the LED on the outlet is lit.</Help>
+			<Item label="LED on when outlet off" value="0" />
+			<Item label="LED on when outlet on" value="1" />
+			<Item label="LED always off" value="2" />
 		</Value>
 	</CommandClass>
 </Product>


### PR DESCRIPTION
Per [this document](http://www.ezzwave.com/advanced-operation/) the GE 12721 Smart Outlet supports an additional parameter to turn the LED light all the way off. This adds that support and clarifies the other options.