### PR TITLE
Add new device: 2Gig (Radio Thermostat) CT80

### DIFF
--- a/config/2gig/ct80.xml
+++ b/config/2gig/ct80.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+  <!-- 2gig CT80 thermostat with USNAP module RTZW-01 -->
+  <!-- This thermostat's setpoint descriptions are 0 based, not 1 -->
+    <CommandClass id="67" base="0" />
+
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -13,6 +13,7 @@
 		<Product type="6402" id="0001" name="CT100 Plus Thermostat" config="2gig/ct100.xml"/>
 		<Product type="6501" id="000c" name="CT101 Thermostat (Iris)" config="2gig/ct101.xml"/>
 		<Product type="6501" id="000d" name="CT101 Thermostat" config="2gig/ct101.xml"/>
+		<Product type="5003" id="0109" name="CT80 Thermostat" config="2gig/ct80.xml"/>
 	</Manufacturer>
 	<Manufacturer id="002a" name="3e Technologies">
 	</Manufacturer>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -229,6 +229,7 @@ DISTFILES =	.gitignore \
 	config/ge/hinge-pin.xml \
 	config/ge/receptacle.xml \
 	config/ge/relay.xml \
+	config/ge/ze26i.xml \
 	config/ge/zw4001-switch.xml \
 	config/gocontrol/GC-TBZ48L.xml \
 	config/gr/gr105.xml \

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -10,6 +10,7 @@ DISTFILES =	.gitignore \
 	config/2gig/ct101.xml \
 	config/2gig/ct30.xml \
 	config/2gig/ct50e.xml \
+	config/2gig/ct80.xml \
 	config/BeNext/1poleswitch.xml \
 	config/BeNext/2poleswitch.xml \
 	config/BeNext/AlarmSound.xml \


### PR DESCRIPTION
I copied `config/ct50e.xml` and updated the comment. This change fixed handling of the `ThermostatSetpointCmd_Get` command for two of the four climate devices reported by the thermostat.

I can just re-use the existing `config/cte50e.xml` file (pointing to that in `manufacturer_specific.xml`) if that's preferred.