### PR TITLE
Eurotronic spirit z + thermostat setpoint v3

### DIFF
--- a/config/eurotronic/eur_spiritz.xml
+++ b/config/eurotronic/eur_spiritz.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+    <CommandClass id="67" base="0" typeInterpretation="A" />
+    <CommandClass id="64" >
+        <Instance index="1" />
+        <Value type="list" genre="user" instance="1" index="0" label="Mode">
+                <Item label="Off" value="0" />
+                <Item label="Heat" value="1" />
+                <Item label="Heat Econ" value="11" />
+                <Item label="Full Power" value="15" />
+                <Item label="Manufacturer Specific" value="31" />
+        </Value>
+        <SupportedModes>
+                <Mode index="0" label="Off" />
+                <Mode index="1" label="Heat" />
+                <Mode index="11" label="Heat Econ" />
+                <Mode index="15" label="Full Power" />
+                <Mode index="31" label="Manufacturer Specific" />
+        </SupportedModes>
+    </CommandClass>
+
+    <CommandClass id="112">
+        <Value type="byte" genre="config" instance="1" index="1" label="Invert LCD" min="0" max="1" units="" value="0">
+            <Help>
+                    0x00 LCD normal
+                    0x01 LCD inverted / upside down
+                    Default: 0x00
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="2" label="LCD Timeout" min="0" max="30" units="" value="0">
+            <Help>
+                    0x00 No Timeout, LCD always on
+                    0x05-0x1E Timeout after 5 - 30s
+                    default: 0x00
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="3" label="Backlight" min="0" max="1" units="" value="1">
+            <Help>
+                0x00 No Backlight
+                0x01 Backlight active
+                default: 0x01
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="4" label="Battery Status" min="0" max="1" units="" value="1">
+            <Help>
+                0x00 Only send battery status as notification
+                0x01 send battery status 1x daily
+                default: 0x01
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="5" label="Temperature Report Threshold" min="0" max="50" units="°C" value="5">
+            <Help>
+                0x00 Don't send temperature automatically
+                0x01 – 0x32 Report temperature at 0,1 - 5.0°C temperature difference
+                default 0x05 (Delta = 0,5°C )
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="6" label="Valve Opening Degree" min="0" max="100" units="" value="0">
+            <Help>
+                0x00 Don't send Valve opening degree automatically 
+                0x01-0x64 report valve opening degree at a delta of 1 - 100%.
+                default 0x00
+            </Help>
+        </Value>   
+        <Value type="byte" genre="config" instance="1" index="7" label="Open Window Detection" min="0" max="3" units="" value="2">
+            <Help>
+                0x00 Disabled
+                0x01 low sensibility
+                0x02 medium sensibility
+                0x03 high sensibility
+                default: 0x02
+            </Help>
+        </Value>
+        <Value type="byte" genre="config" instance="1" index="8" label="Temperature Offset" min="-50" max="128" units="" value="0">
+            <Help>
+                0xCE-0x32 -5,0°C – (+)5,0°C
+                0x80 External Temperature Sensor
+                default: 0x00 0,0°C Offset
+            </Help>
+        </Value>
+    </CommandClass>
+</Product>
+

--- a/config/eurotronic/eur_spiritz.xml
+++ b/config/eurotronic/eur_spiritz.xml
@@ -71,7 +71,7 @@
                 default: 0x02
             </Help>
         </Value>
-        <Value type="byte" genre="config" instance="1" index="8" label="Temperature Offset" min="-50" max="128" units="" value="0">
+        <Value type="byte" genre="config" instance="1" index="8" label="Temperature Offset" min="-128" max="50" units="" value="0">
             <Help>
                 0xCE-0x32 -5,0°C – (+)5,0°C
                 0x80 External Temperature Sensor

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -363,6 +363,9 @@
 		<Product type="0001" id="0001" name="EUR_STELLAZ Wall Radiator Thermostat Valve Control" config="eurotronic/eur_stellaz.xml"/>
 		<Product type="0002" id="0001" name="EUR_COMETZ Wall Radiator Thermostat Valve Control" config="eurotronic/eur_cometz.xml"/>
 		<Product type="0003" id="0001" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
