### PR TITLE
Add zWave node instance to logs

### DIFF
--- a/cpp/src/command_classes/Alarm.cpp
+++ b/cpp/src/command_classes/Alarm.cpp
@@ -192,7 +192,7 @@ bool Alarm::RequestValue
 			return res;
 		}
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "AlarmCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "AlarmCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -213,13 +213,13 @@ bool Alarm::HandleMsg
 		// We have received a report from the Z-Wave device
 		if( GetVersion() == 1 )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Alarm report: type=%d, level=%d", _data[1], _data[2] );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Alarm report: type=%d, level=%d", _data[1], _data[2] );
 		}
 		else
 		{
 			string alarm_type =  ( _data[5] < Alarm_Count ) ? c_alarmTypeName[_data[5]] : "Unknown type";
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Alarm report: type=%d, level=%d, sensorSrcID=%d, type:%s event:%d, status=%d",
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Alarm report: type=%d, level=%d, sensorSrcID=%d, type:%s event:%d, status=%d",
 							_data[1], _data[2], _data[3], alarm_type.c_str(), _data[6], _data[4] );
 		}
 
@@ -259,10 +259,10 @@ bool Alarm::HandleMsg
 		if( Node* node = GetNodeUnsafe() )
 		{
 			// We have received the supported alarm types from the Z-Wave device
-			Log::Write( LogLevel_Info, GetNodeId(), "Received supported alarm types" );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received supported alarm types" );
 
 			node->CreateValueByte( ValueID::ValueGenre_User, GetCommandClassId(), _instance, AlarmIndex_SourceNodeId, "SourceNodeId", "", true, false, 0, 0 );
-			Log::Write( LogLevel_Info, GetNodeId(), "    Added alarm SourceNodeId" );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added alarm SourceNodeId" );
 
 			// Parse the data for the supported alarm types
 			uint8 numBytes = _data[1];
@@ -276,9 +276,9 @@ bool Alarm::HandleMsg
 						if( index < Alarm_Count )
 						{
 							node->CreateValueByte( ValueID::ValueGenre_User, GetCommandClassId(), _instance, index+3, c_alarmTypeName[index], "", true, false, 0, 0 );
-							Log::Write( LogLevel_Info, GetNodeId(), "    Added alarm type: %s", c_alarmTypeName[index] );
+							Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added alarm type: %s", c_alarmTypeName[index] );
 						} else {
-							Log::Write( LogLevel_Info, GetNodeId(), "    Unknown alarm type: %d", index );
+							Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Unknown alarm type: %d", index );
 						}
 					}
 				}

--- a/cpp/src/command_classes/ApplicationStatus.cpp
+++ b/cpp/src/command_classes/ApplicationStatus.cpp
@@ -78,7 +78,7 @@ bool ApplicationStatus::HandleMsg
 				snprintf( msg, sizeof(msg), "Unknown status %d", _data[1] );
 			}
 		}
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Application Status Busy: %s", msg );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Application Status Busy: %s", msg );
 		return true;
 	}
 

--- a/cpp/src/command_classes/Association.cpp
+++ b/cpp/src/command_classes/Association.cpp
@@ -225,7 +225,7 @@ bool Association::HandleMsg
 			// Retrieve the number of groups this device supports.
 			// The groups will be queried with the session data.
 			m_numGroups = _data[1];
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Association Groupings report from node %d. Number of groups is %d", GetNodeId(), m_numGroups );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Association Groupings report from node %d. Number of groups is %d", GetNodeId(), m_numGroups );
 			ClearStaticRequest( StaticRequest_Values );
 			handled = true;
 		}
@@ -242,13 +242,13 @@ bool Association::HandleMsg
 				{
 					uint8 numAssociations = _length - 5;
 
-					Log::Write( LogLevel_Info, GetNodeId(), "Received Association report from node %d, group %d, containing %d associations", GetNodeId(), groupIdx, numAssociations );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Association report from node %d, group %d, containing %d associations", GetNodeId(), groupIdx, numAssociations );
 					if( numAssociations )
 					{
-						Log::Write( LogLevel_Info, GetNodeId(), "  The group contains:" );
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "  The group contains:" );
 						for( i=0; i<numAssociations; ++i )
 						{
-							Log::Write( LogLevel_Info, GetNodeId(), "    Node %d",  _data[i+4] );
+							Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Node %d",  _data[i+4] );
 							m_pendingMembers.push_back( _data[i+4] );
 						}
 					}
@@ -257,7 +257,7 @@ bool Association::HandleMsg
 				if( numReportsToFollow )
 				{
 					// We're expecting more reports for this group
-					Log::Write( LogLevel_Info, GetNodeId(), "%d more association reports expected for node %d, group %d", numReportsToFollow, GetNodeId(), groupIdx );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "%d more association reports expected for node %d, group %d", numReportsToFollow, GetNodeId(), groupIdx );
 					return true;
 				}
 				else
@@ -279,7 +279,7 @@ bool Association::HandleMsg
 			else
 			{
 				// maxAssociations is zero, so we've reached the end of the query process
-				Log::Write( LogLevel_Info, GetNodeId(), "Max associations for node %d, group %d is zero.  Querying associations for this node is complete.", GetNodeId(), groupIdx );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Max associations for node %d, group %d is zero.  Querying associations for this node is complete.", GetNodeId(), groupIdx );
 				node->AutoAssociate();
 				m_queryAll = false;
 			}
@@ -302,7 +302,7 @@ bool Association::HandleMsg
 				else
 				{
 					// We're all done
-					Log::Write( LogLevel_Info, GetNodeId(), "Querying associations for node %d is complete.", GetNodeId() );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Querying associations for node %d is complete.", GetNodeId() );
 					node->AutoAssociate();
 					m_queryAll = false;
 				}

--- a/cpp/src/command_classes/Basic.cpp
+++ b/cpp/src/command_classes/Basic.cpp
@@ -170,7 +170,7 @@ bool Basic::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "BasicCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "BasicCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -189,7 +189,7 @@ bool Basic::HandleMsg
 	if( BasicCmd_Report == (BasicCmd)_data[0] )
 	{
 		// Level
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Basic report from node %d: level=%d", GetNodeId(), _data[1] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Basic report from node %d: level=%d", GetNodeId(), _data[1] );
 		if( !m_ignoreMapping && m_mapping != 0 )
 		{
 			UpdateMappedClass( _instance, m_mapping, _data[1] );
@@ -199,7 +199,7 @@ bool Basic::HandleMsg
 			value->OnValueRefreshed( _data[1] );
 			value->Release();
 		} else {
-			Log::Write(LogLevel_Warning, GetNodeId(), "No Valid Mapping for Basic Command Class and No ValueID Exported. Error?");
+			Log::Write(LogLevel_Warning, GetNodeId(), _instance, "No Valid Mapping for Basic Command Class and No ValueID Exported. Error?");
 		}
 		return true;
 	}
@@ -208,7 +208,7 @@ bool Basic::HandleMsg
 	{
 		if( m_setAsReport )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Basic set from node %d: level=%d. Treating it as a Basic report.", GetNodeId(), _data[1] );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Basic set from node %d: level=%d. Treating it as a Basic report.", GetNodeId(), _data[1] );
 			if( !m_ignoreMapping && m_mapping != 0 )
 			{
 				UpdateMappedClass( _instance, m_mapping, _data[1] );
@@ -222,7 +222,7 @@ bool Basic::HandleMsg
 		else
 		{
 			// Commmand received from the node.  Handle as a notification event
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Basic set from node %d: level=%d.  Sending event notification.", GetNodeId(), _data[1] );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Basic set from node %d: level=%d.  Sending event notification.", GetNodeId(), _data[1] );
 
 			Notification* notification = new Notification( Notification::Type_NodeEvent );
 			notification->SetHomeNodeIdAndInstance( GetHomeId(), GetNodeId(), _instance );

--- a/cpp/src/command_classes/Battery.cpp
+++ b/cpp/src/command_classes/Battery.cpp
@@ -90,7 +90,7 @@ bool Battery::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "BatteryCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "BatteryCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -116,7 +116,7 @@ bool Battery::HandleMsg
 			batteryLevel = 0;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Battery report from node %d: level=%d", GetNodeId(), batteryLevel );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Battery report from node %d: level=%d", GetNodeId(), batteryLevel );
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, 0 ) ) )
 		{

--- a/cpp/src/command_classes/CRC16Encap.cpp
+++ b/cpp/src/command_classes/CRC16Encap.cpp
@@ -70,14 +70,14 @@ bool CRC16Encap::HandleMsg
 {
 	if( CRC16EncapCmd_Encap == (CRC16EncapCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received CRC16-command from node %d", GetNodeId());
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received CRC16-command from node %d", GetNodeId());
 
 		uint16 crcM = (_data[_length - 3] << 8) + _data[_length - 2] ; // crc as reported in msg
 		uint16 crcC = crc16(&_data[0], _length - 3 );				   // crc calculated
 
 		if ( crcM != crcC )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "CRC check failed, message contains 0x%.4x but should be 0x%.4x", crcM, crcC);
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "CRC check failed, message contains 0x%.4x but should be 0x%.4x", crcM, crcC);
 			return false;
 		}
 

--- a/cpp/src/command_classes/CentralScene.cpp
+++ b/cpp/src/command_classes/CentralScene.cpp
@@ -78,13 +78,13 @@ bool CentralScene::RequestState
 		Driver::MsgQueue const _queue
 )
 {
-	Log::Write(LogLevel_Info, GetNodeId(), "CentralScene RequestState: %d", _requestFlags);
+	Log::Write(LogLevel_Info, GetNodeId(), _instance, "CentralScene RequestState: %d", _requestFlags);
 	bool requests = false;
 	if( ( _requestFlags & RequestFlag_AfterMark ))
 	{
 			requests = RequestValue( _requestFlags, CentralSceneCmd_Capability_Get, _instance, _queue );
 	} else {
-		Log::Write(LogLevel_Info, GetNodeId(), "CentralScene: Not a StaticRequest");
+		Log::Write(LogLevel_Info, GetNodeId(), _instance, "CentralScene: Not a StaticRequest");
 	}
 	return requests;
 }
@@ -171,14 +171,14 @@ bool CentralScene::HandleMsg
 			when = 60 * _data[2];
 		else
 			when = 0;
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Central Scene set from node %d: scene id=%d in %d seconds. Sending event notification.", GetNodeId(), _data[3], when);
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Central Scene set from node %d: scene id=%d in %d seconds. Sending event notification.", GetNodeId(), _data[3], when);
 
 		if( ValueInt* value = static_cast<ValueInt*>( GetValue( _instance, _data[3] ) ) )
 		{
 			value->OnValueRefreshed( when );
 			value->Release();
 		} else {
-			Log::Write( LogLevel_Warning, GetNodeId(), "No ValueID created for Scene %d", _data[3]);
+			Log::Write( LogLevel_Warning, GetNodeId(), _instance, "No ValueID created for Scene %d", _data[3]);
 			return false;
 		}
 		return true;
@@ -196,7 +196,7 @@ bool CentralScene::HandleMsg
 			value->OnValueRefreshed(m_scenecount);
 			value->Release();
 		} else {
-			Log::Write( LogLevel_Warning, GetNodeId(), "Can't find ValueID for SceneCount");
+			Log::Write( LogLevel_Warning, GetNodeId(), _instance, "Can't find ValueID for SceneCount");
 		}
 
 		if( Node* node = GetNodeUnsafe() )
@@ -208,7 +208,7 @@ bool CentralScene::HandleMsg
 				}
 
 		} else {
-			Log::Write(LogLevel_Info, GetNodeId(), "CentralScene: Can't find Node!");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "CentralScene: Can't find Node!");
 		}
 	}
 

--- a/cpp/src/command_classes/ClimateControlSchedule.cpp
+++ b/cpp/src/command_classes/ClimateControlSchedule.cpp
@@ -174,11 +174,11 @@ bool ClimateControlSchedule::HandleMsg
 
 		if (day > 7) /* size of c_dayNames */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "Day Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Day Value was greater than range. Setting to Invalid");
 			day = 0;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received climate control schedule report for %s", c_dayNames[day] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received climate control schedule report for %s", c_dayNames[day] );
 
 		if( ValueSchedule* value = static_cast<ValueSchedule*>( GetValue( _instance, day ) ) )
 		{
@@ -200,15 +200,15 @@ bool ClimateControlSchedule::HandleMsg
 
 				if( setback == 0x79 )
 				{
-					Log::Write( LogLevel_Info, GetNodeId(), "  Switch point at %02d:%02d, Frost Protection Mode", hours, minutes, c_dayNames[day] );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Switch point at %02d:%02d, Frost Protection Mode", hours, minutes, c_dayNames[day] );
 				}
 				else if( setback == 0x7a )
 				{
-					Log::Write( LogLevel_Info, GetNodeId(), "  Switch point at %02d:%02d, Energy Saving Mode", hours, minutes, c_dayNames[day] );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Switch point at %02d:%02d, Energy Saving Mode", hours, minutes, c_dayNames[day] );
 				}
 				else
 				{
-					Log::Write( LogLevel_Info, GetNodeId(), "  Switch point at %02d:%02d, Setback %+.1fC", hours, minutes, ((float)setback)*0.1f );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Switch point at %02d:%02d, Setback %+.1fC", hours, minutes, ((float)setback)*0.1f );
 				}
 
 				value->SetSwitchPoint( hours, minutes, setback );
@@ -216,7 +216,7 @@ bool ClimateControlSchedule::HandleMsg
 
 			if( !value->GetNumSwitchPoints() )
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "  No Switch points have been set" );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "  No Switch points have been set" );
 			}
 
 			// Notify the user
