### PR TITLE
Fix valgrind memory warnings and potential cause for a segmentation fault.

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -201,6 +201,8 @@ m_nondelivery( 0 ),
 m_routedbusy( 0 ),
 m_broadcastReadCnt( 0 ),
 m_broadcastWriteCnt( 0 ),
+AuthKey( 0 ),
+EncryptKey( 0 ),
 m_nonceReportSent( 0 ),
 m_nonceReportSentAttempt( 0 )
 {
@@ -352,7 +354,8 @@ Driver::~Driver
 
 	m_notificationsEvent->Release();
 	m_nodeMutex->Release();
-
+	delete AuthKey;
+	delete EncryptKey;
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -81,6 +81,9 @@ Msg::Msg
 		m_expectedReply = _expectedReply ? _expectedReply : _function;
 	}
 
+	memset(m_buffer, 0x00, 256);
+	memset(e_buffer, 0x00, 256);
+
 	m_buffer[0] = SOF;
 	m_buffer[1] = 0;					// Length of the following data, filled in during Finalize.
 	m_buffer[2] = _msgType;

--- a/cpp/src/platform/Stream.cpp
+++ b/cpp/src/platform/Stream.cpp
@@ -51,6 +51,7 @@ Stream::Stream
 	m_mutex( new Mutex() )
 {
 	m_buffer = new uint8[m_bufferSize];
+	memset(m_buffer, 0x00, m_bufferSize);
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/platform/Stream.cpp
+++ b/cpp/src/platform/Stream.cpp
@@ -151,8 +151,9 @@ bool Stream::Put
 
 		memcpy( &m_buffer[m_head], _buffer, block1 );
 		memcpy( m_buffer, &_buffer[block1], block2 );
+		uint8 * logpos = m_buffer + m_head;
 		m_head = block2;
-		LogData( m_buffer + m_head - block1, block1, "      Read (controller->buffer):  ");
+		LogData( logpos, block1, "      Read (controller->buffer):  ");
 		LogData( m_buffer, block2, "      Read (controller->buffer):  ");
 	}
 	else


### PR DESCRIPTION
Sometimes openzwave based binary would crash with a segmentation fault. I ran with valgrind and it showed some warnings on uninitialized members. I believe the segfault was triggered because a LogData in Stream.cpp is logging data from a buffer but the calculated buffer position is wrong, leading to read before the buffer starts:
==7364== Thread 4:
==7364== Invalid read of size 1
==7364==    at 0x289080: OpenZWave::Stream::LogData(unsigned char*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (Stream.cpp:228)
==7364==    by 0x288D96: OpenZWave::Stream::Put(unsigned char*, unsigned int) (Stream.cpp:159)
==7364==    by 0x28CC00: OpenZWave::SerialControllerImpl::Read() (SerialControllerImpl.cpp:327)
==7364==    by 0x28C620: OpenZWave::SerialControllerImpl::ReadThreadProc(OpenZWave::Event*) (SerialControllerImpl.cpp:145)
==7364==    by 0x28C5ED: OpenZWave::SerialControllerImpl::SerialReadThreadEntryPoint(OpenZWave::Event*, void*) (SerialControllerImpl.cpp:123)
==7364==    by 0x28C35D: OpenZWave::ThreadImpl::Run() (ThreadImpl.cpp:176)
==7364==    by 0x28C321: OpenZWave::ThreadImpl::ThreadProc(void*) (ThreadImpl.cpp:161)
==7364==    by 0x525E6D9: start_thread (pthread_create.c:456)
==7364==    by 0x5B1CD7E: clone (clone.S:105)
==7364==  Address 0x6e42cc6 is 10 bytes before a block of size 2,048 alloc'd
==7364==    at 0x4C2E8BF: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7364==    by 0x2888D9: OpenZWave::Stream::Stream(unsigned int) (Stream.cpp:53)
==7364==    by 0x28A326: OpenZWave::Controller::Controller() (Controller.h:52)
==7364==    by 0x28A3B0: OpenZWave::SerialController::SerialController() (SerialController.cpp:55)
==7364==    by 0x1F227B: OpenZWave::Driver::Driver(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OpenZWave::Driver::ControllerInterface const&) (Driver.cpp:234)
==7364==    by 0x222CA0: OpenZWave::Manager::AddDriver(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OpenZWave::Driver::ControllerInterface const&) (Manager.cpp:298)
==7364==    by 0x1BF067: zwave_manager::initialize() (zwave_manager.cpp:204)
==7364==    by 0x1BCDC3: main (main.cpp:77)
==7364==