+		<Product type="0003" id="0002" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
+		<Product type="0003" id="0003" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
+	</Manufacturer>
 	</Manufacturer>
 	<Manufacturer id="0128" name="Eneco">
 		<Product type="0000" id="0000" name="ED2.0 Meter Adapter"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -878,6 +878,7 @@
 		<Product type="0003" id="0002" name="Danalock Circle/Square" config="polycontrol/doorlock.xml"/>
 		<Product type="0001" id="0001" name="Polylock" config="polycontrol/polylock.xml"/>
 		<Product type="0008" id="0002" name="Danalock V2 BTZE" config="polycontrol/doorlock.xml"/>
+		<Product type="0009" id="0001" name="Danalock V3 BTZE" config="polycontrol/doorlockv3.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0154" name="Popp">
 		<Product type="0001" id="0001" name="123658 Plug-in Switch plus Power Meter" config="popp/123658.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -362,6 +362,7 @@
 	<Manufacturer id="0148" name="EUROtronic">
 		<Product type="0001" id="0001" name="EUR_STELLAZ Wall Radiator Thermostat Valve Control" config="eurotronic/eur_stellaz.xml"/>
 		<Product type="0002" id="0001" name="EUR_COMETZ Wall Radiator Thermostat Valve Control" config="eurotronic/eur_cometz.xml"/>
+		<Product type="0003" id="0001" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0128" name="Eneco">
 		<Product type="0000" id="0000" name="ED2.0 Meter Adapter"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -366,7 +366,6 @@
 		<Product type="0003" id="0002" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
 		<Product type="0003" id="0003" name="EUR_SPIRITZ Wall Radiator Thermostat" config="eurotronic/eur_spiritz.xml"/>
 	</Manufacturer>
-	</Manufacturer>
 	<Manufacturer id="0128" name="Eneco">
 		<Product type="0000" id="0000" name="ED2.0 Meter Adapter"/>
 		<Product type="0128" id="0000" name="ED2.0 Display"/>

--- a/config/polycontrol/doorlockv3.xml
+++ b/config/polycontrol/doorlockv3.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns="http://code.google.com/p/open-zwave/">
+    <!--
+    Polycontrol: Danalock V3 door lock
+    https://products.z-wavealliance.org/products/2556
+    -->
+    <!-- COMMAND_CLASS_BASIC does not respond to requests -->
+    <CommandClass id="32" setasreport="true"/>
+
+    <CommandClass id="112">
+        <Value type="list" genre="config" instance="1" index="1" label="Twist Assist" min="0" max="1" value="0" size="1">
+            <Help></Help>
+            <Item label="Disabled" value="0"/>
+            <Item label="Enabled" value="1"/>
+        </Value>
+        <Value type="int" genre="config" instance="1" index="2" label="Hold and Release" min="0" max="2147483647" units="seconds" value="0" size="4">
+            <Help>
+                0 Disable.
+                1 to 2147483647 Enable, time in seconds.
+            </Help>
+        </Value>
+        <Value type="list" genre="config" instance="1" index="3" label="Block to Block" min="0" max="1" value="0" size="1">
+            <Help></Help>
+            <Item label="Disable" value="0"/>
+            <Item label="Enable" value="1"/>
+        </Value>
+        <Value type="int" genre="config" instance="1" index="4" label="BLE Temporary Allowed" min="0" max="2147483647" units="seconds" value="0" size="4">
+            <Help>
+                0 Disable.
+                1 to 2147483647 Enable, time in seconds.
+            </Help>
+        </Value>
+        <Value type="list" genre="config" instance="1" index="5" label="BLE Always Allowed" min="0" max="1" value="0" size="1">
+            <Help></Help>
+            <Item label="Disable" value="0"/>
+            <Item label="Enable" value="1"/>
+        </Value>
+        <Value type="int" genre="config" instance="1" index="6" label="Autolock" min="0" max="2147483647" units="seconds" value="0" size="4">
+            <Help>
+                0 Disable.
+                1 to 2147483647 Enable, time in seconds.
+            </Help>
+        </Value>
+    </CommandClass>
+
+    <CommandClass id="133">
+        <Associations num_groups="1">
+            <Group index="1" max_associations="1" label="Lifeline"/>
+        </Associations>
+    </CommandClass>
+
+</Product>

