### PR TITLE
Added support for Enerwave device ZWN-RSM2 and ZWN-RSM2-PLUS Smart Du…

### DIFF
--- a/config/enerwave/zwnrsm2plus.xml
+++ b/config/enerwave/zwnrsm2plus.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--    
+        Enerwave ZWN-RSM2 Smart Dual Relay Switch Module 
+        Enerwave ZWN-RSM2-PLUS Smart Dual Relay Switch Module 
+
+        Note:  the two devices share the same device ID but have different configuration parameters.
+
+        Z-Wave Alliance Product Database info: 
+        https://products.z-wavealliance.org/products/2242
+-->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Configuration Parameters -->
+        <CommandClass id="112">
+                <Value type="short" genre="config" index="3" label="Unsolicited Report Configuration" units="" min="0" max="255" value="0">
+                        <Help>ZWN-RSM2 and ZWN-RSM2-PLUS can send unsolicited status reports to the primary controller (Node ID 0x1) when the switch is toggled if the controller is designed as a gateway.  If your controller is not a gateway or does not need the status reported or you think it could confuse your Z-Wave network, you can use Command_Class_Configuration to disable this function.  By default this function is disabled. ZWM-RSM2 disabled=0, enabled=255.  ZWN-RSM2-PLUS disabled=0, enabled=1</Help>
+                </Value>
+        </CommandClass>
+	<CommandClass id="133">
+		<Associations num_groups="3">
+			<Group index="1" max_associations="1" label="Lifeline: Send device reset locally notification" />
+			<Group index="2" max_associations="3" label="StatusReport_EP1: Switch Binary Report" />
+			<Group index="3" max_associations="3" label="StatusReport_EP2: Switch Binary Report" />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/enerwave/zwnrsm2plus.xml
+++ b/config/enerwave/zwnrsm2plus.xml
@@ -17,7 +17,7 @@
         </CommandClass>
 	<CommandClass id="133">
 		<Associations num_groups="3">
-			<Group index="1" max_associations="1" label="Lifeline: Send device reset locally notification" />
+			<Group index="1" max_associations="1" label="Lifeline" />
 			<Group index="2" max_associations="3" label="StatusReport_EP1: Switch Binary Report" />
 			<Group index="3" max_associations="3" label="StatusReport_EP2: Switch Binary Report" />
 		</Associations>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -382,6 +382,7 @@
 		<Product type="0101" id="0102" name="ZW15S 15A On/Off Switch" config="enerwave/zw15s.xml"/>
 		<Product type="0101" id="0603" name="ZW20R 20A TR Duplex Receptacle" config="enerwave/zw20r.xml"/>
 		<Product type="0111" id="0605" name="ZWN-RSM1 PLUS—Smart Single Relay Switch Module" config="enerwave/zwnrsm1plus.xml"/>
+		<!--<Product type="0111" id="0605" name="ZWN-RSM2-PLUS Smart Single Relay Switch Module" config="enerwave/zwnrsm2plus.xml"/>-->
 		<Product type="0111" id="0101" name="ZW20RM 20A TR Smart Meter Duplex Receptacle" config="enerwave/zw20rm.xml"/>
 		<Product type="0102" id="0201" name="ZW500D 500W In-Wall Preset Dimmer Switch" config="enerwave/zw500d.xml"/>
 		<Product type="0111" id="0105" name="ZW15RM Plus 15A TR Smart Meter Duplex Receptacle" config="enerwave/zw15rmplus.xml"/>


### PR DESCRIPTION
…al Relay Switch Module

Note:  these devices use the same device ID as the ZWN-RMS1-PLUS device so I created a commented out entry in manufacturer_specific.xml that will have to be manually changed to enabled this device.

run "make xmltest" -- complete
run "make dist-update" -- complete

Tested on:
Linux rpi2 4.9.59-v7+ #1047 SMP Sun Oct 29 12:19:23 GMT 2017 armv7l GNU/Linux

This is related to issue #801 .  