### PR TITLE
Reverting max_associations to correct values

### DIFF
--- a/config/popp/009402.xml
+++ b/config/popp/009402.xml
@@ -28,9 +28,9 @@ http://manuals-backend.z-wave.info/make.php?lang=en&sku=pope009402&type=popp
 	<!-- Association Groups -->
 	<CommandClass id="133">
 		<Associations num_groups="3">
-			<Group index="1" max_associations="4" label="Lifeline"/>
-			<Group index="2" max_associations="4" label="Alarm Reports"/>
-			<Group index="3" max_associations="4" label="Switching Command when Alarm"/>
+			<Group index="1" max_associations="10" label="Lifeline"/>
+			<Group index="2" max_associations="10" label="Alarm Reports"/>
+			<Group index="3" max_associations="10" label="Switching Command when Alarm"/>
 		</Associations>
 	</CommandClass>
 </Product>


### PR DESCRIPTION
Reverting max_association
Original config file was correct and is still correct according to the manual. 

Source: http://manuals-backend.z-wave.info/make.php?lang=en&sku=pope009402&type=popp

Have tested with more than 4 association in group 2 without problem