### PR TITLE
Vision ZD2105US-5 basic as report & remove binary sensor

### DIFF
--- a/config/vision/zd2105us5.xml
+++ b/config/vision/zd2105us5.xml
@@ -5,6 +5,12 @@ Vision ZD2105US-5 Recessed Door/Window Sensor
 https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/1727/ZD%202105-5_V1-20160329.pdf
 -->
 
+    <!-- COMMAND_CLASS_BASIC -->
+    <CommandClass id="32" setasreport="true" />
+
+    <!-- COMMAND_CLASS_SENSOR_BINARY. This class is in the list reported by the device, but it does not respond to requests -->
+    <CommandClass id="48" action="remove" />
+
     <!-- COMMAND_CLASS_ASSOCIATION -->
     <CommandClass id="133">
         <Associations num_groups="1">


### PR DESCRIPTION
This sensor uses BASIC SET as a report. The manual also documents it.

This sensor reports a binary sensor but, according to my tests, it doesn't respond to requests. The manual does not document to support of a binary sensor. This commit removes the binary sensor.

For more details the manual is here: https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/1727/ZD%202105-5_V1-20160329.pdf