### PR TITLE
add vision ZD2105US-5 recessed door/window sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1113,6 +1113,7 @@
 		<Product type="201f" id="1f10" name="ZD2201 Multisensor 4in1" config="vision/zd2201.xml"/>
 		<Product type="201f" id="1f20" name="ZD2301 Multisensor 4in1" config="vision/zd2301.xml"/>
 		<Product type="2021" id="2101" name="ZP3111 Multisensor 4in1" config="vision/zp3111.xml"/>
+		<Product type="2022" id="2201" name="ZD2105US-5 Recessed Door/Window Sensor" config="vision/zd2105us5.xml"/>
 		<Product type="3001" id="0104" name="ZM1602 Main Operated Siren"/>
 	</Manufacturer>
 	<Manufacturer id="004a" name="Visualize">

--- a/config/vision/zd2105us5.xml
+++ b/config/vision/zd2105us5.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+<!--
+Vision ZD2105US-5 Recessed Door/Window Sensor
+https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/1727/ZD%202105-5_V1-20160329.pdf
+-->
+
+    <!-- COMMAND_CLASS_ASSOCIATION -->
+    <CommandClass id="133">
+        <Associations num_groups="1">
+            <Group index="1" max_associations="5" label="All Reports" />
+        </Associations>
+    </CommandClass>
+</Product>

--- a/config/vision/zd2105us5.xml
+++ b/config/vision/zd2105us5.xml
@@ -8,7 +8,7 @@ https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/
     <!-- COMMAND_CLASS_ASSOCIATION -->
     <CommandClass id="133">
         <Associations num_groups="1">
-            <Group index="1" max_associations="5" label="All Reports" />
+            <Group index="1" max_associations="5" label="Lifeline" />
         </Associations>
     </CommandClass>
 </Product>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -392,6 +392,7 @@ DISTFILES =	.gitignore \
 	config/trane/TZEMT400BB32MAA.xml \
 	config/trane/TZEMT524AA21MA.xml \
 	config/vision/zd2102.xml \
+	config/vision/zd2105us5.xml \
 	config/vision/zd2201.xml \
 	config/vision/zd2301.xml \
 	config/vision/zf5201.xml \


### PR DESCRIPTION
This PR adds the Vision ZD2105US-5 recessed door/window sensor.

https://products.z-wavealliance.org/products/1727

I need help figuring out what we need to add to the config file for it. According to the [manual](https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/1727/ZD%202105-5_V1-20160329.pdf) there are no config settings. It also says it can be associated with 5 nodes. I'm also not 100% sure yet what it does with the Basic CC so I don't know if it should be set as report. Should the config file have just the Association CC?