### PR TITLE
This commit fixes #1457 Blue color value not reported by ZIPATO BULB 2

### DIFF
--- a/config/device_configuration.xsd
+++ b/config/device_configuration.xsd
@@ -116,6 +116,14 @@
      </xs:restriction>
     </xs:simpleType>
    </xs:attribute>
+   <xs:attribute name='zipatobulb2colorbug' use='optional'>
+    <xs:simpleType>
+     <xs:restriction base='xs:string'>
+      <xs:enumeration value='true'/>
+      <xs:enumeration value='false'/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:attribute>
    <xs:attribute name='forceUniqueEndpoints' use='optional'>
     <xs:simpleType>
      <xs:restriction base='xs:string'>

--- a/config/zipato/RGBBulb2.xml
+++ b/config/zipato/RGBBulb2.xml
@@ -20,5 +20,10 @@
       <Group index="1" max_associations="5" label="Report"  />
     </Associations>
   </CommandClass>
+
+  <CommandClass id="51" zipatobul2colorbug="true" >
+         <!--  The Fibaro doesn't report immediate color values, so we need to verify the value -->
+        <Value type="string" genre="user" instance="1" index="0" label="Color" units="#RRGGBBWW" verify_changes="false" value="#00000000" />
+  </CommandClass>
 </Product>
 

--- a/cpp/src/command_classes/Color.cpp
+++ b/cpp/src/command_classes/Color.cpp
@@ -123,6 +123,7 @@ Color::Color
 CommandClass( _homeId, _nodeId ),
 m_capabilities ( 0 ),
 m_coloridxbug ( false ),
+m_zipatobulb2colorbug( false ),
 m_refreshinprogress ( false ),
 m_coloridxcount ( 0 )
 {
@@ -154,6 +155,12 @@ void Color::ReadXML
 	if( str )
 	{
 		m_coloridxbug = !strcmp( str, "true");
+	}
+
+	str = _ccElement->Attribute("zipatobulb2colorbug");
+	if( str )
+	{
+		m_zipatobulb2colorbug = !strcmp( str, "true");
 	}
 }
 
@@ -324,9 +331,11 @@ bool Color::HandleMsg
 		uint32 const _instance	// = 1
 )
 {
+
 	if (ColorCmd_Capability_Report == (ColorCmd)_data[0])
 	{
-		m_capabilities = (_data[1] + (_data[2] << 8));
+		if (!m_zipatobulb2colorbug) m_capabilities = (_data[1] + (_data[2] << 8));
+		else m_capabilities = 0x1F;
 		string helpstr = "#RRGGBB";
 		Log::Write(LogLevel_Info, GetNodeId(), "Received an Color Capability Report: Capability=%xd", m_capabilities);
 		if (m_capabilities & 0x04)

--- a/cpp/src/command_classes/Color.h
+++ b/cpp/src/command_classes/Color.h
@@ -65,6 +65,7 @@ namespace OpenZWave
 		Color( uint32 const _homeId, uint8 const _nodeId );
 		uint16 m_capabilities;
 		bool m_coloridxbug; // Fibaro RGBW before version 25.25 always reported the coloridx as 3 in the Report Message. Work around it
+		bool m_zipatobulb2colorbug; // Zipato Bulb 2 reports wrong number of colorchannels causing blue value not to be reported. Work around it
 		bool m_refreshinprogress;
 		uint8 m_coloridxcount;
 		uint8 m_colorvalues[9];


### PR DESCRIPTION
The Zipato bulb returns 15 as colorchannels (channels 1,2,,3 and 4) when nr of channels is requested which should be 31 (channels 1,2,3,4 and 5). I solved this by setting a zipatobulb2colorbug value in the xml of the zipato bulb2 and ignored the returned colorchanels in Color.cpp from the bulb and overriding it with 31 (0b00011111) which includes the blue channel. 

https://github.com/OpenZWave/open-zwave/issues/1457