### PR TITLE
Added GE 12719 and GE 14293

### DIFF
--- a/config/ge/12719-plugin-switch.xml
+++ b/config/ge/12719-plugin-switch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+GE Z-Wave Plug-in Smart Switch 12719 (ZW4101) 
+https://products.z-wavealliance.org/products/1193
+ -->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<Group index="1" max_associations="1" label="Lifeline" />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -567,6 +567,7 @@
 		<Product type="494d" id="3034" name="26933 Smart Motion Dimmer" config="ge/26933-motion-dimmer.xml"/>
 		<Product type="4952" id="3036" name="14291 In-Wall Smart Switch" config="ge/14291-switch.xml"/>
 		<Product type="4952" id="3037" name="14292 In-Wall Smart Toggle Switch" config="ge/14292-toggle-switch.xml"/>
+		<Product type="4952" id="3038" name="14293 In-Wall Smart Toggle Switch" config="ge/14292-toggle-switch.xml"/>
 		<Product type="5250" id="3030" name="45603 Plugin Appliance Module"/>
 		<Product type="5250" id="3130" name="45604 Outdoor Module"/>
 		<Product type="4f50" id="3031" name="12720 Outdoor Smart Switch"/>
@@ -577,6 +578,7 @@
 		<Product type="4952" id="3032" name="12722 On/Off Relay Switch" config="ge/relay.xml"/>
 		<Product type="4952" id="3033" name="12727 In-Wall Smart Switch (Toggle)"/>
 		<Product type="4953" id="3032" name="32563 Hinge Pin Smart Door Sensor" config="ge/hinge-pin.xml"/>
+		<Product type="5052" id="3031" name="12719 Plug-in Smart Switch" config="ge/12719-plugin-switch.xml"/>
 		<Product type="5052" id="3033" name="14282 Plug-In Two-Outlet Smart Switch" config="ge/14282-plugin-switch.xml"/>
 		<Product type="6363" id="3533" name="ZW4001 In-Wall Decora Style On/Off Relay Switch" config="ge/zw4001-switch.xml"/>
 	</Manufacturer>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -115,6 +115,7 @@ DISTFILES =	.gitignore \
 	config/dlink/dch-z120.xml \
 	config/dlink/dch-z510.xml \
 	config/dome/0002.xml \
+	config/dome/0088.xml \
 	config/dome/0101.xml \
 	config/domitech/zb22uk.xml \
 	config/domitech/ze27eu.xml \
@@ -201,12 +202,15 @@ DISTFILES =	.gitignore \
 	config/fibaro/fgwpfzw5.xml \
 	config/firstalert/zcombo.xml \
 	config/forest/fs2z5232000002.xml \
+	config/fortrezz/fmi.xml \
+	config/fortrezz/mimo2plus.xml \
 	config/fortrezz/mimolite.xml \
 	config/fortrezz/ssa2.xml \
 	config/fortrezz/ssa3.xml \
 	config/fortrezz/wv01.xml \
 	config/fortrezz/wwa02.xml \
 	config/frostdale/fdn2nxx.xml \
+	config/ge/12719-plugin-switch.xml \
 	config/ge/12724-dimmer.xml \
 	config/ge/14282-plugin-switch.xml \
 	config/ge/14291-switch.xml \


### PR DESCRIPTION
GE 14293 is called "14292-1" on the box and "14293" in Z-Wave and on the manual (which lists itself as being for both 14292 and 14293). I went with 14293. Regardless, the product is identical and is just an ID update.

GE 12719 is a simple semi-smart plug in toggle switch. No settings to speak of (verified via Jasco and the Z-Wave device DB).

`make dist-update` seems to have added some other recent changes to the `distfiles.mk` file as well. I left them in there, suspecting a previous commit missed that step.