--- a/cpp/src/command_classes/ThermostatMode.cpp
+++ b/cpp/src/command_classes/ThermostatMode.cpp
@@ -363,15 +363,6 @@ bool ThermostatMode::HandleMsg
 				}
 			}
 		}
-//		if ( GetVersion() >= 3)
-//		{
-//			ValueList::Item item;
-//			item.m_value = ThermostatMode_ManufacturerSpecific;
-//			item.m_label = c_modeName[item.m_value];
-//			m_supportedModes.push_back( item );
-//			Log::Write( LogLevel_Info, GetNodeId(), "    Added mode: %s", c_modeName[item.m_value] );
-//		}
-
 		ClearStaticRequest( StaticRequest_Values );
 		CreateVars( _instance );
 		return true;

--- a/cpp/src/command_classes/ThermostatMode.cpp
+++ b/cpp/src/command_classes/ThermostatMode.cpp
@@ -48,6 +48,43 @@ enum ThermostatModeCmd
 	ThermostatModeCmd_SupportedReport	= 0x05
 };
 
+enum
+{
+	ThermostatMode_Off	= 0,
+	ThermostatMode_Heat,
+	ThermostatMode_Cool,
+	ThermostatMode_Auto,
+	ThermostatMode_Auxiliary,
+	ThermostatMode_Resume_On,
+	ThermostatMode_Fan,
+	ThermostatMode_Furnance,
+	ThermostatMode_Dry,
+	ThermostatMode_Moist,
+	ThermostatMode_AutoChangeover,
+	ThermostatMode_HeatingEcon,
+	ThermostatMode_CoolingEcon,
+	ThermostatMode_Away,
+	ThermostatMode_Reserved0E = 0x0E,
+	ThermostatMode_FullPower,
+	ThermostatMode_Reserved10 = 0x10,
+	ThermostatMode_Reserved11,
+	ThermostatMode_Reserved12,
+	ThermostatMode_Reserved13,
+	ThermostatMode_Reserved14,
+	ThermostatMode_Reserved15,
+	ThermostatMode_Reserved16,
+	ThermostatMode_Reserved17,
+	ThermostatMode_Reserved18,
+	ThermostatMode_Reserved19,
+	ThermostatMode_Reserved1A,
+	ThermostatMode_Reserved1B,
+	ThermostatMode_Reserved1C,
+	ThermostatMode_Reserved1D,
+	ThermostatMode_Reserved1E,
+	ThermostatMode_ManufacturerSpecific = 0x1F,
+	ThermostatMode_Count,
+};
+
 static char const* c_modeName[] =
 {
 	"Off",
@@ -64,7 +101,24 @@ static char const* c_modeName[] =
 	"Heat Econ",
 	"Cool Econ",
 	"Away",
-	"Unknown"
+	"Unknown",
+	"Full Power",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Unknown",
+	"Manufacturer Specific"
 };
 
 //-----------------------------------------------------------------------------
@@ -94,10 +148,10 @@ void ThermostatMode::ReadXML
 					int index;
 					if( TIXML_SUCCESS == modeElement->QueryIntAttribute( "index", &index ) )
 					{
-						if (index > 13) /* size of c_modeName minus Invalid */
+						if (index > ThermostatMode_Count)
 						{
 							Log::Write (LogLevel_Warning, GetNodeId(), "index Value in XML was greater than range. Setting to Invalid");
-							index = 14;
+							index = ThermostatMode_Count+1;
 						}
 						ValueList::Item item;
 						item.m_value = index;
@@ -309,6 +363,14 @@ bool ThermostatMode::HandleMsg
 				}
 			}
 		}
+//		if ( GetVersion() >= 3)
+//		{
+//			ValueList::Item item;
+//			item.m_value = ThermostatMode_ManufacturerSpecific;
+//			item.m_label = c_modeName[item.m_value];
+//			m_supportedModes.push_back( item );
+//			Log::Write( LogLevel_Info, GetNodeId(), "    Added mode: %s", c_modeName[item.m_value] );
+//		}
 
 		ClearStaticRequest( StaticRequest_Values );
 		CreateVars( _instance );

