### PR TITLE
Don't trigger Value::OnValueRefreshed() when verifying changes and value hasn't changed

### DIFF
--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -674,8 +674,6 @@ int Value::VerifyRefreshedValue
 	{
 		if( bOriginalEqual )
 		{
-			// values are the same, so signal a refresh and return
-			Value::OnValueRefreshed();
 			return 0;			// value hasn't changed
 		}
 


### PR DESCRIPTION
When a Value is set to verify change, and the value hasn't changed (bOriginalEqual is true), don't call Value::OnValueRefreshed(). Also, don't call OnValueChanged() since it's already called when the changing value is confirmed.

This should fix #1220.