### PR TITLE
Removing references to pepper1

### DIFF
--- a/config/BeNext/EnergySwitch.xml
+++ b/config/BeNext/EnergySwitch.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/269-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
 	<!-- Configuration -->
 	<CommandClass id="112">

--- a/config/BeNext/Molite.xml
+++ b/config/BeNext/Molite.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/265-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="3">
 	<!-- Configuration -->
 	<CommandClass id="112">

--- a/config/BeNext/TagReader.xml
+++ b/config/BeNext/TagReader.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/302-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
 
   <!-- Configuration -->

--- a/config/BeNext/TagReader500.xml
+++ b/config/BeNext/TagReader500.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/302-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
 
     <!-- Configuration -->

--- a/config/act/zir010.xml
+++ b/config/act/zir010.xml
@@ -13,7 +13,6 @@
 				For Lighting Mode: Send a value of 0 to Configuration Parameter #17.
 				For Alarm Mode: Send a value of 1 to Configuration Parameter #17.
 				For Sensor Mode: Send a value of 2 to Configuration Parameter # 17.
-				Information reproduced from: http://www.pepper1.net/zwavedb/uploads/resources/bdf086a9388325a2fb8b8aa298e24e512faec65d.pdf
 			</Help>
 			<Item label="Lighting" value="0" />
 			<Item label="Alarm" value="1" />
@@ -25,7 +24,6 @@
 				This parameter can be configured with the value of 0 through 255.
 				Where 0 means no delay and 255 means 255 minutes of delay.
 				Default appears to be 1 min.
-				Information reproduced from: http://www.pepper1.net/zwavedb/uploads/resources/bdf086a9388325a2fb8b8aa298e24e512faec65d.pdf
 			</Help>
 		</Value>
 		<Value type="list" index="19" genre="config" label="Unsolicited Commands" value="1" size="1">
@@ -33,7 +31,6 @@
 				The ZIR010 can be disabled from sending commands unsolicited without removing associated devices by
 				setting Configuration Parameter # 19 to 0 (when asked for number of bytes, select 1).
 				Setting it back to 1 will re-enable the ZIR010.
-				Information reproduced from: http://www.pepper1.net/zwavedb/uploads/resources/bdf086a9388325a2fb8b8aa298e24e512faec65d.pdf
 			</Help>
 			<Item label="No" value="0" />
 			<Item label="Yes" value="1" />
@@ -44,7 +41,6 @@
 				to 45 to the ZIR010 using Configuration Parameter # 22 (when asked for the number of bytes, select 1).
 				This awake time period starts over every time the ZIR010 receives a command or request.
 				Defaults to 30 seconds.
-				Information reproduced from: http://www.pepper1.net/zwavedb/uploads/resources/bdf086a9388325a2fb8b8aa298e24e512faec65d.pdf
 			</Help>
 		</Value>
 	</CommandClass>

--- a/config/aeotec/zw100.xml
+++ b/config/aeotec/zw100.xml
@@ -4,8 +4,7 @@
 	<MetaData>
 		<MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0086:0064:0002</MetaDataItem>
 		<MetaDataItem name="ZWProductPage">http://products.z-wavealliance.org/products/1812</MetaDataItem>
-		<MetaDataItem name="Pepper1Page">http://www.pepper1.net/zwavedb/device/824</MetaDataItem>
-		<MetaDataItem name="ProductPic">http://www.pepper1.net/zwavedb/uploads/resources/1c9f763dbd9e82b5c3d8d9518392c2bdbdafb2ee.png </MetaDataItem>
+		<MetaDataItem name="ProductPic">https://products.z-wavealliance.org/ProductImages/Index?productName=ZC10-16065113</MetaDataItem>
 		<MetaDataItem name="ProductManual">https://aeotec.freshdesk.com/support/solutions/folders/6000149641</MetaDataItem>
 		<MetaDataItem name="ProductPage">http://aeotec.com/z-wave-sensor</MetaDataItem>
 	</MetaData>

--- a/config/everspring/ad147.xml
+++ b/config/everspring/ad147.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EVERSPRING AD147 Dimming MODULE -->
-<!-- Information from http://www.pepper1.net/zwavedb/device/686 -->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
   <!-- Configuration Parameters -->
   <CommandClass id="112">