--- a/cpp/src/command_classes/ThermostatMode.h
+++ b/cpp/src/command_classes/ThermostatMode.h
@@ -57,6 +57,7 @@ namespace OpenZWave
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
 		virtual bool SetValue( Value const& _value );
+		virtual uint8 GetMaxVersion(){ return 3; }
 
 	protected:
 		virtual void CreateVars( uint8 const _instance );

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -41,11 +41,13 @@ using namespace OpenZWave;
 
 enum ThermostatSetpointCmd
 {
-	ThermostatSetpointCmd_Set				= 0x01,
-	ThermostatSetpointCmd_Get				= 0x02,
-	ThermostatSetpointCmd_Report			= 0x03,
-	ThermostatSetpointCmd_SupportedGet		= 0x04,
-	ThermostatSetpointCmd_SupportedReport	= 0x05
+	ThermostatSetpointCmd_Set					= 0x01,
+	ThermostatSetpointCmd_Get					= 0x02,
+	ThermostatSetpointCmd_Report				= 0x03,
+	ThermostatSetpointCmd_SupportedGet			= 0x04,
+	ThermostatSetpointCmd_SupportedReport		= 0x05,
+	ThermostatSetpointCmd_CapabilitiesGet		= 0x09,
+ 	ThermostatSetpointCmd_CapabilitiesReport	= 0x0A
 };
 
 enum
@@ -64,8 +66,13 @@ enum
 	ThermostatSetpoint_HeatingEcon,
 	ThermostatSetpoint_CoolingEcon,
 	ThermostatSetpoint_AwayHeating,
-	ThermostatSetpoint_Count
+	ThermostatSetpoint_CoolingHeating,
+	ThermostatSetpoint_Count,
+
+	ThermostatSetpoint_Minimum = 100,
+	ThermostatSetpoint_Maximum = 200
 };
+
 
 static char const* c_setpointName[] =
 {
@@ -82,7 +89,9 @@ static char const* c_setpointName[] =
 	"Auto Changeover",
 	"Heating Econ",
 	"Cooling Econ",
-	"Away Heating"
+	"Away Heating",
+	"Away Cooling",
+	"Full Power"
 };
 
 //-----------------------------------------------------------------------------
@@ -261,7 +270,7 @@ bool ThermostatSetpoint::HandleMsg
 		return true;
 	}
 
