### PR TITLE
Update pst02.xml for sensor map.

### DIFF
--- a/config/philio/pst02.xml
+++ b/config/philio/pst02.xml
@@ -138,6 +138,16 @@
   <!-- Basic set as report -->
   <!-- <CommandClass id="32" setasreport="true" ignoremapping="true"/> -->
  
+  <CommandClass id="48" create_vars="false">
+      <Instance index="1" />
+      <Value type="bool" genre="user" instance="1" index="0" label="Motion Sensor" read_only="true" write_only="false"  min="0" max="0" value="false" />
+      <Value type="bool" genre="user" instance="1" index="1" label="Door/Window Sensor" read_only="true" write_only="false" value="false" />
+      <Value type="bool" genre="user" instance="1" index="2" label="Tamper Sensor" read_only="true" write_only="false" min="0" max="0" value="false" />
+      <SensorMap index="0" type="12" />
+      <SensorMap index="1" type="10" />
+      <SensorMap index="2" type="8" />
+  </CommandClass>
+
   <!-- Association Groups -->
   <CommandClass id="133">
     <Associations num_groups="2">


### PR DESCRIPTION
The multisensor quad PST02 need the same mapping than PSM02 to differentiate the event from motion sensor, door/window sensor and tamper sensor.