### PR TITLE
Add support for Inovelli NZW31 switch config, add additional device IDs

### DIFF
--- a/config/inovelli/nzw31.xml
+++ b/config/inovelli/nzw31.xml
@@ -37,4 +37,10 @@
       <Group index="1" label="Lifeline" max_associations="5" />
     </Associations>
   </CommandClass>
+  <CommandClass id="91" name="COMMAND_CLASS_CENTRAL_SCENE" version="1" request_flags="4" scenecount="0">
+				<Instance index="1" />
+				<Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="2" />
+				<Value type="int" genre="user" instance="1" index="1" label="Bottom Button Scene" units="" read_only="false" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="1" />
+				<Value type="int" genre="user" instance="1" index="2" label="Top Button Scene" units="" read_only="false" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="1" />
+  </CommandClass>
 </Product>

--- a/config/inovelli/nzw31.xml
+++ b/config/inovelli/nzw31.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Inovelli Dimmer NZW31 -->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+  <!-- Configuration Parameters -->
+  <CommandClass id="112">
+  	<Value genre="config" type="byte" instance="1" index="1" label="Dimming Step Size" min="1" max="99" units="%" value="1">
+		<Help>Percentage of step when switch is dimming up or down, range 1-99%</Help>
+	</Value>
+	<Value genre="config" type="byte" instance="1" index="2" label="Minimum Level" min="1" max="99" units="%" value="1">
+		<Help>Minimum dimming level for attached light, range 1-99%</Help>
+	</Value>
+    <Value genre="config" type="list" index="3" label="LED Indicator Control" units="" size="1" min="0" max="1" value="0">
+      <Help>Choose if you want the LED indicator to turn on when switch is on, off, or never</Help>
+      <Item value="0" label="LED on when switch is off"/>
+      <Item value="1" label="LED on when switch is on"/>
+      <Item value="2" label="LED disabled"/>
+    </Value>
+    <Value genre="config" type="list" index="4" label="Orientation" units="" size="1" min="0" max="1" value="0">
+      <Help>Controls the on/off orientation of the rocker switch</Help>
+      <Item value="0" label="Normal"/>
+      <Item value="1" label="Inverted"/>
+    </Value>
+    <Value type="short" index="5" genre="config" label="Auto off timer" min="0" max="32767" value="0" units="second">
+      <Help>
+      	  Automatically turn switch off after this number of seconds (0 to disable, or up to 32767 seconds)
+      </Help>
+    </Value> 
+  </CommandClass>
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="1">
+      <Group index="1" max_associations="5" label="Lifeline" />
+    </Associations>
+  </CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -711,8 +711,12 @@
 		<Product type="b211" id="241c" name="NZW36 Smart Plug-In Module (1 Channel)" config="inovelli/simple_module.xml"/>
 		<Product type="b221" id="251c" name="NZW37 Smart Plug-In Module (2 Channel)" config="inovelli/simple_module.xml"/>
 		<Product type="b212" id="271c" name="NZW39 Smart Plug (Dimmer)" config="inovelli/simple_module.xml"/>
-		<Product type="1f01" id="1f01" name="NZW31 Smart Dimmer(non-scene)" config="inovelli/simple_module.xml"/>
-		<Product type="1e01" id="1e01" name="NZW30 Smart Toggle Switch" config="inovelli/simple_module.xml"/>
+		<Product type="1f01" id="1f01" name="NZW31 Dimmer" config="inovelli/nzw31.xml"/>
+		<Product type="1f00" id="1f00" name="NZW31S Dimmer(scene)" config="inovelli/nzw31.xml"/>
+		<Product type="1f02" id="1f02" name="NZW31T Dimmer(scene)" config="inovelli/nzw31.xml"/>
+		<Product type="1e01" id="1e01" name="NZW30 On/Off Switch" config="inovelli/simple_module.xml"/>
+		<Product type="1e00" id="1e00" name="NZW30S On/Off Switch(scene)" config="inovelli/simple_module.xml"/>
+		<Product type="1e02" id="1e02" name="NZW30T On/Off Toggle(scene)" config="inovelli/simple_module.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0006" name="Intel">
 	</Manufacturer>


### PR DESCRIPTION
Based on Inovelli-provided SmartThings device handler, and tested against a hardware NZW31 switch.