### PR TITLE
Fix Auto relock setting on Conexis L1 and Keyfree Connected plus locks

### DIFF
--- a/config/assa_abloy/ConexisL1.xml
+++ b/config/assa_abloy/ConexisL1.xml
@@ -14,8 +14,8 @@ https://products.z-wavealliance.org/products/2535/configs
 		</Value>
 		<Value type="list" size="1" genre="config" instance="1" index="2" label="Auto Relock" value="0">
 			<Help></Help>
-			<Item label="On" value="0" />
-			<Item label="Off" value="255" />
+			<Item label="On" value="255" />
+			<Item label="Off" value="0" />
 		</Value>
 		<Value type="byte" genre="config" instance="1" index="3" label="Auto-re-lock Time" size="1" min="7" max="60" units="seconds" value="30">
 			<Help>seconds; after successful code entry and unit unlocks, it will automatically re-lock after specified time (30 = default value)</Help>

--- a/config/assa_abloy/KeyfreeConnected-plus.xml
+++ b/config/assa_abloy/KeyfreeConnected-plus.xml
@@ -14,8 +14,8 @@ https://products.z-wavealliance.org/products/2743/configs
 		</Value>
 		<Value type="list" size="1" genre="config" instance="1" index="2" label="Auto Relock" value="0">
 			<Help></Help>
-			<Item label="On" value="0" />
-			<Item label="Off" value="255" />
+			<Item label="On" value="255" />
+			<Item label="Off" value="0" />
 		</Value>
 		<Value type="byte" genre="config" instance="1" index="3" label="Auto-re-lock Time" size="1" min="7" max="60" units="seconds" value="30">
 			<Help>seconds; after successful code entry and unit unlocks, it will automatically re-lock after specified time (30 = default value)</Help>


### PR DESCRIPTION
I noticed the setting parameter for Auto Relock had the  wrong values on these two locks this PR fixes that,

Instead of 'off' being '255' its actually 'on'

https://products.z-wavealliance.org/products/2535/configs
https://products.z-wavealliance.org/products/2743/configs
Fix Auto relock setting on Conexis L1 and Keyfree Connected plus locks