--- a/config/everspring/an145.xml
+++ b/config/everspring/an145.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EVERSPRING AN145 SCREW-IN ON/OFF MODULE -->
-<!-- Information from http://www.pepper1.net/zwavedb/device/57 -->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
 	<!-- Configuration Parameters not supported -->
 	<!-- Association Groups -->

--- a/config/everspring/an158.xml
+++ b/config/everspring/an158.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EVERSPRING AN158 ON/OFF MODULE -->
-<!-- Information from http://www.pepper1.net/zwavedb/device/54 -->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
   <!-- Configuration Parameters -->
   <CommandClass id="112">

--- a/config/everspring/sf812.xml
+++ b/config/everspring/sf812.xml
@@ -4,7 +4,6 @@
 	<!-- Configuration Parameters not supported -->
 	<!-- Association Groups -->
 	<CommandClass id="133">
-		<!-- Groups and attributes based on http://www.pepper1.net/zwavedb/uploads/resources/fdeac2e16823d1f80c667ca4cc3ae32253ef4713.pdf -->
 		<Associations num_groups="1">
 			<Group index="1" max_associations="5" label="Reports" />
 		</Associations>

--- a/config/everspring/sp103.xml
+++ b/config/everspring/sp103.xml
@@ -31,7 +31,6 @@
 	<CommandClass id="113" action="add" />
 	<!-- Association Groups -->
 	<CommandClass id="133">
-		<!-- Groups and attributes based on http://www.pepper1.net/zwavedb/device/59 -->
 		<Associations num_groups="1">
 			<Group index="1" max_associations="5" label="Motion" />
 		</Associations>

--- a/config/merten/507801.xml
+++ b/config/merten/507801.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/72-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
   <!-- Configuration -->
   <CommandClass id="112">

--- a/config/merten/50x5xx.xml
+++ b/config/merten/50x5xx.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/85-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="3">
   <!-- Configuration -->
   <CommandClass id="112">

--- a/config/zipato/MiniKeypad.xml
+++ b/config/zipato/MiniKeypad.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--http://www.pepper1.net/zwavedb/device/302-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
 
   <!-- Configuration -->

--- a/config/zwave.me/ZME_05461.xml
+++ b/config/zwave.me/ZME_05461.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Taken from http://manuals.zwaveeurope.com/make.php?lang=en&type=&sku=ZME_05461 and http://www.pepper1.net/zwavedb/device/564/564-0115-1000-0100-03-03-43-01-00.xml-->
+<!--Taken from http://manuals.zwaveeurope.com/make.php?lang=en&type=&sku=ZME_05461-->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
     <!-- Configuration Parameters -->
     <!--IMPORTANT: Controllers may only allow to configure signed values.

--- a/config/zwave.me/ZME_06433.xml
+++ b/config/zwave.me/ZME_06433.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Taken from http://pepper1.net/zwavedb/device/273 and http://www.pepper1.net/zwavedb/device/145 -->
 <Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
 	<!-- Configuration Parameters -->
 	<!--IMPORTANT: Controllers may only allow to configure signed values. 

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -3839,7 +3839,6 @@ string const Node::GetMetaData(MetaDataFields field) {
 Node::MetaDataFields const Node::GetMetaDataId(string name) {
 	if (name == "OzwInfoPage") return MetaData_OzwInfoPage;
 	if (name == "ZWProductPage") return MetaData_ZWProductPage;
-	if (name == "Pepper1Page") return MetaData_Pepper1Page;
 	if (name == "ProductPic") return MetaData_ProductPic;
 	if (name == "ProductManual") return MetaData_ProductManual;
 	if (name == "ProductPage") return MetaData_ProductPage;
@@ -3855,8 +3854,6 @@ string const Node::GetMetaDataString(Node::MetaDataFields id) {
 		return "OzwInfoPage";
 	case MetaData_ZWProductPage:
 		return "ZWProductPage";
-	case MetaData_Pepper1Page:
-		return "Pepper1Page";
 	case MetaData_ProductPic:
 		return "ProductPic";
 	case MetaData_ProductManual:

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -698,7 +698,6 @@ namespace OpenZWave
 			{
 				MetaData_OzwInfoPage,
 				MetaData_ZWProductPage,
-				MetaData_Pepper1Page,
 				MetaData_ProductPic,
 				MetaData_ProductManual,
 				MetaData_ProductPage,


### PR DESCRIPTION
Resolves #1397 

The Pepper1 DB no longer exists.  This removes a bunch of broken links from various configuration files.  And removes support for the Pepper1 metadata item (which was used by one product only).

