### PR TITLE
Refresh clock values upon change

### DIFF
--- a/cpp/src/command_classes/Clock.cpp
+++ b/cpp/src/command_classes/Clock.cpp
@@ -185,16 +185,19 @@ bool Clock::SetValue
 			if (_value.GetID() == dayValue->GetID()) {
 				ValueList const * dayvaluetmp = static_cast<ValueList const*>(&_value);
 				day = dayvaluetmp->GetItem()->m_value;
+				dayValue->OnValueRefreshed(day);
 			}
 			uint8 hour = hourValue->GetValue();
 			if (_value.GetID() == hourValue->GetID()) {
 				ValueByte const * hourvaluetmp = static_cast<ValueByte const*>(&_value);
 				hour = hourvaluetmp->GetValue();
+				hourValue->OnValueRefreshed(hour);
 			}
 			uint8 minute = minuteValue->GetValue();
 			if (_value.GetID() == minuteValue->GetID()) {
 				ValueByte const * minuteValuetmp = static_cast<ValueByte const*>(&_value);
 				minute = minuteValuetmp->GetValue();
+				minuteValue->OnValueRefreshed(minute);
 			}
 
 


### PR DESCRIPTION
This should fix #843 

When updating, say, Hour and Minute, you had to wait for the change report to return before updating the next field.

Example log:
```
2018/01/09 19:48:30 ZWave: Node 7: Polling 2 values.
2018/01/09 19:48:30 Time: 4:16
2018-01-09 19:48:30.279 Info, Node007, Value::Set - COMMAND_CLASS_CLOCK - Hour - 1 - 1 - 5
2018-01-09 19:48:30.279 Info, Node007, Value::Set - COMMAND_CLASS_CLOCK - Minute - 2 - 1 - 10
2018/01/09 19:48:30 ZWave: Node 7 changed: User 0x81.1.1: Hour: 5 
2018-01-09 19:48:30.280 Info, Node007, Sending (Send) message (Callback ID=0x21, Expected Reply=0x13) - ClockCmd_Set (Node=7): 0x01, 0x0b, 0x00, 0x13, 0x07, 0x04, 0x81, 0x04, 0x65, 0x10, 0x25, 0x21, 0x10
2018/01/09 19:48:30 ZWave: Node 7 changed: User 0x81.1.2: Minute: 10 
2018-01-09 19:48:31.540 Info, Node007, Request RTT 1259 Average Request RTT 644
2018-01-09 19:48:31.540 Info, Node007, Sending (Send) message (Callback ID=0x22, Expected Reply=0x04) - ClockCmd_Get (Node=7): 0x01, 0x09, 0x00, 0x13, 0x07, 0x02, 0x81, 0x05, 0x25, 0x22, 0x63
2018-01-09 19:48:31.568 Info, Node007, Request RTT 27 Average Request RTT 335
2018-01-09 19:48:31.602 Info, Node007, Response RTT 61 Average Response RTT 60
2018-01-09 19:48:31.602 Info, Node007, Received Clock report: Wednesday 05:16
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.0: Day: Wednesday 
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.1: Hour: 5 
2018-01-09 19:48:31.603 Info, Node007, Sending (Send) message (Callback ID=0x23, Expected Reply=0x13) - ClockCmd_Set (Node=7): 0x01, 0x0b, 0x00, 0x13, 0x07, 0x04, 0x81, 0x04, 0x65, 0x0a, 0x25, 0x23, 0x08
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.2: Minute: 16 
2018-01-09 19:48:31.633 Info, Node007, Request RTT 30 Average Request RTT 182
2018-01-09 19:48:31.634 Info, Node007, Sending (Send) message (Callback ID=0x24, Expected Reply=0x04) - ClockCmd_Get (Node=7): 0x01, 0x09, 0x00, 0x13, 0x07, 0x02, 0x81, 0x05, 0x25, 0x24, 0x65
2018-01-09 19:48:31.662 Info, Node007, Request RTT 28 Average Request RTT 105
2018-01-09 19:48:31.790 Info, Node007, Response RTT 156 Average Response RTT 108
2018-01-09 19:48:31.791 Info, Node007, Received Clock report: Wednesday 05:10
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.0: Day: Wednesday 
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.1: Hour: 5 
2018/01/09 19:48:31 ZWave: Node 7 changed: User 0x81.1.2: Minute: 10 
```