@@ -229,7 +229,7 @@ bool ClimateControlSchedule::HandleMsg
 
 	if( ClimateControlScheduleCmd_ChangedReport == (ClimateControlScheduleCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received climate control schedule changed report:" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received climate control schedule changed report:" );
 
 		if( _data[1] )
 		{
@@ -240,7 +240,7 @@ bool ClimateControlSchedule::HandleMsg
 				// The schedule has changed and is not in override mode, so request reports for each day
 				for( int i=1; i<=7; ++i )
 				{
-					Log::Write(LogLevel_Info, GetNodeId(), "Get climate control schedule for %s", c_dayNames[i] );
+					Log::Write(LogLevel_Info, GetNodeId(), _instance, "Get climate control schedule for %s", c_dayNames[i] );
 
 					Msg* msg = new Msg( "ClimateControlScheduleCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 					msg->Append( GetNodeId() );
@@ -272,12 +272,12 @@ bool ClimateControlSchedule::HandleMsg
 		uint8 overrideState = _data[1] & 0x03;
 		if (overrideState > 3) /* size of c_overrideStateNames */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "overrideState Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "overrideState Value was greater than range. Setting to Invalid");
 			overrideState = 3;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received climate control schedule override report:" );
-		Log::Write( LogLevel_Info, GetNodeId(), "  Override State: %s:", c_overrideStateNames[overrideState] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received climate control schedule override report:" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Override State: %s:", c_overrideStateNames[overrideState] );
 
 		if( ValueList* valueList = static_cast<ValueList*>( GetValue( _instance, ClimateControlScheduleIndex_OverrideState ) ) )
 		{
@@ -290,15 +290,15 @@ bool ClimateControlSchedule::HandleMsg
 		{
 			if( setback == 0x79 )
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "  Override Setback: Frost Protection Mode" );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Override Setback: Frost Protection Mode" );
 			}
 			else if( setback == 0x7a )
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "  Override Setback: Energy Saving Mode" );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Override Setback: Energy Saving Mode" );
 			}
 			else
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "  Override Setback: %+.1fC", ((float)setback)*0.1f );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Override Setback: %+.1fC", ((float)setback)*0.1f );
 			}
 		}
 
@@ -332,7 +332,7 @@ bool ClimateControlSchedule::SetValue
 		// Set a schedule
 		ValueSchedule const* value = static_cast<ValueSchedule const*>(&_value);
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Set the climate control schedule for %s", c_dayNames[idx]);
+		Log::Write( LogLevel_Info, GetNodeId(), instance, "Set the climate control schedule for %s", c_dayNames[idx]);
 
 		Msg* msg = new Msg( "ClimateControlScheduleCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 		msg->SetInstance( this, instance );

--- a/cpp/src/command_classes/Clock.cpp
+++ b/cpp/src/command_classes/Clock.cpp
@@ -107,7 +107,7 @@ bool Clock::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ClockCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ClockCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -131,11 +131,11 @@ bool Clock::HandleMsg
 
 		if (day > 7) /* size of c_dayNames */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "Day Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Day Value was greater than range. Setting to Invalid");
 			day = 0;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Clock report: %s %.2d:%.2d", c_dayNames[day], hour, minute );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Clock report: %s %.2d:%.2d", c_dayNames[day], hour, minute );
 
 
 		if( ValueList* dayValue = static_cast<ValueList*>( GetValue( _instance, ClockIndex_Day ) ) )

--- a/cpp/src/command_classes/Color.cpp
+++ b/cpp/src/command_classes/Color.cpp
@@ -214,7 +214,7 @@ bool Color::RequestState
 		 * by the device
 		 */
 		if (m_refreshinprogress == true) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Color Refresh in progress");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Color Refresh in progress");
 			return false;
 		}
 
@@ -250,7 +250,7 @@ bool Color::RequestValue
 	{
 		if (m_coloridxbug && m_refreshinprogress == true)
 		{
-			Log::Write(LogLevel_Warning, GetNodeId(), "ColorRefresh is already in progress. Ignoring Get Request");
+			Log::Write(LogLevel_Warning, GetNodeId(), _instance, "ColorRefresh is already in progress. Ignoring Get Request");
 			return false;
 		}
 		for (int i = 0; i <= 9; i++) {
@@ -328,35 +328,35 @@ bool Color::HandleMsg
 	{
 		m_capabilities = (_data[1] + (_data[2] << 8));
 		string helpstr = "#RRGGBB";
-		Log::Write(LogLevel_Info, GetNodeId(), "Received an Color Capability Report: Capability=%xd", m_capabilities);
+		Log::Write(LogLevel_Info, GetNodeId(), _instance, "Received an Color Capability Report: Capability=%xd", m_capabilities);
 		if (m_capabilities & 0x04)
-			Log::Write(LogLevel_Info, GetNodeId(), "Red (0x02)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Red (0x02)");
 		if (m_capabilities & 0x08)
-			Log::Write(LogLevel_Info, GetNodeId(), "Green (0x03)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Green (0x03)");
 		if (m_capabilities & 0x10)
-			Log::Write(LogLevel_Info, GetNodeId(), "Blue (0x04)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Blue (0x04)");
 		if (m_capabilities & 0x01) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Warm White (0x00)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Warm White (0x00)");
 			helpstr += "WW";
 		}
 		if (m_capabilities & 0x02) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Cold White (0x01)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Cold White (0x01)");
 			helpstr += "CW";
 		}
 		if (m_capabilities & 0x20) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Amber (0x05)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Amber (0x05)");
 			helpstr += "AM";
 		}
 		if (m_capabilities & 0x40) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Cyan (0x06)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Cyan (0x06)");
 			helpstr += "CY";
 		}
 		if (m_capabilities & 0x80) {
-			Log::Write(LogLevel_Info, GetNodeId(), "Purple (0x07)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Purple (0x07)");
 			helpstr += "PR";
 		}
 		if (m_capabilities & 0x100)
-			Log::Write(LogLevel_Info, GetNodeId(), "Indexed Color (0x08)");
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Indexed Color (0x08)");
 		if( ValueInt* colorchannels = static_cast<ValueInt*>( GetValue( _instance, Value_Color_Channels_Capabilities ) ) )
 		{
 			colorchannels->OnValueRefreshed( m_capabilities );
@@ -516,7 +516,7 @@ bool Color::HandleMsg
 			 * don't put anything in our Color String
 			 */
 
-			Log::Write(LogLevel_Info, GetNodeId(), "Received a updated Color from Device: %s", ss.str().c_str() );
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Received a updated Color from Device: %s", ss.str().c_str() );
 			color->OnValueRefreshed( string(ss.str()) );
 			color->Release();
 

--- a/cpp/src/command_classes/Configuration.cpp
+++ b/cpp/src/command_classes/Configuration.cpp
@@ -107,7 +107,7 @@ bool Configuration::HandleMsg
 				}
 				default:
 				{
-					Log::Write( LogLevel_Info, GetNodeId(), "Invalid type (%d) for configuration parameter %d", value->GetID().GetType(), parameter );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Invalid type (%d) for configuration parameter %d", value->GetID().GetType(), parameter );
 				}
 			}
 			value->Release();
@@ -139,13 +139,13 @@ bool Configuration::HandleMsg
 					}
 					default:
 					{
-						Log::Write( LogLevel_Info, GetNodeId(), "Invalid size of %d bytes for configuration parameter %d", size, parameter );
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "Invalid size of %d bytes for configuration parameter %d", size, parameter );
 					}
 				}
 			}
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Configuration report: Parameter=%d, Value=%d", parameter, paramValue );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Configuration report: Parameter=%d, Value=%d", parameter, paramValue );
 		return true;
 	}
 
@@ -239,7 +239,7 @@ bool Configuration::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ConfigurationCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ConfigurationCmd_Get Not Supported on this node");
 	}
 	return false;
 }

--- a/cpp/src/command_classes/DeviceResetLocally.cpp
+++ b/cpp/src/command_classes/DeviceResetLocally.cpp
@@ -54,7 +54,7 @@ bool DeviceResetLocally::HandleMsg
 	if( DeviceResetLocallyCmd_Notification == _data[0] )
 	{
 		// device has been reset
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Device Reset Locally from node %d", GetNodeId() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Device Reset Locally from node %d", GetNodeId() );
 
 		// send a NoOperation message to the node, this will fail since the node is no longer included in the network
 		// we must do this because the Controller will only remove failed nodes

--- a/cpp/src/command_classes/DoorLock.cpp
+++ b/cpp/src/command_classes/DoorLock.cpp
@@ -257,7 +257,7 @@ bool DoorLock::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "DoorLockCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "DoorLockCmd_Get Not Supported on this node");
 		}
 	}
 	return false;
@@ -281,11 +281,11 @@ bool DoorLock::HandleMsg
 		uint8 lockState = (_data[1] == 0xFF) ? 6 : _data[1];
 		if (lockState > 6) /* size of c_LockStateNames minus Invalid Entry */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "LockState Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "LockState Value was greater than range. Setting to Invalid");
 			lockState = 7;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received DoorLock report: DoorLock is %s", c_LockStateNames[lockState] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received DoorLock report: DoorLock is %s", c_LockStateNames[lockState] );
 
 		if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, Value_Lock ) ) )
 		{
@@ -320,7 +320,7 @@ bool DoorLock::HandleMsg
 			  	m_timeoutsecs = _data[4];
 				break;
 			default:
-				Log::Write(LogLevel_Warning, GetNodeId(), "Received a Unsupported Door Lock Config Report %d", _data[1]);
+				Log::Write(LogLevel_Warning, GetNodeId(), _instance, "Received a Unsupported Door Lock Config Report %d", _data[1]);
 		}
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, Value_System_Config_OutsideHandles ) ) )
@@ -357,7 +357,7 @@ bool DoorLock::SetValue
 	{
 		ValueBool const* value = static_cast<ValueBool const*>(&_value);
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Value_Lock::Set - Requesting lock to be %s", value->GetValue() ? "Locked" : "Unlocked" );
+		Log::Write( LogLevel_Info, GetNodeId(), instance, "Value_Lock::Set - Requesting lock to be %s", value->GetValue() ? "Locked" : "Unlocked" );
 		Msg* msg = new Msg( "DoorLockCmd_Set",  GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 		msg->SetInstance( this, _value.GetID().GetInstance() );
 		msg->Append( GetNodeId() );
@@ -377,7 +377,7 @@ bool DoorLock::SetValue
 			return false;
 
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Value_Lock_Mode::Set - Requesting lock to be %s", item->m_label.c_str() );
+		Log::Write( LogLevel_Info, GetNodeId(), instance, "Value_Lock_Mode::Set - Requesting lock to be %s", item->m_label.c_str() );
 		Msg* msg = new Msg( "DoorLockCmd_Set",  GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 		msg->SetInstance( this, _value.GetID().GetInstance() );
 		msg->Append( GetNodeId() );
@@ -437,7 +437,7 @@ bool DoorLock::SetValue
 				}
 				break;
 			default:
-				Log::Write(LogLevel_Warning, GetNodeId(), "DoorLock::SetValue - Unhandled System_Config Variable %d", _value.GetID().GetIndex());
+				Log::Write(LogLevel_Warning, GetNodeId(), instance, "DoorLock::SetValue - Unhandled System_Config Variable %d", _value.GetID().GetIndex());
 				sendmsg = false;
 				break;
 		}
@@ -451,7 +451,7 @@ bool DoorLock::SetValue
 					m_timeoutsupported = item->m_value;
 			} else {
 				ok = false;
-				Log::Write(LogLevel_Warning, GetNodeId(), "Failed To Retrieve Value_System_Config_Mode For SetValue");
+				Log::Write(LogLevel_Warning, GetNodeId(), instance, "Failed To Retrieve Value_System_Config_Mode For SetValue");
 			}
 			uint8 control = 0;
 			if( ValueByte* value = static_cast<ValueByte*>( GetValue( instance, Value_System_Config_OutsideHandles ) ) )
