### PR TITLE
debian: Protect variables args with quotes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,10 +24,10 @@ LIBDIR := /usr/lib/$(DEB_HOST_MULTIARCH)/
 	dh $@
 
 override_dh_auto_build:
-	CPPFLAGS=$(CPPFLAGS) VERSION_MAJ=$(MAJOR) VERSION_MIN=$(MINOR) VERSION_REV=$(REV) PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=$(LIBDIR) make
+	CPPFLAGS="$(CPPFLAGS)" VERSION_MAJ="$(MAJOR)" VERSION_MIN="$(MINOR)" VERSION_REV="$(REV)" PREFIX="/usr" SYSCONFDIR="/etc/openzwave" instlibdir="$(LIBDIR)" make
 
 override_dh_auto_install:
-	VERSION_MAJ=$(MAJOR) VERSION_MIN=$(MINOR) VERSION_REV=$(REV) DESTDIR=$(DESTDIR) PREFIX=/usr SYSCONFDIR=/etc/openzwave instlibdir=$(LIBDIR) make install
+	VERSION_MAJ="$(MAJOR)" VERSION_MIN="$(MINOR)" VERSION_REV="$(REV)" DESTDIR="$(DESTDIR)" PREFIX=/usr SYSCONFDIR="/etc/openzwave" instlibdir="$(LIBDIR)" make install
 	# install docs in /usr/share/doc/openzwave/, not openzwave-VERSION
 	install -d debian/libopenzwave-doc/usr/share/doc
 	mv debian/tmp/usr/share/doc/openzwave-1* debian/libopenzwave-doc/usr/share/doc/openzwave


### PR DESCRIPTION
Observed issue was:

  CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2 VERSION_MAJ=1 (...) make
  /bin/sh: 1: -D_FORTIFY_SOURCE=2: not found

Relate-to: https://github.com/OpenZWave/open-zwave/pull/1123
Change-Id: I4b730cc76fde0ea4ec3654fb4f2c29c544f96bc1
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>