-	if( ThermostatSetpointCmd_SupportedReport == (ThermostatSetpointCmd)_data[0] )
+	else if( ThermostatSetpointCmd_SupportedReport == (ThermostatSetpointCmd)_data[0] )
 	{
 		if( Node* node = GetNodeUnsafe() )
 		{
@@ -275,6 +284,29 @@ bool ThermostatSetpoint::HandleMsg
 				{
 					if( ( _data[i] & (1<<bit) ) != 0 )
 					{
+						if ( GetVersion() >= 3)
+						{
+							// Request the supported setpoints
+							Msg* msg = new Msg( "ThermostatSetpointCmd_CapabilitesGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
+							msg->SetInstance( this, _instance );
+							msg->Append( GetNodeId() );
+							msg->Append( 3 );
+							msg->Append( GetCommandClassId() );
+							msg->Append( ThermostatSetpointCmd_CapabilitiesGet );
+							uint8 type = ((i-1)<<3) + bit;
+							if ( m_setPointTypeInterpretation == 0x0A )
+							{
+								// for interpretation A the setpoint identifier makes a jump of 4 after the 2nd bit ... wtf @ zensys
+								if ( type > 2 )
+								{
+									type += 4;
+								}
+							}
+							msg->Append(type);
+							msg->Append( GetDriver()->GetTransmitOptions() );
+							GetDriver()->SendMsg( msg, OpenZWave::Driver::MsgQueue_Query );
+						}
+
 						uint8 type = ((i-1)<<3) + bit;
 						if ( m_setPointTypeInterpretation == 0x0A )
 						{
@@ -289,6 +321,7 @@ bool ThermostatSetpoint::HandleMsg
 						if( index < ThermostatSetpoint_Count )
 						{
 							string setpointName = c_setpointName[index];
+
 							node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, index, setpointName, "C", false, false, "0.0", 0 );
 							Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName );
 						}
@@ -299,6 +332,32 @@ bool ThermostatSetpoint::HandleMsg
 
 		ClearStaticRequest( StaticRequest_Values );
 		return true;
+	}
+	else if( ThermostatSetpointCmd_CapabilitiesReport == (ThermostatSetpointCmd)_data[0] )
+	{
+		if( Node* node = GetNodeUnsafe() )
+		{
+			// We have received the capabilites for supported setpoint Type
+			uint8 scale;
+			uint8 precision = 0;
+			uint8 size = _data[2] & 0x07;
+			string minValue = ExtractValue( &_data[2], &scale, &precision );
+			string maxValue = ExtractValue( &_data[2+size+1], &scale, &precision );
+
+			Log::Write( LogLevel_Info, GetNodeId(), "Received capabilites of thermostat setpoint type %d, min %s max %s" , (int)_data[1], minValue.c_str(), maxValue.c_str());
+
+			uint8 index = _data[1];
+			// Add supported setpoint
+			if( index < ThermostatSetpoint_Count )
+			{
+				string setpointName = c_setpointName[index];
+
+				node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, ThermostatSetpoint_Minimum + index, setpointName + "_minimum", "C", false, false, minValue, 0 );
+				node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, ThermostatSetpoint_Maximum + index, setpointName + "_maximum", "C", false, false, maxValue, 0 );
+				Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName );
+			}
+
+		}
 	}
 
 	return false;

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -323,7 +323,7 @@ bool ThermostatSetpoint::HandleMsg
 							string setpointName = c_setpointName[index];
 
 							node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, index, setpointName, "C", false, false, "0.0", 0 );
-							Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName );
+							Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName.c_str() );
 						}
 					}
 				}
@@ -354,7 +354,7 @@ bool ThermostatSetpoint::HandleMsg
 
 				node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, ThermostatSetpoint_Minimum + index, setpointName + "_minimum", "C", false, false, minValue, 0 );
 				node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, ThermostatSetpoint_Maximum + index, setpointName + "_maximum", "C", false, false, maxValue, 0 );
-				Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName );
+				Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName.c_str() );
 			}
 
 		}

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -56,6 +56,7 @@ namespace OpenZWave
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
 		virtual bool SetValue( Value const& _value );
+		virtual uint8 GetMaxVersion(){ return 3; }
 
 	public:
 		virtual void CreateVars( uint8 const _instance, uint8 const _index );
@@ -63,6 +64,7 @@ namespace OpenZWave
 	private:
 		ThermostatSetpoint( uint32 const _homeId, uint8 const _nodeId );
 		uint8 m_setPointBase;
+		uint8 m_setPointTypeInterpretation;
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
The PR for #1340

The Thermostate_Setpoint has 2 interpretations. OZW seems to follow Interpretation B per default. 

>It has been found that early implementations of this Command Class specification apply two non-
interoperable interpretations of the bit mask advertising the support for specific Setpoint Types.
As a consequence, one may find thermostat products and controller products in the marketplace which
implement either of the two bit mask interpretations found in Table 106. The notation x.y indicates Bit
Mask byte x, bit y.

>Implementations of Thermostat Setpoint Command Class, version 3 MUST comply with Interpretation A.

The EUROtronic Spirit Z Thermostate (and comet and stella z too)  uses version 3 and thus follows interpretation A.

![image](https://user-images.githubusercontent.com/4622393/31661514-4f3a256a-b33b-11e7-98c9-8a81c1c39d1a.png)


This PR adds a config Parameter `<CommandClass id="67" base="0" typeInterpretation="A" />` .
Together with this i added the Capabilities Get and Report Command support (its now possible to get the min and max from the devices).
And while i'm at it, the Thermostate_Mode got new values as well.

Also adds a config file for the Spirit Z Thermostat