@@ -460,7 +460,7 @@ bool DoorLock::SetValue
 				m_insidehandlemode = control;
 			} else {
 				ok = false;
-				Log::Write(LogLevel_Warning, GetNodeId(), "Failed To Retrieve Value_System_Config_OutsideHandles For SetValue");
+				Log::Write(LogLevel_Warning, GetNodeId(), instance, "Failed To Retrieve Value_System_Config_OutsideHandles For SetValue");
 			}
 			if( ValueByte* value = static_cast<ValueByte*>( GetValue( instance, Value_System_Config_InsideHandles ) ) )
 			{
@@ -468,7 +468,7 @@ bool DoorLock::SetValue
 				m_outsidehandlemode = (value->GetValue() & 0x0F);
 			} else {
 				ok = false;
-				Log::Write(LogLevel_Warning, GetNodeId(), "Failed To Retrieve Value_System_Config_InsideHandles For SetValue");
+				Log::Write(LogLevel_Warning, GetNodeId(), instance, "Failed To Retrieve Value_System_Config_InsideHandles For SetValue");
 			}
 			if( ValueInt* value = static_cast<ValueInt*>( GetValue( instance, Value_System_Config_Minutes ) ) )
 			{

--- a/cpp/src/command_classes/DoorLockLogging.cpp
+++ b/cpp/src/command_classes/DoorLockLogging.cpp
@@ -265,7 +265,7 @@ bool DoorLockLogging::HandleMsg
 
 	if( DoorLockLoggingCmd_RecordSupported_Report == (DoorLockLoggingCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received DoorLockLoggingCmd_RecordSupported_Report: Max Records is %d ", _data[1]);
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received DoorLockLoggingCmd_RecordSupported_Report: Max Records is %d ", _data[1]);
 		m_MaxRecords = _data[1];
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, Value_System_Config_MaxRecords ) ) )
 		{
@@ -281,7 +281,7 @@ bool DoorLockLogging::HandleMsg
 		if (EventType >= DoorLockEventType_Max)
 			EventType = DoorLockEventType_Max;
 
-		Log::Write (LogLevel_Info, GetNodeId(), "Received a DoorLockLogging Record %d which is \"%s\"", _data[1], c_DoorLockEventType[EventType-1]);
+		Log::Write (LogLevel_Info, GetNodeId(), _instance, "Received a DoorLockLogging Record %d which is \"%s\"", _data[1], c_DoorLockEventType[EventType-1]);
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, Value_GetRecordNo ) ) )
 		{

--- a/cpp/src/command_classes/EnergyProduction.cpp
+++ b/cpp/src/command_classes/EnergyProduction.cpp
@@ -97,13 +97,13 @@ bool EnergyProduction::RequestValue
 {
 	if (_valueEnum > EnergyProductionIndex_Time)
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "RequestValue _valueEnum was greater than range. Dropping");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "RequestValue _valueEnum was greater than range. Dropping");
 		return false;
 	}
 
 	if ( IsGetSupported() )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Requesting the %s value", c_energyParameterNames[_valueEnum] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Requesting the %s value", c_energyParameterNames[_valueEnum] );
 		Msg* msg = new Msg( "EnergyProductionCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 		msg->SetInstance( this, _instance );
 		msg->Append( GetNodeId() );
@@ -115,7 +115,7 @@ bool EnergyProduction::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "EnergyProductionCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "EnergyProductionCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -138,11 +138,11 @@ bool EnergyProduction::HandleMsg
 		uint8 paramType = _data[1];
 		if (paramType > 4) /* size of  c_energyParameterNames minus Invalid Entry*/
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "paramType Value was greater than range. Dropping Message");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "paramType Value was greater than range. Dropping Message");
 			return false;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received an Energy production report: %s = %s", c_energyParameterNames[_data[1]], value.c_str() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received an Energy production report: %s = %s", c_energyParameterNames[_data[1]], value.c_str() );
 		if( ValueDecimal* decimalValue = static_cast<ValueDecimal*>( GetValue( _instance, _data[1] ) ) )
 		{
 			decimalValue->OnValueRefreshed( value );

--- a/cpp/src/command_classes/Hail.cpp
+++ b/cpp/src/command_classes/Hail.cpp
@@ -56,7 +56,7 @@ bool Hail::HandleMsg
 	{
 		// We have received a hail from the Z-Wave device.
 		// Request an update of the dynamic values.
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Hail command from node %d", GetNodeId() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Hail command from node %d", GetNodeId() );
 		if( Node* node = GetNodeUnsafe() )
 		{
 			node->RequestDynamicValues();

--- a/cpp/src/command_classes/Indicator.cpp
+++ b/cpp/src/command_classes/Indicator.cpp
@@ -87,7 +87,7 @@ bool Indicator::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "IndicatorCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "IndicatorCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -106,7 +106,7 @@ bool Indicator::HandleMsg
 {
 	if( IndicatorCmd_Report == (IndicatorCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received an Indicator report: Indicator=%d", _data[1] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received an Indicator report: Indicator=%d", _data[1] );
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, 0 ) ) )
 		{
@@ -130,11 +130,12 @@ bool Indicator::SetValue
 {
 	if( ValueID::ValueType_Byte == _value.GetID().GetType() )
 	{
+                uint8 _instance = _value.GetID().GetInstance();
 		ValueByte const* value = static_cast<ValueByte const*>(&_value);
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Indicator::SetValue - Setting indicator to %d", value->GetValue());
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Indicator::SetValue - Setting indicator to %d", value->GetValue());
 		Msg* msg = new Msg( "IndicatorCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
-		msg->SetInstance( this, _value.GetID().GetInstance() );
+		msg->SetInstance( this, _instance );
 		msg->Append( GetNodeId() );
 		msg->Append( 3 );
 		msg->Append( GetCommandClassId() );

--- a/cpp/src/command_classes/Language.cpp
+++ b/cpp/src/command_classes/Language.cpp
@@ -97,7 +97,7 @@ bool Language::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "LanguageCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "LanguageCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -127,7 +127,7 @@ bool Language::HandleMsg
 		country[1] = _data[5];
 		country[2] = 0;
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Language report: Language=%s, Country=%s", language, country );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Language report: Language=%s, Country=%s", language, country );
 		ClearStaticRequest( StaticRequest_Values );
 
 		if( ValueString* languageValue = static_cast<ValueString*>( GetValue( _instance, LanguageIndex_Language ) ) )

--- a/cpp/src/command_classes/Lock.cpp
+++ b/cpp/src/command_classes/Lock.cpp
@@ -87,7 +87,7 @@ bool Lock::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "LockCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "LockCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -106,7 +106,7 @@ bool Lock::HandleMsg
 {
 	if( LockCmd_Report == (LockCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Lock report: Lock is %s", _data[1] ? "Locked" : "Unlocked" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Lock report: Lock is %s", _data[1] ? "Locked" : "Unlocked" );
 
 		if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, 0 ) ) )
 		{
@@ -130,11 +130,12 @@ bool Lock::SetValue
 {
 	if( ValueID::ValueType_Bool == _value.GetID().GetType() )
 	{
+                uint8 const _instance = _value.GetID().GetInstance();
 		ValueBool const* value = static_cast<ValueBool const*>(&_value);
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Lock::Set - Requesting lock to be %s", value->GetValue() ? "Locked" : "Unlocked" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Lock::Set - Requesting lock to be %s", value->GetValue() ? "Locked" : "Unlocked" );
 		Msg* msg = new Msg( "LockCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
-		msg->SetInstance( this, _value.GetID().GetInstance() );
+		msg->SetInstance( this, _instance );
 		msg->Append( GetNodeId() );
 		msg->Append( 3 );
 		msg->Append( GetCommandClassId() );

--- a/cpp/src/command_classes/ManufacturerSpecific.cpp
+++ b/cpp/src/command_classes/ManufacturerSpecific.cpp
@@ -100,7 +100,7 @@ bool ManufacturerSpecific::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ManufacturerSpecificCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ManufacturerSpecificCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -198,9 +198,9 @@ bool ManufacturerSpecific::HandleMsg
 				LoadConfigXML( node, configPath );
 			}
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received manufacturer specific report from node %d: Manufacturer=%s, Product=%s",
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received manufacturer specific report from node %d: Manufacturer=%s, Product=%s",
 				    GetNodeId(), node->GetManufacturerName().c_str(), node->GetProductName().c_str() );
-			Log::Write( LogLevel_Info, GetNodeId(), "Node Identity Codes: %.4x:%.4x:%.4x", manufacturerId, productType, productId );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Node Identity Codes: %.4x:%.4x:%.4x", manufacturerId, productType, productId );
 			ClearStaticRequest( StaticRequest_Values );
 			node->m_manufacturerSpecificClassReceived = true;
 		}

--- a/cpp/src/command_classes/Meter.cpp
+++ b/cpp/src/command_classes/Meter.cpp
@@ -188,7 +188,7 @@ bool Meter::RequestValue
 	bool res = false;
 	if ( !IsGetSupported())
 	{
-		Log::Write(  LogLevel_Info, GetNodeId(), "MeterCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "MeterCmd_Get Not Supported on this node");
 		return false;
 	}
 	for( uint8 i=0; i<8; ++i )
@@ -253,7 +253,7 @@ bool Meter::HandleSupportedReport
 	int8 meterType = (MeterType)(_data[1] & 0x1f);
 	if (meterType > 4) /* size of c_meterTypes */
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "meterType Value was greater than range. Dropping Message");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "meterType Value was greater than range. Dropping Message");
 		return false;
 	}
 
@@ -347,7 +347,7 @@ bool Meter::HandleSupportedReport
 			node->CreateValueButton( ValueID::ValueGenre_System, GetCommandClassId(), _instance, MeterIndex_Reset, "Reset", 0 );
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Meter supported report from node %d, %s", GetNodeId(), msg.c_str() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Meter supported report from node %d, %s", GetNodeId(), msg.c_str() );
 		return true;
 	}
 
@@ -384,7 +384,7 @@ bool Meter::HandleReport
 
 	if (scale > 7) /* size of c_electricityLabels, c_electricityUnits, c_gasUnits, c_waterUnits */
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "Scale was greater than range. Setting to Invalid");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale was greater than range. Setting to Invalid");
 		scale = 7;
 	}
 
@@ -397,7 +397,7 @@ bool Meter::HandleReport
 		int8 meterType = (MeterType)(_data[1] & 0x1f);
 		if (meterType > 4) /* size of c_meterTypes */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "meterType Value was greater than range. Dropping Message");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "meterType Value was greater than range. Dropping Message");
 			return false;
 		}
 
@@ -432,7 +432,7 @@ bool Meter::HandleReport
 
 		if( ValueDecimal* value = static_cast<ValueDecimal*>( GetValue( _instance, 0 ) ) )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Meter report from node %d: %s=%s%s", GetNodeId(), label.c_str(), valueStr.c_str(), units.c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Meter report from node %d: %s=%s%s", GetNodeId(), label.c_str(), valueStr.c_str(), units.c_str() );
 			value->SetLabel( label );
 			value->SetUnits( units );
 			value->OnValueRefreshed( valueStr );
