### PR TITLE
Added Vision ZL7431 - Single Relay Switch

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1119,6 +1119,7 @@
 		<Product type="200f" id="0f03" name="ZS6301 CO Detector"/>
 		<Product type="2012" id="1203" name="ZR1202 Repeater"/>
 		<Product type="2014" id="1401" name="ZL7101 Plug-in Dimmer Module"/>
+		<Product type="200c" id="0c02" name="ZL7431 In-Wall Switch, Single Relay"/>
 		<Product type="2017" id="1717" name="ZL7432 In-Wall Switch, Dual Relay"/>
 		<Product type="201a" id="1aa4" name="ZL7261 Plug-in Power Monitor" config="vision/zl7261.xml"/>
 		<Product type="201c" id="1c01" name="ZF5201 Flood sensor" config="vision/zf5201.xml"/>


### PR DESCRIPTION
Vision ZL7331 is Single Relay version of popular Vision ZL7432 - Dual Relay Switch.
Device has no any configurable parameters according to manual.