### PR TITLE
Added new version of the MCO home MH-S412

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -828,6 +828,7 @@
 		<Product type="3102" id="0204" name="MH-S314 Four-load" config="mcohome/mhs314.xml"/>
 		<Product type="4102" id="0201" name="MH-S411 One-load" config="mcohome/mhs411.xml"/>
 		<Product type="4102" id="0202" name="MH-S412 Two-load" config="mcohome/mhs412.xml"/>
+		<Product type="4121" id="1302" name="MH-S412 B Two-load" config="mcohome/mhs412.xml"/>
 		<Product type="0801" id="3102" name="MH8-FC-EU Thermostat" config="mcohome/mh8fceu.xml"/>
 		<Product type="0802" id="3102" name="MH8-FC4-EU Thermostat" config="mcohome/mh8fceu.xml"/>
 		<Product type="0905" id="0201 " name="MH9-CO2-WD CO2 Monitor" config="mcohome/mh9co2.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -828,7 +828,7 @@
 		<Product type="3102" id="0204" name="MH-S314 Four-load" config="mcohome/mhs314.xml"/>
 		<Product type="4102" id="0201" name="MH-S411 One-load" config="mcohome/mhs411.xml"/>
 		<Product type="4102" id="0202" name="MH-S412 Two-load" config="mcohome/mhs412.xml"/>
-		<Product type="4121" id="1302" name="MH-S412 B Two-load" config="mcohome/mhs412.xml"/>
+		<Product type="4121" id="1302" name="MH-S412 Two-load" config="mcohome/mhs412.xml"/>
 		<Product type="0801" id="3102" name="MH8-FC-EU Thermostat" config="mcohome/mh8fceu.xml"/>
 		<Product type="0802" id="3102" name="MH8-FC4-EU Thermostat" config="mcohome/mh8fceu.xml"/>
 		<Product type="0905" id="0201 " name="MH9-CO2-WD CO2 Monitor" config="mcohome/mh9co2.xml"/>


### PR DESCRIPTION
Mcohome appareantly released a different id-version of the same product. 
Tested it with the new product type and id, and used the original "mcohome/mhs412.xml" 
as the lifeline switch is still present in this version.
It now performs perfectly.

Product type="4121" id="1302" 
No idea as for naming convention but i named it version B  as its a black one + info on the box says "MH-S412-EU B" (switch just says MH-S412-EU on the back)