@@ -456,7 +456,7 @@ bool Meter::HandleReport
 
 		if( ValueDecimal* value = static_cast<ValueDecimal*>( GetValue( _instance, baseIndex ) ) )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Meter report from node %d: %s%s=%s%s", GetNodeId(), exporting ? "Exporting ": "", value->GetLabel().c_str(), valueStr.c_str(), value->GetUnits().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Meter report from node %d: %s%s=%s%s", GetNodeId(), exporting ? "Exporting ": "", value->GetLabel().c_str(), valueStr.c_str(), value->GetUnits().c_str() );
 			value->OnValueRefreshed( valueStr );
 			if( value->GetPrecision() != precision )
 			{
@@ -485,7 +485,7 @@ bool Meter::HandleReport
 				{
 					precision = 0;
 					valueStr = ExtractValue( &_data[2], &scale, &precision, 3+size );
-					Log::Write( LogLevel_Info, GetNodeId(), "    Previous value was %s%s, received %d seconds ago.", valueStr.c_str(), previous->GetUnits().c_str(), delta );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Previous value was %s%s, received %d seconds ago.", valueStr.c_str(), previous->GetUnits().c_str(), delta );
 					previous->OnValueRefreshed( valueStr );
 					if( previous->GetPrecision() != precision )
 					{

--- a/cpp/src/command_classes/MeterPulse.cpp
+++ b/cpp/src/command_classes/MeterPulse.cpp
@@ -86,7 +86,7 @@ bool MeterPulse::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "MeterPulseCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "MeterPulseCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -111,7 +111,7 @@ bool MeterPulse::HandleMsg
 			count |= (uint32)_data[i+1];
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received a meter pulse count: Count=%d", count );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received a meter pulse count: Count=%d", count );
 		if( ValueInt* value = static_cast<ValueInt*>( GetValue( _instance, 0 ) ) )
 		{
 			value->OnValueRefreshed( count );

--- a/cpp/src/command_classes/MultiChannelAssociation.cpp
+++ b/cpp/src/command_classes/MultiChannelAssociation.cpp
@@ -233,7 +233,7 @@ bool MultiChannelAssociation::HandleMsg
 			// Retrieve the number of groups this device supports.
 			// The groups will be queried with the session data.
 			m_numGroups = _data[1];
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association Groupings report from node %d. Number of groups is %d", GetNodeId(), m_numGroups );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Multi Instance Association Groupings report from node %d. Number of groups is %d", GetNodeId(), m_numGroups );
 			ClearStaticRequest( StaticRequest_Values );
 			handled = true;
 		}
@@ -256,8 +256,8 @@ bool MultiChannelAssociation::HandleMsg
 					//   instance #
 					//   node D
 					//   instance #
-					Log::Write( LogLevel_Info, GetNodeId(), "Received Multi Instance Association report from node %d, group %d", GetNodeId(), groupIdx );
-					Log::Write( LogLevel_Info, GetNodeId(), "  The group contains:" );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Multi Instance Association report from node %d, group %d", GetNodeId(), groupIdx );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "  The group contains:" );
 					bool pastMarker = false;
 					for( i=0; i < _length-5; ++i )
 					{	
@@ -269,7 +269,7 @@ bool MultiChannelAssociation::HandleMsg
 						{
 							if (!pastMarker)
 							{
-								Log::Write( LogLevel_Info, GetNodeId(), "    Node %d",  _data[i+4] );
+								Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Node %d",  _data[i+4] );
 								InstanceAssociation association;
 								association.m_nodeId=_data[i+4];
 								association.m_instance=0x00;
@@ -277,7 +277,7 @@ bool MultiChannelAssociation::HandleMsg
 							} 
 							else 
 							{
-								Log::Write( LogLevel_Info, GetNodeId(), "    Node %d instance %d",  _data[i+4], _data[i+5] );
+								Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Node %d instance %d",  _data[i+4], _data[i+5] );
 								InstanceAssociation association;
 								association.m_nodeId=_data[i+4];
 								association.m_instance=_data[i+5];								
@@ -291,7 +291,7 @@ bool MultiChannelAssociation::HandleMsg
 				if( numReportsToFollow )
 				{
 					// We're expecting more reports for this group
-					Log::Write( LogLevel_Info, GetNodeId(), "%d more association reports expected for node %d, group %d", numReportsToFollow, GetNodeId(), groupIdx );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "%d more association reports expected for node %d, group %d", numReportsToFollow, GetNodeId(), groupIdx );
 					return true;
 				}
 				else
@@ -314,7 +314,7 @@ bool MultiChannelAssociation::HandleMsg
 			else
 			{
 				// maxAssociations is zero, so we've reached the end of the query process
-				Log::Write( LogLevel_Info, GetNodeId(), "Max associations for node %d, group %d is zero.  Querying associations for this node is complete.", GetNodeId(), groupIdx );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Max associations for node %d, group %d is zero.  Querying associations for this node is complete.", GetNodeId(), groupIdx );
 				node->AutoAssociate();
 				m_queryAll = false;
 			}
@@ -337,7 +337,7 @@ bool MultiChannelAssociation::HandleMsg
 				else
 				{
 					// We're all done
-					Log::Write( LogLevel_Info, GetNodeId(), "Querying associations for node %d is complete.", GetNodeId() );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Querying associations for node %d is complete.", GetNodeId() );
 					node->AutoAssociate();
 					m_queryAll = false;
 				}
@@ -398,7 +398,7 @@ void MultiChannelAssociation::Set
 		_instance = 0x01;
 	}
 
-	Log::Write( LogLevel_Info, GetNodeId(), "MultiChannelAssociation::Set - Adding instance %d on node %d to group %d of node %d", 
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "MultiChannelAssociation::Set - Adding instance %d on node %d to group %d of node %d", 
 	           _instance, _targetNodeId, _groupIdx, GetNodeId() );
 
 	if ( _instance == 0x00 )
@@ -440,7 +440,7 @@ void MultiChannelAssociation::Remove
  	uint8 _instance
 )
 {
-	Log::Write( LogLevel_Info, GetNodeId(), "MultiChannelAssociation::Remove - Removing instance %d on node %d from group %d of node %d",
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "MultiChannelAssociation::Remove - Removing instance %d on node %d from group %d of node %d",
 	           _instance, _targetNodeId, _groupIdx, GetNodeId());
 
 	if ( _instance == 0x00 )

--- a/cpp/src/command_classes/MultiCmd.cpp
+++ b/cpp/src/command_classes/MultiCmd.cpp
@@ -49,7 +49,7 @@ bool MultiCmd::HandleMsg
 {
 	if( MultiCmdCmd_Encap == (MultiCmdCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received encapsulated multi-command from node %d", GetNodeId() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received encapsulated multi-command from node %d", GetNodeId() );
 
 		if( Node const* node = GetNodeUnsafe() )
 		{
@@ -69,7 +69,7 @@ bool MultiCmd::HandleMsg
 			}
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "End of encapsulated multi-command from node %d", GetNodeId() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "End of encapsulated multi-command from node %d", GetNodeId() );
 		return true;
 	}
 	return false;

--- a/cpp/src/command_classes/MultiInstance.cpp
+++ b/cpp/src/command_classes/MultiInstance.cpp
@@ -346,7 +346,7 @@ void MultiInstance::HandleMultiInstanceEncap
 
 		if( CommandClass* pCommandClass = node->GetCommandClass( commandClassId ) )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received a MultiInstanceEncap from node %d, instance %d, for Command Class %s", GetNodeId(), instance, pCommandClass->GetCommandClassName().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), instance, "Received a MultiInstanceEncap from node %d, instance %d, for Command Class %s", GetNodeId(), instance, pCommandClass->GetCommandClassName().c_str() );
 			pCommandClass->ReceivedCntIncr();
 			pCommandClass->HandleMsg( &_data[3], _length-3, instance );
 		}

--- a/cpp/src/command_classes/NoOperation.cpp
+++ b/cpp/src/command_classes/NoOperation.cpp
@@ -47,7 +47,7 @@ bool NoOperation::HandleMsg
 )
 {
 	// We have received a no operation from the Z-Wave device.
-	Log::Write( LogLevel_Info, GetNodeId(), "Received NoOperation command from node %d", GetNodeId() );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received NoOperation command from node %d", GetNodeId() );
 	return true;
 }
 

--- a/cpp/src/command_classes/NodeNaming.cpp
+++ b/cpp/src/command_classes/NodeNaming.cpp
@@ -259,7 +259,7 @@ bool NodeNaming::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "NodeNamingCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "NodeNamingCmd_Get Not Supported on this node");
 		}
 		return false;
 	}
@@ -300,7 +300,7 @@ bool NodeNaming::HandleMsg
 			{
 				// We only overwrite the name if it is empty
 				node->m_nodeName = name;
-				Log::Write( LogLevel_Info, GetNodeId(), "Received the name: %s.", name.c_str() );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received the name: %s.", name.c_str() );
 				updated = true;
 			}
 		}
@@ -311,7 +311,7 @@ bool NodeNaming::HandleMsg
 			{
 				// We only overwrite the location if it is empty
 				node->m_location = location;
-				Log::Write( LogLevel_Info, GetNodeId(), "Received the location: %s.", location.c_str() );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received the location: %s.", location.c_str() );
 				updated = true;
 			}
 		}

--- a/cpp/src/command_classes/Powerlevel.cpp
+++ b/cpp/src/command_classes/Powerlevel.cpp
@@ -134,7 +134,7 @@ bool Powerlevel::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "Powerlevel_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "Powerlevel_Get Not Supported on this node");
 		}
 	}
 	return false;
@@ -156,12 +156,12 @@ bool Powerlevel::HandleMsg
 		PowerLevelEnum powerLevel = (PowerLevelEnum)_data[1];
 		if (powerLevel > 9) /* size of c_powerLevelNames minus Unknown*/
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "powerLevel Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "powerLevel Value was greater than range. Setting to Invalid");
 			powerLevel = (PowerLevelEnum)10;
 		}
 		uint8 timeout = _data[2];
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received a PowerLevel report: PowerLevel=%s, Timeout=%d", c_powerLevelNames[powerLevel], timeout );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received a PowerLevel report: PowerLevel=%s, Timeout=%d", c_powerLevelNames[powerLevel], timeout );
 		if( ValueList* value = static_cast<ValueList*>( GetValue( _instance, PowerlevelIndex_Powerlevel ) ) )
 		{
 			value->OnValueRefreshed( (int)powerLevel );
@@ -183,11 +183,11 @@ bool Powerlevel::HandleMsg
 
 		if (status > 2) /* size of c_powerLevelStatusNames minus Unknown */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "status Value was greater than range. Setting to Unknown");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "status Value was greater than range. Setting to Unknown");
 			status = (PowerLevelStatusEnum)3;
 		}
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received a PowerLevel Test Node report: Test Node=%d, Status=%s, Test Frame ACK Count=%d", testNode, c_powerLevelStatusNames[status], ackCount );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received a PowerLevel Test Node report: Test Node=%d, Status=%s, Test Frame ACK Count=%d", testNode, c_powerLevelStatusNames[status], ackCount );
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, PowerlevelIndex_TestNode ) ) )
 		{
 			value->OnValueRefreshed( testNode );
@@ -354,13 +354,13 @@ bool Powerlevel::Set
 	}
 	if (powerLevel > 9) /* size of c_powerLevelNames minus Unknown */
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "powerLevel Value was greater than range. Dropping");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "powerLevel Value was greater than range. Dropping");
 		/* Drop it */
 		return false;
 	}
 
 
-	Log::Write( LogLevel_Info, GetNodeId(), "Setting the power level to %s for %d seconds", c_powerLevelNames[powerLevel], timeout );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "Setting the power level to %s for %d seconds", c_powerLevelNames[powerLevel], timeout );
 	Msg* msg = new Msg( "PowerlevelCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );
@@ -420,12 +420,12 @@ bool Powerlevel::Test
 	}
 	if (powerLevel > 9) /* size of c_powerLevelNames minus Unknown */
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "powerLevel Value was greater than range. Dropping");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "powerLevel Value was greater than range. Dropping");
 		return false;
 	}
 
 
-	Log::Write( LogLevel_Info, GetNodeId(), "Running a Power Level Test: Target Node = %d, Power Level = %s, Number of Frames = %d", testNodeId, c_powerLevelNames[powerLevel], numFrames );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "Running a Power Level Test: Target Node = %d, Power Level = %s, Number of Frames = %d", testNodeId, c_powerLevelNames[powerLevel], numFrames );
 	Msg* msg = new Msg( "PowerlevelCmd_TestNodeSet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );
@@ -450,7 +450,7 @@ bool Powerlevel::Report
 	uint8 const _instance
 )
 {
-	Log::Write( LogLevel_Info, GetNodeId(), "Power Level Report" );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "Power Level Report" );
 	Msg* msg = new Msg( "PowerlevelCmd_TestNodeGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );

--- a/cpp/src/command_classes/Protection.cpp
+++ b/cpp/src/command_classes/Protection.cpp
@@ -97,7 +97,7 @@ bool Protection::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ProtectionCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ProtectionCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -118,10 +118,10 @@ bool Protection::HandleMsg
 		int8 stateValue = _data[1];
 		if (stateValue > 2) /* size of c_protectionStateNames minus Invalid */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "State Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "State Value was greater than range. Setting to Invalid");
 			stateValue = 3;
 		}
-		Log::Write( LogLevel_Info, GetNodeId(), "Received a Protection report: %s", c_protectionStateNames[_data[1]] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received a Protection report: %s", c_protectionStateNames[_data[1]] );
 		if( ValueList* value = static_cast<ValueList*>( GetValue( _instance, 0 ) ) )
 		{
 			value->OnValueRefreshed( (int)_data[1] );

--- a/cpp/src/command_classes/SceneActivation.cpp
+++ b/cpp/src/command_classes/SceneActivation.cpp
@@ -65,7 +65,7 @@ bool SceneActivation::HandleMsg
 			snprintf( msg, sizeof(msg), "%d minutes", _data[2] );
 		else
 			snprintf( msg, sizeof(msg), "via configuration" );
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Scene Activation set from node %d: scene id=%d %s. Sending event notification.", GetNodeId(), _data[1], msg );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Scene Activation set from node %d: scene id=%d %s. Sending event notification.", GetNodeId(), _data[1], msg );
 		Notification* notification = new Notification( Notification::Type_SceneEvent );
 		notification->SetHomeAndNodeIds( GetHomeId(), GetNodeId() );
 		notification->SetSceneId( _data[1] );

--- a/cpp/src/command_classes/Security.cpp
+++ b/cpp/src/command_classes/Security.cpp
@@ -166,7 +166,7 @@ bool Security::RequestValue
 		Driver::MsgQueue const _queue
 )
 {
-	Log::Write(LogLevel_Info, GetNodeId(), "Got a RequestValue Call");
+	Log::Write(LogLevel_Info, GetNodeId(), _instance, "Got a RequestValue Call");
 	return true;
 }
 
@@ -209,7 +209,7 @@ bool Security::HandleMsg
 			 * This means we must do a SecurityCmd_SupportedGet request ASAP so we dont have
 			 * Command Classes created after the Discovery Phase is completed!
 			 */
-			Log::Write(LogLevel_Info, GetNodeId(), "Received SecurityCmd_SupportedReport from node %d", GetNodeId() );
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Received SecurityCmd_SupportedReport from node %d", GetNodeId() );
 			m_secured = true;
 			if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, 0 ) ) )
 			{
@@ -221,10 +221,10 @@ bool Security::HandleMsg
 		}
 		case SecurityCmd_SchemeReport:
 		{
-			Log::Write(LogLevel_Info, GetNodeId(), "Received SecurityCmd_SchemeReport from node %d: %d", GetNodeId(), _data[1]);
+			Log::Write(LogLevel_Info, GetNodeId(), _instance, "Received SecurityCmd_SchemeReport from node %d: %d", GetNodeId(), _data[1]);
 			uint8 schemes = _data[1];
 			if (m_schemeagreed == true) {
-				Log::Write(LogLevel_Warning, GetNodeId(), "   Already Received a SecurityCmd_SchemeReport from the node. Ignoring");
+				Log::Write(LogLevel_Warning, GetNodeId(), _instance, "   Already Received a SecurityCmd_SchemeReport from the node. Ignoring");
 				break;
 			}
 			if( schemes == SecurityScheme_Zero )
@@ -232,7 +232,7 @@ bool Security::HandleMsg
 				/* We're good to go.  We now should send our NetworkKey to the device if this is the first
 				 * time we have seen it
 				 */
-				Log::Write(LogLevel_Info, GetNodeId(), "    Security scheme agreed." );
+				Log::Write(LogLevel_Info, GetNodeId(), _instance, "    Security scheme agreed." );
 				/* create the NetworkKey Packet. EncryptMessage will encrypt it for us (And request the NONCE) */
 				Msg * msg = new Msg ("SecurityCmd_NetworkKeySet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 				msg->Append( GetNodeId() );
@@ -251,7 +251,7 @@ bool Security::HandleMsg
 				/* No common security scheme.  The device should continue as an unsecured node.
 				 * but Some Command Classes might not be present...
 				 */
-				Log::Write(LogLevel_Warning,  GetNodeId(), "    No common security scheme.  The device will continue as an unsecured node." );
+				Log::Write(LogLevel_Warning,  GetNodeId(), _instance, "    No common security scheme.  The device will continue as an unsecured node." );
 			}
 			break;
 		}
