### PR TITLE
ZHC5010 Fix CentralScene support

### DIFF
--- a/config/logicsoft/ZHC5010.xml
+++ b/config/logicsoft/ZHC5010.xml
@@ -285,6 +285,10 @@
 	<CommandClass id="39" getsupported="false" />
 	<!-- MultiInstance Command Class. Note: If you do not need Dedicated Relay Control instance, change below mapping to "endpoints", then rejoin the node to your network. -->
 	<CommandClass id="96" mapping="all" />
+	<!-- Central Scene always come from root device -->
+	<CommandClass id="91">
+		<Instance index="1" endpoint="0" />
+	</CommandClass>
 	<!-- Multi Channel Association Groups -->
 	<CommandClass id="142" ForceInstances="true"/>
 	<!-- Association Groups -->


### PR DESCRIPTION
CentralScene is issued from Root device endpoint0 which by default maps to instance0, but all CCs start from instance1.
Map endpoint0 to instance1.