@@ -260,7 +260,7 @@ bool Security::HandleMsg
 			/* we shouldn't get a NetworkKeySet from a node if we are the controller
 			 * as we send it out to the Devices
 			 */
-			Log::Write(LogLevel_Info,  GetNodeId(), "Received SecurityCmd_NetworkKeySet from node %d", GetNodeId() );
+			Log::Write(LogLevel_Info,  GetNodeId(), _instance, "Received SecurityCmd_NetworkKeySet from node %d", GetNodeId() );
 			break;
 		}
 		case SecurityCmd_NetworkKeyVerify:
@@ -268,7 +268,7 @@ bool Security::HandleMsg
 			/* if we can decrypt this packet, then we are assured that our NetworkKeySet is successfull
 			 * and thus should set the Flag referenced in SecurityCmd_SchemeReport
 			 */
-			Log::Write(LogLevel_Info,  GetNodeId(), "Received SecurityCmd_NetworkKeyVerify from node %d", GetNodeId() );
+			Log::Write(LogLevel_Info,  GetNodeId(), _instance, "Received SecurityCmd_NetworkKeyVerify from node %d", GetNodeId() );
 			/* now as for our SupportedGet */
 			Msg* msg = new Msg( "SecurityCmd_SupportedGet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 			msg->Append( GetNodeId() );
@@ -286,7 +286,7 @@ bool Security::HandleMsg
 			/* only used in a Controller Replication Type enviroment.
 			 *
 			 */
-			Log::Write(LogLevel_Info,  GetNodeId(), "Received SecurityCmd_SchemeInherit from node %d", GetNodeId() );
+			Log::Write(LogLevel_Info,  GetNodeId(), _instance, "Received SecurityCmd_SchemeInherit from node %d", GetNodeId() );
 			break;
 		}
 		/* the rest of these should be handled by the Driver Code (in Driver::ProcessMsg) */
@@ -295,7 +295,7 @@ bool Security::HandleMsg
 		case SecurityCmd_MessageEncap:
 		case SecurityCmd_MessageEncapNonceGet:
 		{
-			Log::Write(LogLevel_Warning, GetNodeId(), "Received a Security Message that should have been handled in the Driver");
+			Log::Write(LogLevel_Warning, GetNodeId(), _instance, "Recieved a Security Message that should have been handled in the Driver");
 			break;
 		}
 		default:

--- a/cpp/src/command_classes/SensorAlarm.cpp
+++ b/cpp/src/command_classes/SensorAlarm.cpp
@@ -145,7 +145,7 @@ bool SensorAlarm::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "SensorAlarmCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SensorAlarmCmd_Get Not Supported on this node");
 		}
 	}
 	return false;
@@ -173,7 +173,7 @@ bool SensorAlarm::HandleMsg
 
 			value->OnValueRefreshed( state );
 			value->Release();
-			Log::Write( LogLevel_Info, GetNodeId(), "Received alarm state report from node %d: %s = %d", sourceNodeId, value->GetLabel().c_str(), state );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received alarm state report from node %d: %s = %d", sourceNodeId, value->GetLabel().c_str(), state );
 		}
 
 		return true;
@@ -184,7 +184,7 @@ bool SensorAlarm::HandleMsg
 		if( Node* node = GetNodeUnsafe() )
 		{
 			// We have received the supported alarm types from the Z-Wave device
-			Log::Write( LogLevel_Info, GetNodeId(), "Received supported alarm types" );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received supported alarm types" );
 
 			// Parse the data for the supported alarm types
 			uint8 numBytes = _data[1];
@@ -199,7 +199,7 @@ bool SensorAlarm::HandleMsg
 						if( index < SensorAlarm_Count )
 						{
 						  	node->CreateValueByte( ValueID::ValueGenre_User, GetCommandClassId(), _instance, index, c_alarmTypeName[index], "", true, false, 0, 0 );
-							Log::Write( LogLevel_Info, GetNodeId(), "    Added alarm type: %s", c_alarmTypeName[index] );
+							Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added alarm type: %s", c_alarmTypeName[index] );
 						}
 					}
 				}

--- a/cpp/src/command_classes/SensorBinary.cpp
+++ b/cpp/src/command_classes/SensorBinary.cpp
@@ -146,7 +146,7 @@ bool SensorBinary::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SensorBinaryCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SensorBinaryCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -168,7 +168,7 @@ bool SensorBinary::HandleMsg
 	    {
 	        uint8 index = m_sensorsMap[_data[2]];
 
-            Log::Write( LogLevel_Info, GetNodeId(), "Received SensorBinary report: Sensor:%d State=%s", _data[2], _data[1] ? "On" : "Off" );
+            Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SensorBinary report: Sensor:%d State=%s", _data[2], _data[1] ? "On" : "Off" );
 
             if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, index ) ) )
             {
@@ -180,7 +180,7 @@ bool SensorBinary::HandleMsg
 	    }
 	    else
 	    {
-            Log::Write( LogLevel_Info, GetNodeId(), "Received SensorBinary report: State=%s", _data[1] ? "On" : "Off" );
+            Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SensorBinary report: State=%s", _data[1] ? "On" : "Off" );
 
             if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, 0 ) ) )
             {

--- a/cpp/src/command_classes/SensorMultilevel.cpp
+++ b/cpp/src/command_classes/SensorMultilevel.cpp
@@ -220,7 +220,7 @@ bool SensorMultilevel::RequestValue
 {
 	bool res = false;
 	if ( !IsGetSupported() ) {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SensorMultilevelCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SensorMultilevelCmd_Get Not Supported on this node");
 		return false;
 	}
 	if( GetVersion() < 5 )
@@ -287,7 +287,7 @@ bool SensorMultilevel::HandleMsg
 						uint8 index = ( ( i - 1 ) * 8 ) + j + 1;
 						if (index >= SensorType_MaxType) /* max size for c_sensorTypeNames */
 						{
-							Log::Write (LogLevel_Warning, GetNodeId(), "SensorType Value was greater than range. Dropping");
+							Log::Write (LogLevel_Warning, GetNodeId(), _instance, "SensorType Value was greater than range. Dropping");
 							continue;
 						}
 						msg += c_sensorTypeNames[index];
@@ -300,7 +300,7 @@ bool SensorMultilevel::HandleMsg
 				}
 			}
 		}
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SensorMultiLevel supported report from node %d: %s", GetNodeId(), msg.c_str() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SensorMultiLevel supported report from node %d: %s", GetNodeId(), msg.c_str() );
 	}
 	else if (SensorMultilevelCmd_Report == (SensorMultilevelCmd)_data[0])
 	{
@@ -336,7 +336,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_TankCapacity: {
 					if (scale > 2) /* size of c_tankCapcityUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_tankCapcityUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_tankCapcityUnits was greater than range. Setting to empty");
 						units = c_tankCapcityUnits[3]; /* empty entry */
 					}
 					else
@@ -348,7 +348,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_Distance: {
 					if (scale > 2) /* size of c_distanceUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_distanceUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_distanceUnits was greater than range. Setting to empty");
 						units = c_distanceUnits[3]; /* empty entry */
 					}
 					else
@@ -360,7 +360,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_AnglePosition: {
 					if (scale > 2) /* size of c_anglePositionUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_anglePositionUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_anglePositionUnits was greater than range. Setting to empty");
 						units = c_anglePositionUnits[3]; /* empty entry */
 					}
 					else
@@ -375,7 +375,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_SeismicIntensity: {
 					if (scale > 3) /* size of c_seismicIntensityUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_seismicIntensityUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_seismicIntensityUnits was greater than range. Setting to empty");
 						units = c_seismicIntensityUnits[4]; /* empty entry */
 					}
 					else
@@ -387,7 +387,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_SeismicMagnitude: {
 					if (scale > 3) /* size of c_seismicMagnitudeUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_seismicMagnitudeUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_seismicMagnitudeUnits was greater than range. Setting to empty");
 						units = c_seismicMagnitudeUnits[4]; /* empty entry */
 					}
 					else
@@ -403,7 +403,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_Moisture: {
 					if (scale > 3) /* size of c_moistureUnits minus invalid */
 					{
-						Log::Write (LogLevel_Warning, GetNodeId(), "Scale Value for c_moistureUnits was greater than range. Setting to empty");
+						Log::Write (LogLevel_Warning, GetNodeId(), _instance, "Scale Value for c_moistureUnits was greater than range. Setting to empty");
 						units = c_moistureUnits[4]; /* empty entry */
 					}
 					else
@@ -413,7 +413,7 @@ bool SensorMultilevel::HandleMsg
 				}
 				break;
 				default: {
-					Log::Write (LogLevel_Warning, GetNodeId(), "sensorType Value was greater than range. Dropping");
+					Log::Write (LogLevel_Warning, GetNodeId(), _instance, "sensorType Value was greater than range. Dropping");
 					return false;
 				}
 				break;
@@ -431,7 +431,7 @@ bool SensorMultilevel::HandleMsg
 				value->SetUnits(units);
 			}
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received SensorMultiLevel report from node %d, instance %d, %s: value=%s%s", GetNodeId(), _instance, c_sensorTypeNames[sensorType], valueStr.c_str(), value->GetUnits().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SensorMultiLevel report from node %d, instance %d, %s: value=%s%s", GetNodeId(), _instance, c_sensorTypeNames[sensorType], valueStr.c_str(), value->GetUnits().c_str() );
 			if( value->GetPrecision() != precision )
 			{
 				value->SetPrecision( precision );

--- a/cpp/src/command_classes/SwitchAll.cpp
+++ b/cpp/src/command_classes/SwitchAll.cpp
@@ -97,7 +97,7 @@ bool SwitchAll::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SwitchAllCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SwitchAllCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -120,9 +120,9 @@ bool SwitchAll::HandleMsg
 			value->OnValueRefreshed( (int32)_data[1] );
 			value->Release();
 			if (value->GetItem())
-				Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchAll report from node %d: %s", GetNodeId(), value->GetItem()->m_label.c_str() );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchAll report from node %d: %s", GetNodeId(), value->GetItem()->m_label.c_str() );
 			else
-				Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchAll report from node %d: %d", GetNodeId(), _data[1]);
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchAll report from node %d: %d", GetNodeId(), _data[1]);
 		}
  		return true;
 	}

--- a/cpp/src/command_classes/SwitchBinary.cpp
+++ b/cpp/src/command_classes/SwitchBinary.cpp
@@ -88,7 +88,7 @@ bool SwitchBinary::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SwitchBinaryCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SwitchBinaryCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -106,7 +106,7 @@ bool SwitchBinary::HandleMsg
 {
 	if (SwitchBinaryCmd_Report == (SwitchBinaryCmd)_data[0])
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchBinary report from node %d: level=%s", GetNodeId(), _data[1] ? "On" : "Off" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchBinary report from node %d: level=%s", GetNodeId(), _data[1] ? "On" : "Off" );
 
 		if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, 0 ) ) )
 		{

--- a/cpp/src/command_classes/SwitchMultilevel.cpp
+++ b/cpp/src/command_classes/SwitchMultilevel.cpp
@@ -149,7 +149,7 @@ bool SwitchMultilevel::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "SwitchMultilevelCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SwitchMultilevelCmd_Get Not Supported on this node");
 		}
 	}
 	return false;
@@ -168,7 +168,7 @@ bool SwitchMultilevel::HandleMsg
 {
 	if( SwitchMultilevelCmd_Report == (SwitchMultilevelCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchMultiLevel report: level=%d", _data[1] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchMultiLevel report: level=%d", _data[1] );
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Level ) ) )
 		{
@@ -186,17 +186,17 @@ bool SwitchMultilevel::HandleMsg
 		uint8 switchtype2label = switchType2;
 		if (switchtype1label > 7) /* size of c_switchLabelsPos, c_switchLabelsNeg */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "switchtype1label Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "switchtype1label Value was greater than range. Setting to Invalid");
 			switchtype1label = 0;
 		}
 		if (switchtype2label > 7) /* sizeof c_switchLabelsPos, c_switchLabelsNeg */
 		{
-			Log::Write (LogLevel_Warning, GetNodeId(), "switchtype2label Value was greater than range. Setting to Invalid");
+			Log::Write (LogLevel_Warning, GetNodeId(), _instance, "switchtype2label Value was greater than range. Setting to Invalid");
 			switchtype2label = 0;
 		}
 
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchMultiLevel supported report: Switch1=%s/%s, Switch2=%s/%s", c_switchLabelsPos[switchtype1label], c_switchLabelsNeg[switchtype1label], c_switchLabelsPos[switchtype2label], c_switchLabelsNeg[switchtype2label] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchMultiLevel supported report: Switch1=%s/%s, Switch2=%s/%s", c_switchLabelsPos[switchtype1label], c_switchLabelsNeg[switchtype1label], c_switchLabelsPos[switchtype2label], c_switchLabelsNeg[switchtype2label] );
 		ClearStaticRequest( StaticRequest_Version );
 
 		// Set the labels on the values
@@ -442,7 +442,7 @@ bool SwitchMultilevel::SetLevel
 	uint8 const _level
 )
 {
-	Log::Write( LogLevel_Info, GetNodeId(), "SwitchMultilevel::Set - Setting to level %d", _level );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "SwitchMultilevel::Set - Setting to level %d", _level );
 	Msg* msg = new Msg( "SwitchMultilevelCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );
@@ -453,15 +453,15 @@ bool SwitchMultilevel::SetLevel
 		durationValue->Release();
 		if( duration == 0xff )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "  Duration: Default" );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Duration: Default" );
 		}
 		else if( duration >= 0x80 )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "  Duration: %d minutes", duration - 0x7f );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Duration: %d minutes", duration - 0x7f );
 		}
 		else
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "  Duration: %d seconds", duration );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Duration: %d seconds", duration );
 		}
 
 		msg->Append( 4 );
@@ -493,16 +493,16 @@ bool SwitchMultilevel::StartLevelChange
 	SwitchMultilevelDirection const _direction
 )
 {
-	Log::Write( LogLevel_Info, GetNodeId(), "SwitchMultilevel::StartLevelChange - Starting a level change" );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "SwitchMultilevel::StartLevelChange - Starting a level change" );
 
 	uint8 length = 4;
 	if (_direction > 3) /* size of  c_directionParams, c_directionDebugLabels */
 	{
-		Log::Write (LogLevel_Warning, GetNodeId(), "_direction Value was greater than range. Dropping");
+		Log::Write (LogLevel_Warning, GetNodeId(), _instance, "_direction Value was greater than range. Dropping");
 		return false;
 	}
 	uint8 direction = c_directionParams[_direction];
-	Log::Write( LogLevel_Info, GetNodeId(), "  Direction:          %s", c_directionDebugLabels[_direction] );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Direction:          %s", c_directionDebugLabels[_direction] );
 
 	if( ValueBool* ignoreStartLevel = static_cast<ValueBool*>( GetValue( _instance, SwitchMultilevelIndex_IgnoreStartLevel ) ) )
 	{
@@ -513,7 +513,7 @@ bool SwitchMultilevel::StartLevelChange
 		}
 		ignoreStartLevel->Release();
 	}
-	Log::Write( LogLevel_Info, GetNodeId(), "  Ignore Start Level: %s", (direction & 0x20) ? "True" : "False" );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Ignore Start Level: %s", (direction & 0x20) ? "True" : "False" );
 
 	uint8 startLevel = 0;
 	if( ValueByte* startLevelValue = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_StartLevel ) ) )
@@ -521,7 +521,7 @@ bool SwitchMultilevel::StartLevelChange
 		startLevel = startLevelValue->GetValue();
 		startLevelValue->Release();
 	}
-	Log::Write( LogLevel_Info, GetNodeId(), "  Start Level:        %d", startLevel );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Start Level:        %d", startLevel );
 
 	uint8 duration = 0;
 	if( ValueByte* durationValue = static_cast<ValueByte*>( GetValue( _instance, SwitchMultilevelIndex_Duration ) ) )
@@ -529,7 +529,7 @@ bool SwitchMultilevel::StartLevelChange
 		length = 5;
 		duration = durationValue->GetValue();
 		durationValue->Release();
-		Log::Write( LogLevel_Info, GetNodeId(), "  Duration:           %d", duration );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Duration:           %d", duration );
 	}
 
 	uint8 step = 0;
@@ -540,7 +540,7 @@ bool SwitchMultilevel::StartLevelChange
 			length = 6;
 			step = stepValue->GetValue();
 			stepValue->Release();
-			Log::Write( LogLevel_Info, GetNodeId(), "  Step Size:          %d", step );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "  Step Size:          %d", step );
 		}
 	}
 
@@ -584,7 +584,7 @@ bool SwitchMultilevel::StopLevelChange
 	uint8 const _instance
 )
 {
-	Log::Write( LogLevel_Info, GetNodeId(), "SwitchMultilevel::StopLevelChange - Stopping the level change" );
+	Log::Write( LogLevel_Info, GetNodeId(), _instance, "SwitchMultilevel::StopLevelChange - Stopping the level change" );
 	Msg* msg = new Msg( "SwitchMultilevelCmd_StopLevelChange", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true );
 	msg->SetInstance( this, _instance );
 	msg->Append( GetNodeId() );

--- a/cpp/src/command_classes/SwitchToggleBinary.cpp
+++ b/cpp/src/command_classes/SwitchToggleBinary.cpp
@@ -87,7 +87,7 @@ bool SwitchToggleBinary::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SwitchToggleBinaryCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SwitchToggleBinaryCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -105,7 +105,7 @@ bool SwitchToggleBinary::HandleMsg
 {
 	if( SwitchToggleBinaryCmd_Report == (SwitchToggleBinaryCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchToggleBinary report: %s", _data[1] ? "On" : "Off" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchToggleBinary report: %s", _data[1] ? "On" : "Off" );
 
 		if( ValueBool* value = static_cast<ValueBool*>( GetValue( _instance, 0 ) ) )
 		{

--- a/cpp/src/command_classes/SwitchToggleMultilevel.cpp
+++ b/cpp/src/command_classes/SwitchToggleMultilevel.cpp
@@ -90,7 +90,7 @@ bool SwitchToggleMultilevel::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "SwitchToggleMultilevelCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "SwitchToggleMultilevelCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -108,7 +108,7 @@ bool SwitchToggleMultilevel::HandleMsg
 {
 	if( SwitchToggleMultilevelCmd_Report == (SwitchToggleMultilevelCmd)_data[0] )
 	{
-		Log::Write( LogLevel_Info, GetNodeId(), "Received SwitchToggleMultiLevel report: level=%d", _data[1] );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received SwitchToggleMultiLevel report: level=%d", _data[1] );
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, 0 ) ) )
 		{

--- a/cpp/src/command_classes/ThermostatFanMode.cpp
+++ b/cpp/src/command_classes/ThermostatFanMode.cpp
@@ -212,7 +212,7 @@ bool ThermostatFanMode::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "ThermostatFanModeCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ThermostatFanModeCmd_Get Not Supported on this node");
 		}
 	}
 	return false;
@@ -249,19 +249,19 @@ bool ThermostatFanMode::HandleMsg
 			{
 				valueList->OnValueRefreshed( (int32)_data[1] );
 				if (valueList->GetItem())
-					Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat fan mode: %s", valueList->GetItem()->m_label.c_str() );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat fan mode: %s", valueList->GetItem()->m_label.c_str() );
 				else
-					Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat fan mode: %d", _data[1]);
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat fan mode: %d", _data[1]);
 				valueList->Release();
 			}
 			else
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat fan mode: index %d", mode );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat fan mode: index %d", mode );
 			}
 		}
 		else
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received unknown thermostat fan mode: %d", mode );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received unknown thermostat fan mode: %d", mode );
 		}
 		return true;
 	}
@@ -269,7 +269,7 @@ bool ThermostatFanMode::HandleMsg
 	if( ThermostatFanModeCmd_SupportedReport == (ThermostatFanModeCmd)_data[0] )
 	{
 		// We have received the supported thermostat fan modes from the Z-Wave device
-		Log::Write( LogLevel_Info, GetNodeId(), "Received supported thermostat fan modes" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received supported thermostat fan modes" );
 
 		m_supportedModes.clear();
 		for( uint32 i=1; i<_length-1; ++i )
@@ -284,14 +284,14 @@ bool ThermostatFanMode::HandleMsg
 					/* Minus 1 here as the Unknown Entry is our addition */
 					if ((size_t)item.m_value >= (sizeof(c_modeName)/sizeof(*c_modeName) -1))
 					{
-						Log::Write( LogLevel_Info, GetNodeId(), "Received unknown fan mode: 0x%x", item.m_value);
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received unknown fan mode: 0x%x", item.m_value);
 					}
 					else
 					{
 						item.m_label = c_modeName[item.m_value];
 						m_supportedModes.push_back( item );
 
-						Log::Write( LogLevel_Info, GetNodeId(), "    Added fan mode: %s", c_modeName[item.m_value].c_str() );
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added fan mode: %s", c_modeName[item.m_value].c_str() );
 					}
 				}
 			}

--- a/cpp/src/command_classes/ThermostatFanState.cpp
+++ b/cpp/src/command_classes/ThermostatFanState.cpp
@@ -107,7 +107,7 @@ bool ThermostatFanState::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ThermostatFanStateCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ThermostatFanStateCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -133,7 +133,7 @@ bool ThermostatFanState::HandleMsg
 
 			valueString->OnValueRefreshed( c_stateName[state] );
 			valueString->Release();
-			Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat fan state: %s", valueString->GetValue().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat fan state: %s", valueString->GetValue().c_str() );
 		}
 		return true;
 	}

--- a/cpp/src/command_classes/ThermostatMode.cpp
+++ b/cpp/src/command_classes/ThermostatMode.cpp
@@ -223,7 +223,7 @@ bool ThermostatMode::RequestValue
 			GetDriver()->SendMsg( msg, _queue );
 			return true;
 		} else {
-			Log::Write(  LogLevel_Info, GetNodeId(), "ThermostatModeCmd_Get Not Supported on this node");
+			Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ThermostatModeCmd_Get Not Supported on this node");
 
 		}
 	}
@@ -261,19 +261,19 @@ bool ThermostatMode::HandleMsg
 			{
 				valueList->OnValueRefreshed( mode );
 				if (valueList->GetItem())
-					Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat mode: %s", valueList->GetItem()->m_label.c_str() );
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat mode: %s", valueList->GetItem()->m_label.c_str() );
 				else
-					Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat mode: %d", mode);
+					Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat mode: %d", mode);
 				valueList->Release();
 			}
 			else
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat mode: index %d", mode );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat mode: index %d", mode );
 			}
 		}
 		else
 		{
-			 Log::Write( LogLevel_Info, GetNodeId(), "Received unknown thermostat mode: index %d", mode );
+			 Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received unknown thermostat mode: index %d", mode );
 		}
 		return true;
 	}
@@ -283,7 +283,7 @@ bool ThermostatMode::HandleMsg
 		// We have received the supported thermostat modes from the Z-Wave device
 		// these values are used to populate m_supportedModes which, in turn, is used to "seed" the values
 		// for each m_modes instance
-		Log::Write( LogLevel_Info, GetNodeId(), "Received supported thermostat modes" );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received supported thermostat modes" );
 
 		m_supportedModes.clear();
 		for( uint32 i=1; i<_length-1; ++i )
@@ -297,14 +297,14 @@ bool ThermostatMode::HandleMsg
 					/* minus 1 in the sizeof calc here, as the Unknown entry is our addition */
 					if ((size_t)item.m_value >= (sizeof(c_modeName)/sizeof(*c_modeName) -1))
 					{
-						Log::Write( LogLevel_Info, GetNodeId(), "Received unknown thermostat mode: 0x%x", item.m_value);
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received unknown thermostat mode: 0x%x", item.m_value);
 					}
 					else
 					{
 						item.m_label = c_modeName[item.m_value];
 						m_supportedModes.push_back( item );
 
-						Log::Write( LogLevel_Info, GetNodeId(), "    Added mode: %s", c_modeName[item.m_value] );
+						Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added mode: %s", c_modeName[item.m_value] );
 					}
 				}
 			}

--- a/cpp/src/command_classes/ThermostatOperatingState.cpp
+++ b/cpp/src/command_classes/ThermostatOperatingState.cpp
@@ -105,7 +105,7 @@ bool ThermostatOperatingState::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ThermostatOperatingStateCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ThermostatOperatingStateCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -129,7 +129,7 @@ bool ThermostatOperatingState::HandleMsg
 			/* no need bounds checking on c_stateName here, as it can only be 1 Byte anyway */
 			valueString->OnValueRefreshed( c_stateName[_data[1]&0x0f] );
 			valueString->Release();
-			Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat operating state: %s", valueString->GetValue().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat operating state: %s", valueString->GetValue().c_str() );
 		}
 		return true;
 	}

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -188,7 +188,7 @@ bool ThermostatSetpoint::RequestValue
 	}
 	if ( !IsGetSupported() )
 	{
-		Log::Write(  LogLevel_Info, GetNodeId(), "ThermostatSetpointCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ThermostatSetpointCmd_Get Not Supported on this node");
 		return false;
 	}
 	Value* value = GetValue( 1, _setPointIndex );
@@ -238,7 +238,7 @@ bool ThermostatSetpoint::HandleMsg
 			}
 			value->Release();
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received thermostat setpoint report: Setpoint %s = %s%s", value->GetLabel().c_str(), value->GetValue().c_str(), value->GetUnits().c_str() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received thermostat setpoint report: Setpoint %s = %s%s", value->GetLabel().c_str(), value->GetValue().c_str(), value->GetUnits().c_str() );
 		}
 		return true;
 	}
@@ -248,7 +248,7 @@ bool ThermostatSetpoint::HandleMsg
 		if( Node* node = GetNodeUnsafe() )
 		{
 			// We have received the supported thermostat setpoints from the Z-Wave device
-			Log::Write( LogLevel_Info, GetNodeId(), "Received supported thermostat setpoints" );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received supported thermostat setpoints" );
 
 			// Parse the data for the supported setpoints
 			for( uint32 i=1; i<_length-1; ++i )
@@ -262,7 +262,7 @@ bool ThermostatSetpoint::HandleMsg
 						if( index < ThermostatSetpoint_Count )
 						{
 						  	node->CreateValueDecimal( ValueID::ValueGenre_User, GetCommandClassId(), _instance, index, c_setpointName[index], "C", false, false, "0.0", 0 );
-							Log::Write( LogLevel_Info, GetNodeId(), "    Added setpoint: %s", c_setpointName[index] );
+							Log::Write( LogLevel_Info, GetNodeId(), _instance, "    Added setpoint: %s", c_setpointName[index] );
 						}
 					}
 				}

--- a/cpp/src/command_classes/TimeParameters.cpp
+++ b/cpp/src/command_classes/TimeParameters.cpp
@@ -113,7 +113,7 @@ bool TimeParameters::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "TimeParametersCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "TimeParametersCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -138,7 +138,7 @@ bool TimeParameters::HandleMsg
 		uint8 minute = (_data[6] & 0x3F);
 		uint8 second = (_data[7] & 0x3F);
 
-		Log::Write( LogLevel_Info, GetNodeId(), "Received TimeParameters report: %02d/%02d/%04d %02d:%02d:%02d", (int)day, (int)month, (int)year, (int)hour, (int)minute, (int)second);
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received TimeParameters report: %02d/%02d/%04d %02d:%02d:%02d", (int)day, (int)month, (int)year, (int)hour, (int)minute, (int)second);
 		if( ValueString* value = static_cast<ValueString*>( GetValue( _instance, TimeParametersIndex_Date ) ) )
 		{
 			char msg[512];

--- a/cpp/src/command_classes/UserCode.cpp
+++ b/cpp/src/command_classes/UserCode.cpp
@@ -158,7 +158,7 @@ bool UserCode::RequestValue
 	}
 	if ( !IsGetSupported() )
 	{
-		Log::Write(  LogLevel_Info, GetNodeId(), "UserNumberCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "UserNumberCmd_Get Not Supported on this node");
 		return false;
 	}
 	if( _userCodeIdx == UserCodeIndex_Count )
@@ -175,7 +175,7 @@ bool UserCode::RequestValue
 	}
 	if (_userCodeIdx == 0)
 	{
-		Log::Write( LogLevel_Warning, GetNodeId(), "UserCodeCmd_Get with Index 0 not Supported");
+		Log::Write( LogLevel_Warning, GetNodeId(), _instance, "UserCodeCmd_Get with Index 0 not Supported");
 		return false;
 	}
 	Msg* msg = new Msg( "UserCodeCmd_Get", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
@@ -211,11 +211,11 @@ bool UserCode::HandleMsg
 		ClearStaticRequest( StaticRequest_Values );
 		if( m_userCodeCount == 0 )
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received User Number report from node %d: Not supported", GetNodeId() );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received User Number report from node %d: Not supported", GetNodeId() );
 		}
 		else
 		{
-			Log::Write( LogLevel_Info, GetNodeId(), "Received User Number report from node %d: Supported Codes %d (%d)", GetNodeId(), m_userCodeCount, _data[1] );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received User Number report from node %d: Supported Codes %d (%d)", GetNodeId(), m_userCodeCount, _data[1] );
 		}
 
 		if( ValueByte* value = static_cast<ValueByte*>( GetValue( _instance, UserCodeIndex_Count ) ) )
@@ -255,10 +255,10 @@ bool UserCode::HandleMsg
 			int8 size = _length - 4;
 			if( size > UserCodeLength )
 			{
-				Log::Write( LogLevel_Warning, GetNodeId(), "User Code length %d is larger then maximum %d", size, UserCodeLength );
+				Log::Write( LogLevel_Warning, GetNodeId(), _instance, "User Code length %d is larger then maximum %d", size, UserCodeLength );
 				size = UserCodeLength;
 			}
-			Log::Write( LogLevel_Info, GetNodeId(), "User Code Packet is %d", size );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "User Code Packet is %d", size );
 			m_userCodesStatus[i] = _data[2];
 			if (size > 0) {
 				memcpy( data, &_data[3], size );
@@ -269,7 +269,7 @@ bool UserCode::HandleMsg
 			value->OnValueRefreshed( data, size );
 			value->Release();
 		}
-		Log::Write( LogLevel_Info, GetNodeId(), "Received User Code Report from node %d for User Code %d (%s)", GetNodeId(), i, CodeStatus( _data[2] ).c_str() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received User Code Report from node %d for User Code %d (%s)", GetNodeId(), i, CodeStatus( _data[2] ).c_str() );
 		if( m_queryAll && i == m_currentCode )
 		{
 
@@ -286,7 +286,7 @@ bool UserCode::HandleMsg
 					Options::Get()->GetOptionAsBool("RefreshAllUserCodes", &m_refreshUserCodes );
 				}
 			} else {
-				Log::Write( LogLevel_Info, GetNodeId(), "Not Requesting additional UserCode Slots as RefreshAllUserCodes is false, and slot %d is available", i);
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Not Requesting additional UserCode Slots as RefreshAllUserCodes is false, and slot %d is available", i);
 				m_queryAll = false;
 			}
 		}

--- a/cpp/src/command_classes/Version.cpp
+++ b/cpp/src/command_classes/Version.cpp
@@ -151,7 +151,7 @@ bool Version::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "VersionCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "VersionCmd_Get Not Supported on this node");
 	}
 	return false;
 }
@@ -179,7 +179,7 @@ bool Version::HandleMsg
 			snprintf( protocol, sizeof(protocol), "%d.%.2d", _data[2], _data[3] );
 			snprintf( application, sizeof(application), "%d.%.2d", _data[4], _data[5] );
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Version report from node %d: Library=%s, Protocol=%s, Application=%s", GetNodeId(), library, protocol, application );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Version report from node %d: Library=%s, Protocol=%s, Application=%s", GetNodeId(), library, protocol, application );
 			ClearStaticRequest( StaticRequest_Values );
 
 			if( ValueString* libraryValue = static_cast<ValueString*>( GetValue( _instance, VersionIndex_Library ) ) )
@@ -205,7 +205,7 @@ bool Version::HandleMsg
 		{
 			if( CommandClass* pCommandClass = node->GetCommandClass( _data[1] ) )
 			{
-				Log::Write( LogLevel_Info, GetNodeId(), "Received Command Class Version report from node %d: CommandClass=%s, Version=%d", GetNodeId(), pCommandClass->GetCommandClassName().c_str(), _data[2] );
+				Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Command Class Version report from node %d: CommandClass=%s, Version=%d", GetNodeId(), pCommandClass->GetCommandClassName().c_str(), _data[2] );
 				pCommandClass->ClearStaticRequest( StaticRequest_Version );
 				pCommandClass->SetVersion( _data[2] );
 			}

--- a/cpp/src/command_classes/WakeUp.cpp
+++ b/cpp/src/command_classes/WakeUp.cpp
@@ -209,7 +209,7 @@ bool WakeUp::HandleMsg
 			if( _length < 6 )
 			{
 				Log::Write( LogLevel_Warning, "" );
-				Log::Write( LogLevel_Warning, GetNodeId(), "Unusual response: WakeUpCmd_IntervalReport with len = %d.  Ignored.", _length );
+				Log::Write( LogLevel_Warning, GetNodeId(), _instance, "Unusual response: WakeUpCmd_IntervalReport with len = %d.  Ignored.", _length );
 				value->Release();
 				return false;
 			}
@@ -220,7 +220,7 @@ bool WakeUp::HandleMsg
 
 			uint8 targetNodeId = _data[4];
 
-			Log::Write( LogLevel_Info, GetNodeId(), "Received Wakeup Interval report from node %d: Interval=%d, Target Node=%d", GetNodeId(), interval, targetNodeId );
+			Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Wakeup Interval report from node %d: Interval=%d, Target Node=%d", GetNodeId(), interval, targetNodeId );
 
 			value->OnValueRefreshed( (int32)interval );
 
@@ -239,7 +239,7 @@ bool WakeUp::HandleMsg
 	else if( WakeUpCmd_Notification == (WakeUpCmd)_data[0] )
 	{
 		// The device is awake.
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Wakeup Notification from node %d", GetNodeId() );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Wakeup Notification from node %d", GetNodeId() );
 		SetAwake( true );
 		return true;
 	}
@@ -249,7 +249,7 @@ bool WakeUp::HandleMsg
 		uint32 maxinterval = (((uint32)_data[4]) << 16) | (((uint32)_data[5]) << 8) | ((uint32)_data[6]);
 		uint32 definterval = (((uint32)_data[7]) << 16) | (((uint32)_data[8]) << 8) | ((uint32)_data[9]);
 		uint32 stepinterval = (((uint32)_data[10]) << 16) | (((uint32)_data[11]) << 8) | ((uint32)_data[12]);
-		Log::Write( LogLevel_Info, GetNodeId(), "Received Wakeup Interval Capability report from node %d: Min Interval=%d, Max Interval=%d, Default Interval=%d, Interval Step=%d", GetNodeId(), mininterval, maxinterval, definterval, stepinterval );
+		Log::Write( LogLevel_Info, GetNodeId(), _instance, "Received Wakeup Interval Capability report from node %d: Min Interval=%d, Max Interval=%d, Default Interval=%d, Interval Step=%d", GetNodeId(), mininterval, maxinterval, definterval, stepinterval );
 		if( ValueInt* value = static_cast<ValueInt*>( GetValue( _instance, 1 ) ) )
 		{
 			value->OnValueRefreshed( (int32)mininterval );

--- a/cpp/src/command_classes/ZWavePlusInfo.cpp
+++ b/cpp/src/command_classes/ZWavePlusInfo.cpp
@@ -116,7 +116,7 @@ bool ZWavePlusInfo::RequestValue
 		GetDriver()->SendMsg( msg, _queue );
 		return true;
 	} else {
-		Log::Write(  LogLevel_Info, GetNodeId(), "ZWavePlusInfoCmd_Get Not Supported on this node");
+		Log::Write(  LogLevel_Info, GetNodeId(), _instance, "ZWavePlusInfoCmd_Get Not Supported on this node");
 	}
 	return false;
 }

--- a/cpp/src/platform/Log.cpp
+++ b/cpp/src/platform/Log.cpp
@@ -260,6 +260,25 @@ void Log::Write
 }
 
 //-----------------------------------------------------------------------------
+//      <Log::Write>
+//      Write to the log
+//-----------------------------------------------------------------------------
+void Log::Write(LogLevel _level, uint8 const _nodeId, uint8 const _instance, char const* _format, ...) {
+  if( s_instance && s_dologging && s_instance->m_pImpl ) {
+    if( _level != LogLevel_Internal ) {
+      s_instance->m_logMutex->Lock();
+    }
+    va_list args;
+    va_start( args, _format );
+    s_instance->m_pImpl->Write( _level, _nodeId, _instance, _format, args );
+    va_end( args );
+    if( _level != LogLevel_Internal ) {
+      s_instance->m_logMutex->Unlock();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
 //	<Log::QueueDump>
 //	Send queued messages to the log (and empty the queue)
 //-----------------------------------------------------------------------------

--- a/cpp/src/platform/Log.h
+++ b/cpp/src/platform/Log.h
@@ -61,6 +61,7 @@ namespace OpenZWave
 		i_LogImpl() { } ;
 		virtual ~i_LogImpl() { } ;
 		virtual void Write( LogLevel _level, uint8 const _nodeId, char const* _format, va_list _args ) = 0;
+		virtual void Write( LogLevel _level, uint8 const _nodeId, uint8 const _instance, char const* _format, va_list _args ) = 0;
 		virtual void QueueDump() = 0;
 		virtual void QueueClear() = 0;
 		virtual void SetLoggingState( LogLevel _saveLevel, LogLevel _queueLevel, LogLevel _dumpTrigger ) = 0;
@@ -164,6 +165,18 @@ namespace OpenZWave
 		 * \see Create, Destroy
 		 */
 		static void Write( LogLevel _level, uint8 const _nodeId, char const* _format, ... );
+
+                /**
+                 * Write an entry to the log.
+                 * Writes a formatted string to the log.
+                 * \param _level        Specifies the type of log message (Error, Warning, Debug, etc.)
+                 * \param _nodeId       Node Id this entry is about.
+                 * \param _instance     instance Id this entry is about.
+                 * \param _format.  A string formatted in the same manner as used with printf etc.
+                 * \param ... a variable number of arguments, to be included in the formatted string.
+                 * \see Create, Destroy
+                 */
+                static void Write( LogLevel _level, uint8 const _nodeId, uint8 const _instance, char const* _format, ... );
 
 		/**
 		 * Send the queued log messages to the log output.

--- a/cpp/src/platform/unix/LogImpl.h
+++ b/cpp/src/platform/unix/LogImpl.h
@@ -46,6 +46,7 @@ namespace OpenZWave
 		~LogImpl();
 
 		void Write( LogLevel _level, uint8 const _nodeId, char const* _format, va_list _args );
+		void Write( LogLevel _level, uint8 const _nodeId, uint8 const _instance, char const* _format, va_list _args );
 		void Queue( char const* _buffer );
 		void QueueDump();
 		void QueueClear();
@@ -54,6 +55,7 @@ namespace OpenZWave
 
 		string GetTimeStampString();
 		string GetNodeString( uint8 const _nodeId );
+		string GetNodeString( uint8 const _nodeId, uint8 const _instance );
 		string GetThreadId();
 		string GetLogLevelString(LogLevel _level);
 		unsigned int toEscapeCode(LogLevel _level);

--- a/cpp/src/platform/winRT/LogImpl.cpp
+++ b/cpp/src/platform/winRT/LogImpl.cpp
@@ -113,6 +113,88 @@ LogImpl::~LogImpl
 {
 }
 
+/-----------------------------------------------------------------------------
+//      <LogImpl::Write>
+//      Write to the log
+//-----------------------------------------------------------------------------
+void LogImpl::Write
+(
+        LogLevel _logLevel,
+        uint8 const _nodeId,
+        uint8 const _instance,
+        char const* _format,
+        va_list _args
+)
+{
+        // create a timestamp string
+        string timeStr = GetTimeStampString();
+        string nodeStr = GetNodeString( _nodeId, _instance );
+        string logLevelStr = GetLogLevelString(_logLevel);
+
+        // handle this message
+        if( (_logLevel <= m_queueLevel) || (_logLevel == LogLevel_Internal) )   // we're going to do something with this message...
+        {
+                char lineBuf[1024];
+                if( !_format || ( _format[0] == 0 ) )
+                {
+                        strcpy_s( lineBuf, 1024, "" );
+                }
+                else
+                {
+                        vsprintf_s( lineBuf, sizeof(lineBuf), _format, _args );
+                }
+
+                // should this message be saved to file (and possibly written to console?)
+                if( (_logLevel <= m_saveLevel) || (_logLevel == LogLevel_Internal) )
+                {
+                        // save to file
+                        FILE* pFile = NULL;
+                        if( !fopen_s( &pFile, m_filename.c_str(), "a" ) || m_bConsoleOutput )
+                        {
+                                if( _logLevel != LogLevel_Internal )                                            // don't add a second timestamp to display of queued messages
+                                {
+                                        if( pFile != NULL )
+                                        {
+                                                fprintf( pFile, "%s%s%s", timeStr.c_str(), logLevelStr.c_str(), nodeStr.c_str() );
+                                        }
+                                        if( m_bConsoleOutput )
+                                        {
+                                                printf( "%s%s%s", timeStr.c_str(), logLevelStr.c_str(), nodeStr.c_str() );
+                                        }
+                                }
+
+                                // print message to file (and possibly screen)
+                                if( pFile != NULL )
+                                {
+                                        fprintf( pFile, "%s", lineBuf );
+                                        fprintf( pFile, "\n" );
+                                        fclose( pFile );
+                                }
+                                if( m_bConsoleOutput )
+                                {
+                                        printf( "%s", lineBuf );
+                                        printf( "\n" );
+                                }
+
+                        }
+                }
+
+                if( _logLevel != LogLevel_Internal )
+                {
+                        char queueBuf[1024];
+                        string threadStr = GetThreadId();
+                        sprintf_s( queueBuf, sizeof(queueBuf), "%s%s%s", timeStr.c_str(), threadStr.c_str(), lineBuf );
+                        Queue( queueBuf );
+                }
+        }
+
+        // now check to see if the _dumpTrigger has been hit
+        if( (_logLevel <= m_dumpTrigger) && (_logLevel != LogLevel_Internal) && (_logLevel != LogLevel_Always) )
+        {
+                QueueDump();
+        }
+}
+
 //-----------------------------------------------------------------------------
 //	<LogImpl::Write>
 //	Write to the log
@@ -303,6 +385,33 @@ string LogImpl::GetNodeString
 			snprintf( buf, sizeof(buf), "Node%03d, ", _nodeId );
 			return buf;
 		}
+}
+
+//-----------------------------------------------------------------------------
+//      <LogImpl::GetNodeString>
+//      Generate a string with formatted node id
+//-----------------------------------------------------------------------------
+string LogImpl::GetNodeString
+(
+        uint8 const _nodeId,
+        uint8 const _instance
+)
+{
+        if( _nodeId == 0 )
+        {
+                return "";
+        }
+        else
+                if( _nodeId == 255 ) // should make distinction between broadcast and controller better for SwitchAll broadcast
+                {
+                        return "contrlr, ";
+                }
+                else
+                {
+                        char buf[20];
+                        snprintf( buf, sizeof(buf), "Node%03d:%03d, ", _nodeId );
+                        return buf;
+                }
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/platform/windows/LogImpl.h
+++ b/cpp/src/platform/windows/LogImpl.h
@@ -46,6 +46,7 @@ namespace OpenZWave
 		~LogImpl();
 
 		void Write( LogLevel _level, uint8 const _nodeId, char const* _format, va_list _args );
+		void Write( LogLevel _level, uint8 const _nodeId, uint8 const _instance, char const* _format, va_list _args );
 		void Queue( char const* _buffer );
 		void QueueDump();
 		void QueueClear();

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -366,7 +366,9 @@ bool Value::Set
 		{
 			if( CommandClass* cc = node->GetCommandClass( m_id.GetCommandClassId() ) )
 			{
-				Log::Write(LogLevel_Info, m_id.GetNodeId(), "Value::Set - %s - %s - %d - %d - %s", cc->GetCommandClassName().c_str(), this->GetLabel().c_str(), m_id.GetIndex(), m_id.GetInstance(), this->GetAsString().c_str());
+                                uint8 const _instance = m_id.GetInstance();
+
+				Log::Write(LogLevel_Info, m_id.GetNodeId(), _instance, "Value::Set - %s - %s - %d - %d - %s", cc->GetCommandClassName().c_str(), this->GetLabel().c_str(), m_id.GetIndex(), _instance, this->GetAsString().c_str());
 				// flag value as set and queue a "Set Value" message for transmission to the device
 				res = cc->SetValue( *this );
 
@@ -574,9 +576,11 @@ int Value::VerifyRefreshedValue
 	// focus on the actual variable storage, we should be able to accomplish this with
 	// memory functions.  It's really the strings that make things complicated(?).
 	// if this is the first read of a value, assume it is valid (and notify as a change)
+        uint8 const _instance = m_id.GetInstance();
+
 	if( !IsSet() )
 	{
-		Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Initial read of value" );
+		Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Initial read of value" );
 		Value::OnValueChanged();
 		return 2;		// confirmed change of value
 	}
@@ -587,39 +591,39 @@ int Value::VerifyRefreshedValue
 			case ValueID::ValueType_Button:			// Button is stored as a bool
 			case ValueID::ValueType_Bool:			// bool
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%s, new value=%s, type=%s", *((bool*)_originalValue)?"true":"false", *((uint8*)_newValue)?"true":"false", GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%s, new value=%s, type=%s", *((bool*)_originalValue)?"true":"false", *((uint8*)_newValue)?"true":"false", GetTypeNameFromEnum(_type) );
 				break;
 			}
 			case ValueID::ValueType_Byte:			// byte
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%d, new value=%d, type=%s", *((uint8*)_originalValue), *((uint8*)_newValue), GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%d, new value=%d, type=%s", *((uint8*)_originalValue), *((uint8*)_newValue), GetTypeNameFromEnum(_type) );
 				break;
 			}
 			case ValueID::ValueType_Decimal:		// decimal is stored as a string, so treat it as a string here
 			case ValueID::ValueType_String:			// string
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%s, new value=%s, type=%s", ((string*)_originalValue)->c_str(), ((string*)_newValue)->c_str(), GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%s, new value=%s, type=%s", ((string*)_originalValue)->c_str(), ((string*)_newValue)->c_str(), GetTypeNameFromEnum(_type) );
 				break;
 			}
 			case ValueID::ValueType_Short:			// short
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%d, new value=%d, type=%s", *((short*)_originalValue), *((short*)_newValue), GetTypeNameFromEnum(_type));
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%d, new value=%d, type=%s", *((short*)_originalValue), *((short*)_newValue), GetTypeNameFromEnum(_type));
 				break;
 			}
 			case ValueID::ValueType_List:			// List Type is treated as a int32
 			case ValueID::ValueType_Int:			// int32
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%d, new value=%d, type=%s", *((int32*)_originalValue), *((int32*)_newValue), GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%d, new value=%d, type=%s", *((int32*)_originalValue), *((int32*)_newValue), GetTypeNameFromEnum(_type) );
 				break;
 			}
 			case ValueID::ValueType_Raw:			// raw
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%x, new value=%x, type=%s", _originalValue, _newValue, GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%x, new value=%x, type=%s", _originalValue, _newValue, GetTypeNameFromEnum(_type) );
 				break;
 			}
 			case ValueID::ValueType_Schedule:		// Schedule Type
 			{
-				Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Refreshed Value: old value=%s, new value=%s, type=%s", _originalValue, _newValue, GetTypeNameFromEnum(_type) );
+				Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Refreshed Value: old value=%s, new value=%s, type=%s", _originalValue, _newValue, GetTypeNameFromEnum(_type) );
 				/* we cant support verifyChanges yet... so always unset this */
 				m_verifyChanges = false;
 				break;
@@ -630,7 +634,7 @@ int Value::VerifyRefreshedValue
 
 	// check whether changes in this value should be verified (since some devices will report values that always
 	// change, where confirming changes is difficult or impossible)
-	Log::Write( LogLevel_Detail, m_id.GetNodeId(), "Changes to this value are %sverified", m_verifyChanges ? "" : "not " );
+	Log::Write( LogLevel_Detail, m_id.GetNodeId(), _instance, "Changes to this value are %sverified", m_verifyChanges ? "" : "not " );
 
 	if( !m_verifyChanges )
 	{
@@ -680,7 +684,7 @@ int Value::VerifyRefreshedValue
 		}
 
 		// values are different, so flag this as a verification refresh and queue it
-		Log::Write( LogLevel_Info, m_id.GetNodeId(), "Changed value (possible)--rechecking" );
+		Log::Write( LogLevel_Info, m_id.GetNodeId(), _instance, "Changed value (possible)--rechecking" );
 		SetCheckingChange( true );
 		Manager::Get()->RefreshValue( GetID() );
 		return 1;				// value has changed (to be confirmed)
@@ -718,7 +722,7 @@ int Value::VerifyRefreshedValue
 		}
 		if( bCheckEqual )
 		{
-			Log::Write( LogLevel_Info, m_id.GetNodeId(), "Changed value--confirmed" );
+			Log::Write( LogLevel_Info, m_id.GetNodeId(), _instance, "Changed value--confirmed" );
 			SetCheckingChange( false );
 
 			// update the saved value and send notification
@@ -730,7 +734,7 @@ int Value::VerifyRefreshedValue
 		// log this situation, but don't change the value or send a ValueChanged Notification
 		if( bOriginalEqual )
 		{
-			Log::Write( LogLevel_Info, m_id.GetNodeId(), "Spurious value change was noted." );
+			Log::Write( LogLevel_Info, m_id.GetNodeId(), _instance, "Spurious value change was noted." );
 			SetCheckingChange( false );
 			Value::OnValueRefreshed();
 			return 0;
@@ -738,7 +742,7 @@ int Value::VerifyRefreshedValue
 
 		// the second read is different than both the original value and the checked value...retry
 		// keep trying until we get the same value twice
-		Log::Write( LogLevel_Info, m_id.GetNodeId(), "Changed value (changed again)--rechecking" );
+		Log::Write( LogLevel_Info, m_id.GetNodeId(), _instance, "Changed value (changed again)--rechecking" );
 		SetCheckingChange( true );
 
 		// save a temporary copy of value and re-read value from device

--- a/cpp/src/value_classes/ValueBool.cpp
+++ b/cpp/src/value_classes/ValueBool.cpp
@@ -97,7 +97,9 @@ void ValueBool::ReadXML
 	}
 	else
 	{
-		Log::Write( LogLevel_Info, "Missing default boolean value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId,  _commandClassId, GetID().GetInstance(), GetID().GetIndex() );
+                uint8 const _instance = GetID().GetInstance();
+
+		Log::Write( LogLevel_Info, _instance, "Missing default boolean value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId,  _commandClassId, _instance, GetID().GetIndex() );
 	}
 }
 

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -119,7 +119,9 @@ void ValueByte::ReadXML
 	}
 	else
 	{
-		Log::Write( LogLevel_Info, "Missing default byte value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId,  _commandClassId, GetID().GetInstance(), GetID().GetIndex() );
+                uint8 const _instance = GetID().GetInstance();
+
+		Log::Write( LogLevel_Info, _instance, "Missing default byte value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId,  _commandClassId, _instance, GetID().GetIndex() );
 	}
 }
 


### PR DESCRIPTION
Add the zWave node instance to logs - this makes it easy to see which instances in a multi-instance node a message is from. e.g. the Fibaro double switch. Or the Qubino relay x2 