### PR TITLE
Add ANZ mappings for Fibaro and Aeotec, removed AU tags

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -444,25 +444,25 @@
 		<Product type="0501" id="0102" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="0109" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="1002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
-		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor AU" config="fibaro/fgbs001.xml" />
+		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor ANZ [3002]" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="4002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0100" id="0104" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0106" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W ANZ [0107]" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0109" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="100a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W AU" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W ANZ [300a]" config="fibaro/fgd211.xml" />
 		<Product type="0102" id="1000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="2000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml"/>
-		<Product type="0102" id="3000" name="FGD212 Dimmer 2 AU" config="fibaro/fgd212.xml" />
+		<Product type="0102" id="3000" name="FGD212 Dimmer 2 ANZ [3000]" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="4000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0700" id="1000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="2000" name="FGK10x Door Opening Sensor" config="fibaro/fgk001.xml" />
-		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor AU" config="fibaro/fgk001.xml" />
+		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor ANZ [3000]" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="4000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0701" id="1001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
 		<Product type="0701" id="2001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
-		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor AU" config="fibaro/fgk10x.xml" />
+		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor ANZ [3001]" config="fibaro/fgk10x.xml" />
 		<Product type="0702" id="1000" name="FGDW002 Door Opening Sensor 2" config="fibaro/fgdw2.xml" />
 		<Product type="0300" id="0104" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0300" id="100a" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
@@ -471,7 +471,7 @@
 		<Product type="0300" id="0109" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0301" id="1001" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
 		<Product type="0302" id="1000" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
-		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2 AU" config="fibaro/fgrm222.xml"/>
+		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2 ANZ [3000]" config="fibaro/fgrm222.xml"/>
 		<Product type="0400" id="0104" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0105" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0106" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
@@ -484,25 +484,25 @@
 		<Product type="0402" id="3002" name="FGS212 Switch 3kW" config="fibaro/fgs212.xml" />
 		<Product type="0403" id="1000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
 		<Product type="0403" id="2000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
-		<Product type="0403" id="3000" name="FGS213 Switch AU" config="fibaro/fgs213.xml"/>
+		<Product type="0403" id="3000" name="FGS213 Switch ANZ [3000]" config="fibaro/fgs213.xml"/>
 		<Product type="0200" id="0104" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0105" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0106" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0107" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0109" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="100a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
-		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW AU" config="fibaro/fgs221.xml" />
+		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW ANZ [300a]" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="400a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0202" id="1002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
-		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW AU" config="fibaro/fgs222.xml" />
+		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW ANZ [3002]" config="fibaro/fgs222.xml" />
 		<Product type="0203" id="1000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
-		<Product type="0203" id="3000" name="FGS223 Double Relay AU config="fibaro/fgs223.xml"/>
+		<Product type="0203" id="3000" name="FGS223 Double Relay ANZ [3000]" config="fibaro/fgs223.xml"/>
 		<Product type="0600" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml" />
 		<Product type="0200" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml"/>
 		<Product type="0602" id="1001" name="FGWPE/F Wall Plug Gen5" config="fibaro/fgwpfzw5.xml" />
 		<Product type="0800" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="2001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
-		<Product type="0800" id="3001" name="FGMS001 Motion Sensor AU" config="fibaro/fgms.xml" />
+		<Product type="0800" id="3001" name="FGMS001 Motion Sensor ANZ [3001]" config="fibaro/fgms.xml" />
 		<Product type="0800" id="4001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<!--<Product type="0801" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />-->
 		<Product type="0801" id="1001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
@@ -517,19 +517,19 @@
 		<Product type="0b01" id="2002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0900" id="1000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0900" id="2000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
-		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller AU" config="fibaro/fgrgbwm441.xml"/>
+		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller ANZ [3000]" config="fibaro/fgrgbwm441.xml"/>
 		<Product type="0900" id="4000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0c00" id="1000" name="FGSS101 Smoke Sensor" config="fibaro/fgss101.xml" />
 		<Product type="0c02" id="1002" name="FGSD002 Smoke Sensor" config="fibaro/fgsd002.xml" />
 		<Product type="0d01" id="1000" name="FGGC001 Swipe" config="fibaro/fggc001.xml" />
 		<Product type="0d01" id="2000" name="FGGC001 Swipe" config="fibaro/fggc001.xml"/>
-		<Product type="0d01" id="3000" name="FGGC001 Swipe AU" config="fibaro/fggc001.xml"/>
+		<Product type="0d01" id="3000" name="FGGC001 Swipe ANZ [3000]" config="fibaro/fggc001.xml"/>
 		<Product type="0f01" id="1000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
 		<Product type="0f01" id="2000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
-		<Product type="0f01" id="3000" name="FGPB101 Button AU" config="fibaro/fgpb101.xml" />
+		<Product type="0f01" id="3000" name="FGPB101 Button ANZ [3000]" config="fibaro/fgpb101.xml" />
 		<Product type="1001" id="1000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
 		<Product type="1001" id="2000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
-		<Product type="1001" id="3000" name="FGKF601 Keyfob AU" config="fibaro/fgkf601.xml" />
+		<Product type="1001" id="3000" name="FGKF601 Keyfob ANZ [3000]" config="fibaro/fgkf601.xml" />
 		<Product type="1201" id="1000" name="FGSD001 CO Sensor" config="fibaro/fgcd001.xml" />
 		<Product type="1301" id="1000" name="FGT001 Heat Controller" config="fibaro/fgt001.xml"/>
 	</Manufacturer>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -62,7 +62,7 @@
 		<Product type="0003" id="000c" name="DSC12104 Micro Smart Energy Switch" config="aeotec/dsc12104.xml"/>
 		<Product type="0003" id="000d" name="DSC13104 Micro Smart Energy Illuminator" config="aeotec/dsc13104.xml"/>
 		<Product type="0003" id="000e" name="DSC14104 Micro Motor Controller" config="aeotec/dsc14104.xml"/>
-		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition)AU" config="aeotec/dsc18103.xml" />
+		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition) AU" config="aeotec/dsc18103.xml" />
 		<Product type="0003" id="0013" name="DSC19103 Micro Smart Dimmer (2nd Edition)" config="aeotec/dsc19103.xml" />
 		<Product type="0003" id="001a" name="DSC26103 Micro Switch (2nd Edition)" config="aeotec/dsc26103.xml"/>
 		<Product type="0003" id="001b" name="DSC27103 Micro Dimmer (2nd Edition)" config="aeotec/dsc27103.xml"/>
@@ -86,10 +86,10 @@
 		<Product type="0203" id="003e" name="ZW062 Garage Door ControllerAU" config="aeotec/zw062.xml" />
 		<Product type="0002" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
 		<Product type="0102" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
-		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5AU" config="aeotec/zw074.xml"/>
+		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5 AU" config="aeotec/zw074.xml"/>
 		<Product type="0003" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
 		<Product type="0103" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
-		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5AU" config="aeotec/zw075.xml"/>
+		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5 AU" config="aeotec/zw075.xml"/>
 		<Product type="0003" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0103" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0203" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
@@ -110,7 +110,7 @@
 		<Product type="0201" id="005c" name="ZW092 Z-Stick Lite Gen5 AU"/>
 		<Product type="0002" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
 		<Product type="0102" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
-		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5AU" config="aeotec/zw095.xml" />
+		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5 AU" config="aeotec/zw095.xml" />
 		<Product type="0003" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0103" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0203" id="0060" name="ZW096 Smart Switch 6AU" config="aeotec/zw096.xml" />
@@ -122,7 +122,7 @@
 		<Product type="0203" id="0062" name="ZW098 LED Bulb" config="aeotec/zw098.xml" />
 		<Product type="0003" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0103" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
-		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6AU" config="aeotec/zw099.xml" />
+		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6 AU" config="aeotec/zw099.xml" />
 		<Product type="1D03" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0002" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
 		<Product type="0102" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
@@ -136,7 +136,7 @@
 		<Product type="0202" id="0070" name="ZW112 Door Window Sensor 6" config="aeotec/zw112.xml" />
 		<Product type="0003" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0103" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
-		<Product type="0203" id="0074" name="ZW116 Nano SwitchAU" config="aeotec/zw116.xml"/>
+		<Product type="0203" id="0074" name="ZW116 Nano Switch AU" config="aeotec/zw116.xml"/>
 		<Product type="1d03" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0004" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>
 		<Product type="0104" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>
@@ -444,25 +444,25 @@
 		<Product type="0501" id="0102" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="0109" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="1002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
-		<Product type="0501" id="3002" name="FGBS001 Universal Binary SensorAu" config="fibaro/fgbs001.xml" />
+		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor AU" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="4002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0100" id="0104" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0106" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0109" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="100a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500WAU" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W AU" config="fibaro/fgd211.xml" />
 		<Product type="0102" id="1000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="2000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml"/>
-		<Product type="0102" id="3000" name="FGD212 Dimmer 2AU" config="fibaro/fgd212.xml" />
+		<Product type="0102" id="3000" name="FGD212 Dimmer 2 AU" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="4000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0700" id="1000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="2000" name="FGK10x Door Opening Sensor" config="fibaro/fgk001.xml" />
-		<Product type="0700" id="3000" name="FGK101 Door Opening SensorAu" config="fibaro/fgk001.xml" />
+		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor AU" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="4000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0701" id="1001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
 		<Product type="0701" id="2001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
-		<Product type="0701" id="3001" name="FGK10x Door Opening SensorAu" config="fibaro/fgk10x.xml" />
+		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor AU" config="fibaro/fgk10x.xml" />
 		<Product type="0702" id="1000" name="FGDW002 Door Opening Sensor 2" config="fibaro/fgdw2.xml" />
 		<Product type="0300" id="0104" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0300" id="100a" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
@@ -471,7 +471,7 @@
 		<Product type="0300" id="0109" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0301" id="1001" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
 		<Product type="0302" id="1000" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
-		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2AU" config="fibaro/fgrm222.xml"/>
+		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2 AU" config="fibaro/fgrm222.xml"/>
 		<Product type="0400" id="0104" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0105" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0106" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
@@ -484,25 +484,25 @@
 		<Product type="0402" id="3002" name="FGS212 Switch 3kW" config="fibaro/fgs212.xml" />
 		<Product type="0403" id="1000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
 		<Product type="0403" id="2000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
-		<Product type="0403" id="3000" name="FGS213 SwitchAu" config="fibaro/fgs213.xml"/>
+		<Product type="0403" id="3000" name="FGS213 Switch AU" config="fibaro/fgs213.xml"/>
 		<Product type="0200" id="0104" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0105" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0106" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0107" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0109" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="100a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
-		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kWAu" config="fibaro/fgs221.xml" />
+		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW AU" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="400a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0202" id="1002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
-		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kWAu" config="fibaro/fgs222.xml" />
+		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW AU" config="fibaro/fgs222.xml" />
 		<Product type="0203" id="1000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
-		<Product type="0203" id="3000" name="FGS223 Double RelayAu" config="fibaro/fgs223.xml"/>
+		<Product type="0203" id="3000" name="FGS223 Double Relay AU config="fibaro/fgs223.xml"/>
 		<Product type="0600" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml" />
 		<Product type="0200" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml"/>
 		<Product type="0602" id="1001" name="FGWPE/F Wall Plug Gen5" config="fibaro/fgwpfzw5.xml" />
 		<Product type="0800" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="2001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
-		<Product type="0800" id="3001" name="FGMS001 Motion SensorAu" config="fibaro/fgms.xml" />
+		<Product type="0800" id="3001" name="FGMS001 Motion Sensor AU" config="fibaro/fgms.xml" />
 		<Product type="0800" id="4001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<!--<Product type="0801" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />-->
 		<Product type="0801" id="1001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
@@ -517,19 +517,19 @@
 		<Product type="0b01" id="2002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0900" id="1000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0900" id="2000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
-		<Product type="0900" id="3000" name="FGRGBWM441 RGBW ControllerAU" config="fibaro/fgrgbwm441.xml"/>
+		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller AU" config="fibaro/fgrgbwm441.xml"/>
 		<Product type="0900" id="4000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0c00" id="1000" name="FGSS101 Smoke Sensor" config="fibaro/fgss101.xml" />
 		<Product type="0c02" id="1002" name="FGSD002 Smoke Sensor" config="fibaro/fgsd002.xml" />
 		<Product type="0d01" id="1000" name="FGGC001 Swipe" config="fibaro/fggc001.xml" />
 		<Product type="0d01" id="2000" name="FGGC001 Swipe" config="fibaro/fggc001.xml"/>
-		<Product type="0d01" id="3000" name="FGGC001 SwipeAu" config="fibaro/fggc001.xml"/>
+		<Product type="0d01" id="3000" name="FGGC001 Swipe AU" config="fibaro/fggc001.xml"/>
 		<Product type="0f01" id="1000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
 		<Product type="0f01" id="2000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
-		<Product type="0f01" id="3000" name="FGPB101 ButtonAu" config="fibaro/fgpb101.xml" />
+		<Product type="0f01" id="3000" name="FGPB101 Button AU" config="fibaro/fgpb101.xml" />
 		<Product type="1001" id="1000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
 		<Product type="1001" id="2000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
-		<Product type="1001" id="3000" name="FGKF601 KeyfobAu" config="fibaro/fgkf601.xml" />
+		<Product type="1001" id="3000" name="FGKF601 Keyfob AU" config="fibaro/fgkf601.xml" />
 		<Product type="1201" id="1000" name="FGSD001 CO Sensor" config="fibaro/fgcd001.xml" />
 		<Product type="1301" id="1000" name="FGT001 Heat Controller" config="fibaro/fgt001.xml"/>
 	</Manufacturer>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -62,7 +62,7 @@
 		<Product type="0003" id="000c" name="DSC12104 Micro Smart Energy Switch" config="aeotec/dsc12104.xml"/>
 		<Product type="0003" id="000d" name="DSC13104 Micro Smart Energy Illuminator" config="aeotec/dsc13104.xml"/>
 		<Product type="0003" id="000e" name="DSC14104 Micro Motor Controller" config="aeotec/dsc14104.xml"/>
-		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition) AU" config="aeotec/dsc18103.xml" />
+		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition)" config="aeotec/dsc18103.xml" />
 		<Product type="0003" id="0013" name="DSC19103 Micro Smart Dimmer (2nd Edition)" config="aeotec/dsc19103.xml" />
 		<Product type="0003" id="001a" name="DSC26103 Micro Switch (2nd Edition)" config="aeotec/dsc26103.xml"/>
 		<Product type="0003" id="001b" name="DSC27103 Micro Dimmer (2nd Edition)" config="aeotec/dsc27103.xml"/>
@@ -83,13 +83,13 @@
 		<Product type="0A04" id="0038" name="ZW056 Doorbell Gen5" config="aeotec/zw056.xml" />
 		<Product type="0003" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
 		<Product type="0103" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
-		<Product type="0203" id="003e" name="ZW062 Garage Door ControllerAU" config="aeotec/zw062.xml" />
+		<Product type="0203" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
 		<Product type="0002" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
 		<Product type="0102" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
-		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5 AU" config="aeotec/zw074.xml"/>
+		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
 		<Product type="0003" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
 		<Product type="0103" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
-		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5 AU" config="aeotec/zw075.xml"/>
+		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
 		<Product type="0003" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0103" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0203" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
@@ -102,15 +102,15 @@
 		<Product type="0002" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0102" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0202" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
-		<Product type="0001" id="005a" name="ZW090 Z-Stick Gen5 EU" config="aeotec/zw090.xml"/>
-		<Product type="0101" id="005a" name="ZW090 Z-Stick Gen5 US" config="aeotec/zw090.xml"/>
-		<Product type="0201" id="005a" name="ZW090 Z-Stick Gen5 AU" config="aeotec/zw090.xml"/>
-		<Product type="0001" id="005c" name="ZW092 Z-Stick Lite Gen5 EU"/>
-		<Product type="0101" id="005c" name="ZW092 Z-Stick Lite Gen5 US"/>
-		<Product type="0201" id="005c" name="ZW092 Z-Stick Lite Gen5 AU"/>
+		<Product type="0001" id="005a" name="ZW090 Z-Stick Gen5" config="aeotec/zw090.xml"/>
+		<Product type="0101" id="005a" name="ZW090 Z-Stick Gen5" config="aeotec/zw090.xml"/>
+		<Product type="0201" id="005a" name="ZW090 Z-Stick Gen5" config="aeotec/zw090.xml"/>
+		<Product type="0001" id="005c" name="ZW092 Z-Stick Lite Gen5"/>
+		<Product type="0101" id="005c" name="ZW092 Z-Stick Lite Gen5"/>
+		<Product type="0201" id="005c" name="ZW092 Z-Stick Lite Gen5"/>
 		<Product type="0002" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
 		<Product type="0102" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
-		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5 AU" config="aeotec/zw095.xml" />
+		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
 		<Product type="0003" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0103" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0203" id="0060" name="ZW096 Smart Switch 6AU" config="aeotec/zw096.xml" />
@@ -444,25 +444,25 @@
 		<Product type="0501" id="0102" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="0109" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="1002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
-		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor ANZ [3002]" config="fibaro/fgbs001.xml" />
+		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="4002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0100" id="0104" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0106" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W ANZ [0107]" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0109" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="100a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W ANZ [300a]" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0102" id="1000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="2000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml"/>
-		<Product type="0102" id="3000" name="FGD212 Dimmer 2 ANZ [3000]" config="fibaro/fgd212.xml" />
+		<Product type="0102" id="3000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="4000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0700" id="1000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="2000" name="FGK10x Door Opening Sensor" config="fibaro/fgk001.xml" />
-		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor ANZ [3000]" config="fibaro/fgk001.xml" />
+		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="4000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0701" id="1001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
 		<Product type="0701" id="2001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
-		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor ANZ [3001]" config="fibaro/fgk10x.xml" />
+		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
 		<Product type="0702" id="1000" name="FGDW002 Door Opening Sensor 2" config="fibaro/fgdw2.xml" />
 		<Product type="0300" id="0104" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0300" id="100a" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
@@ -471,7 +471,7 @@
 		<Product type="0300" id="0109" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0301" id="1001" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
 		<Product type="0302" id="1000" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
-		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2 ANZ [3000]" config="fibaro/fgrm222.xml"/>
+		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
 		<Product type="0400" id="0104" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0105" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0106" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
@@ -484,25 +484,25 @@
 		<Product type="0402" id="3002" name="FGS212 Switch 3kW" config="fibaro/fgs212.xml" />
 		<Product type="0403" id="1000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
 		<Product type="0403" id="2000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
-		<Product type="0403" id="3000" name="FGS213 Switch ANZ [3000]" config="fibaro/fgs213.xml"/>
+		<Product type="0403" id="3000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
 		<Product type="0200" id="0104" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0105" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0106" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0107" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0109" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="100a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
-		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW ANZ [300a]" config="fibaro/fgs221.xml" />
+		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="400a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0202" id="1002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
-		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW ANZ [3002]" config="fibaro/fgs222.xml" />
+		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
 		<Product type="0203" id="1000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
-		<Product type="0203" id="3000" name="FGS223 Double Relay ANZ [3000]" config="fibaro/fgs223.xml"/>
+		<Product type="0203" id="3000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
 		<Product type="0600" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml" />
 		<Product type="0200" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml"/>
 		<Product type="0602" id="1001" name="FGWPE/F Wall Plug Gen5" config="fibaro/fgwpfzw5.xml" />
 		<Product type="0800" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="2001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
-		<Product type="0800" id="3001" name="FGMS001 Motion Sensor ANZ [3001]" config="fibaro/fgms.xml" />
+		<Product type="0800" id="3001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="4001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<!--<Product type="0801" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />-->
 		<Product type="0801" id="1001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
@@ -517,19 +517,19 @@
 		<Product type="0b01" id="2002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0900" id="1000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0900" id="2000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
-		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller ANZ [3000]" config="fibaro/fgrgbwm441.xml"/>
+		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
 		<Product type="0900" id="4000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0c00" id="1000" name="FGSS101 Smoke Sensor" config="fibaro/fgss101.xml" />
 		<Product type="0c02" id="1002" name="FGSD002 Smoke Sensor" config="fibaro/fgsd002.xml" />
 		<Product type="0d01" id="1000" name="FGGC001 Swipe" config="fibaro/fggc001.xml" />
 		<Product type="0d01" id="2000" name="FGGC001 Swipe" config="fibaro/fggc001.xml"/>
-		<Product type="0d01" id="3000" name="FGGC001 Swipe ANZ [3000]" config="fibaro/fggc001.xml"/>
+		<Product type="0d01" id="3000" name="FGGC001 Swipe" config="fibaro/fggc001.xml"/>
 		<Product type="0f01" id="1000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
 		<Product type="0f01" id="2000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
-		<Product type="0f01" id="3000" name="FGPB101 Button ANZ [3000]" config="fibaro/fgpb101.xml" />
+		<Product type="0f01" id="3000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
 		<Product type="1001" id="1000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
 		<Product type="1001" id="2000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
-		<Product type="1001" id="3000" name="FGKF601 Keyfob ANZ [3000]" config="fibaro/fgkf601.xml" />
+		<Product type="1001" id="3000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
 		<Product type="1201" id="1000" name="FGSD001 CO Sensor" config="fibaro/fgcd001.xml" />
 		<Product type="1301" id="1000" name="FGT001 Heat Controller" config="fibaro/fgt001.xml"/>
 	</Manufacturer>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -62,7 +62,7 @@
 		<Product type="0003" id="000c" name="DSC12104 Micro Smart Energy Switch" config="aeotec/dsc12104.xml"/>
 		<Product type="0003" id="000d" name="DSC13104 Micro Smart Energy Illuminator" config="aeotec/dsc13104.xml"/>
 		<Product type="0003" id="000e" name="DSC14104 Micro Motor Controller" config="aeotec/dsc14104.xml"/>
-		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition)" config="aeotec/dsc18103.xml" />
+		<Product type="0003" id="0012" name="DSC18103 Micro Smart Switch (2nd Edition)AU" config="aeotec/dsc18103.xml" />
 		<Product type="0003" id="0013" name="DSC19103 Micro Smart Dimmer (2nd Edition)" config="aeotec/dsc19103.xml" />
 		<Product type="0003" id="001a" name="DSC26103 Micro Switch (2nd Edition)" config="aeotec/dsc26103.xml"/>
 		<Product type="0003" id="001b" name="DSC27103 Micro Dimmer (2nd Edition)" config="aeotec/dsc27103.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -98,7 +98,7 @@
 		<Product type="0204" id="0050" name="ZW080 Siren Gen5" config="aeotec/zw080.xml"/>
 		<Product type="0001" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
 		<Product type="0101" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
-		<Product type="0201" id="0058" name="ZW088 Key Fob Gen5AU" config="aeotec/zw088.xml"/>
+		<Product type="0201" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
 		<Product type="0002" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0102" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0202" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
@@ -113,7 +113,7 @@
 		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
 		<Product type="0003" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0103" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
-		<Product type="0203" id="0060" name="ZW096 Smart Switch 6AU" config="aeotec/zw096.xml" />
+		<Product type="0203" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0002" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
 		<Product type="0102" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
 		<Product type="0202" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
@@ -122,11 +122,11 @@
 		<Product type="0203" id="0062" name="ZW098 LED Bulb" config="aeotec/zw098.xml" />
 		<Product type="0003" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0103" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
-		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6 AU" config="aeotec/zw099.xml" />
+		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="1D03" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0002" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
 		<Product type="0102" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
-		<Product type="0202" id="0064" name="ZW100 MultiSensor 6AU" config="aeotec/zw100.xml" />
+		<Product type="0202" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
 		<Product type="0003" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
 		<Product type="0103" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
 		<Product type="0203" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
@@ -136,7 +136,7 @@
 		<Product type="0202" id="0070" name="ZW112 Door Window Sensor 6" config="aeotec/zw112.xml" />
 		<Product type="0003" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0103" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
-		<Product type="0203" id="0074" name="ZW116 Nano Switch AU" config="aeotec/zw116.xml"/>
+		<Product type="0203" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="1d03" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0004" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>
 		<Product type="0104" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -83,13 +83,13 @@
 		<Product type="0A04" id="0038" name="ZW056 Doorbell Gen5" config="aeotec/zw056.xml" />
 		<Product type="0003" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
 		<Product type="0103" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
-		<Product type="0203" id="003e" name="ZW062 Garage Door Controller" config="aeotec/zw062.xml" />
+		<Product type="0203" id="003e" name="ZW062 Garage Door ControllerAU" config="aeotec/zw062.xml" />
 		<Product type="0002" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
 		<Product type="0102" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
-		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5" config="aeotec/zw074.xml"/>
+		<Product type="0202" id="004a" name="ZW074 MultiSensor Gen5AU" config="aeotec/zw074.xml"/>
 		<Product type="0003" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
 		<Product type="0103" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
-		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5" config="aeotec/zw075.xml"/>
+		<Product type="0203" id="004b" name="ZW075 Smart Switch Gen5AU" config="aeotec/zw075.xml"/>
 		<Product type="0003" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0103" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
 		<Product type="0203" id="004e" name="ZW078 Heavy Duty Smart Switch Gen5" config="aeotec/zw078.xml" />
@@ -98,7 +98,7 @@
 		<Product type="0204" id="0050" name="ZW080 Siren Gen5" config="aeotec/zw080.xml"/>
 		<Product type="0001" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
 		<Product type="0101" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
-		<Product type="0201" id="0058" name="ZW088 Key Fob Gen5" config="aeotec/zw088.xml"/>
+		<Product type="0201" id="0058" name="ZW088 Key Fob Gen5AU" config="aeotec/zw088.xml"/>
 		<Product type="0002" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0102" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
 		<Product type="0202" id="0059" name="ZW089 Recessed Door Sensor Gen5" config="aeotec/zw089.xml"/>
@@ -110,10 +110,10 @@
 		<Product type="0201" id="005c" name="ZW092 Z-Stick Lite Gen5 AU"/>
 		<Product type="0002" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
 		<Product type="0102" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
-		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5" config="aeotec/zw095.xml" />
+		<Product type="0202" id="005f" name="ZW095 Home Energy Meter Gen5AU" config="aeotec/zw095.xml" />
 		<Product type="0003" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
 		<Product type="0103" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
-		<Product type="0203" id="0060" name="ZW096 Smart Switch 6" config="aeotec/zw096.xml" />
+		<Product type="0203" id="0060" name="ZW096 Smart Switch 6AU" config="aeotec/zw096.xml" />
 		<Product type="0002" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
 		<Product type="0102" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
 		<Product type="0202" id="0061" name="ZW097 Dry Contact Sensor Gen5" config="aeotec/zw097.xml" />
@@ -122,11 +122,11 @@
 		<Product type="0203" id="0062" name="ZW098 LED Bulb" config="aeotec/zw098.xml" />
 		<Product type="0003" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0103" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
-		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
+		<Product type="0203" id="0063" name="ZW099 Smart Dimmer 6AU" config="aeotec/zw099.xml" />
 		<Product type="1D03" id="0063" name="ZW099 Smart Dimmer 6" config="aeotec/zw099.xml" />
 		<Product type="0002" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
 		<Product type="0102" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
-		<Product type="0202" id="0064" name="ZW100 MultiSensor 6" config="aeotec/zw100.xml" />
+		<Product type="0202" id="0064" name="ZW100 MultiSensor 6AU" config="aeotec/zw100.xml" />
 		<Product type="0003" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
 		<Product type="0103" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
 		<Product type="0203" id="006f" name="ZW111 Nano Dimmer" config="aeotec/zw111.xml"/>
@@ -136,7 +136,7 @@
 		<Product type="0202" id="0070" name="ZW112 Door Window Sensor 6" config="aeotec/zw112.xml" />
 		<Product type="0003" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0103" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
-		<Product type="0203" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
+		<Product type="0203" id="0074" name="ZW116 Nano SwitchAU" config="aeotec/zw116.xml"/>
 		<Product type="1d03" id="0074" name="ZW116 Nano Switch" config="aeotec/zw116.xml"/>
 		<Product type="0004" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>
 		<Product type="0104" id="0075" name="ZW117 Range Extender 6" config="aeotec/zw117.xml"/>
@@ -444,25 +444,25 @@
 		<Product type="0501" id="0102" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="0109" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="1002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
-		<Product type="0501" id="3002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
+		<Product type="0501" id="3002" name="FGBS001 Universal Binary SensorAu" config="fibaro/fgbs001.xml" />
 		<Product type="0501" id="4002" name="FGBS001 Universal Binary Sensor" config="fibaro/fgbs001.xml" />
 		<Product type="0100" id="0104" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0106" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0107" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="0109" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
 		<Product type="0100" id="100a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
-		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500W" config="fibaro/fgd211.xml" />
+		<Product type="0100" id="300a" name="FGD211 Universal Dimmer 500WAU" config="fibaro/fgd211.xml" />
 		<Product type="0102" id="1000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="2000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml"/>
-		<Product type="0102" id="3000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
+		<Product type="0102" id="3000" name="FGD212 Dimmer 2AU" config="fibaro/fgd212.xml" />
 		<Product type="0102" id="4000" name="FGD212 Dimmer 2" config="fibaro/fgd212.xml" />
 		<Product type="0700" id="1000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="2000" name="FGK10x Door Opening Sensor" config="fibaro/fgk001.xml" />
-		<Product type="0700" id="3000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
+		<Product type="0700" id="3000" name="FGK101 Door Opening SensorAu" config="fibaro/fgk001.xml" />
 		<Product type="0700" id="4000" name="FGK101 Door Opening Sensor" config="fibaro/fgk001.xml" />
 		<Product type="0701" id="1001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
 		<Product type="0701" id="2001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
-		<Product type="0701" id="3001" name="FGK10x Door Opening Sensor" config="fibaro/fgk10x.xml" />
+		<Product type="0701" id="3001" name="FGK10x Door Opening SensorAu" config="fibaro/fgk10x.xml" />
 		<Product type="0702" id="1000" name="FGDW002 Door Opening Sensor 2" config="fibaro/fgdw2.xml" />
 		<Product type="0300" id="0104" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0300" id="100a" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
@@ -471,6 +471,7 @@
 		<Product type="0300" id="0109" name="FGR221 Roller Shutter Controller" config="fibaro/fgr221.xml"/>
 		<Product type="0301" id="1001" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
 		<Product type="0302" id="1000" name="FGRM222 Roller Shutter Controller 2" config="fibaro/fgrm222.xml"/>
+		<Product type="0302" id="3000" name="FGRM222 Roller Shutter Controller 2AU" config="fibaro/fgrm222.xml"/>
 		<Product type="0400" id="0104" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0105" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
 		<Product type="0400" id="0106" name="FGS211 Switch 3kW" config="fibaro/fgs211.xml" />
@@ -483,24 +484,25 @@
 		<Product type="0402" id="3002" name="FGS212 Switch 3kW" config="fibaro/fgs212.xml" />
 		<Product type="0403" id="1000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
 		<Product type="0403" id="2000" name="FGS213 Switch" config="fibaro/fgs213.xml"/>
+		<Product type="0403" id="3000" name="FGS213 SwitchAu" config="fibaro/fgs213.xml"/>
 		<Product type="0200" id="0104" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0105" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0106" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0107" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="0109" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="100a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
-		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
+		<Product type="0200" id="300a" name="FGS221 Double Relay Switch 2x1.5kWAu" config="fibaro/fgs221.xml" />
 		<Product type="0200" id="400a" name="FGS221 Double Relay Switch 2x1.5kW" config="fibaro/fgs221.xml" />
 		<Product type="0202" id="1002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
-		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kW" config="fibaro/fgs222.xml" />
+		<Product type="0202" id="3002" name="FGS222 Double Relay Switch 2x1.5kWAu" config="fibaro/fgs222.xml" />
 		<Product type="0203" id="1000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
-		<Product type="0203" id="3000" name="FGS223 Double Relay" config="fibaro/fgs223.xml"/>
+		<Product type="0203" id="3000" name="FGS223 Double RelayAu" config="fibaro/fgs223.xml"/>
 		<Product type="0600" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml" />
 		<Product type="0200" id="1000" name="FGWPE/F Wall Plug" config="fibaro/fgwpe.xml"/>
 		<Product type="0602" id="1001" name="FGWPE/F Wall Plug Gen5" config="fibaro/fgwpfzw5.xml" />
 		<Product type="0800" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<Product type="0800" id="2001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
-		<Product type="0800" id="3001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
+		<Product type="0800" id="3001" name="FGMS001 Motion SensorAu" config="fibaro/fgms.xml" />
 		<Product type="0800" id="4001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />
 		<!--<Product type="0801" id="1001" name="FGMS001 Motion Sensor" config="fibaro/fgms.xml" />-->
 		<Product type="0801" id="1001" name="FGMS001-ZW5 Motion Sensor" config="fibaro/fgmszw5.xml"/>
@@ -515,15 +517,19 @@
 		<Product type="0b01" id="2002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0900" id="1000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0900" id="2000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
+		<Product type="0900" id="3000" name="FGRGBWM441 RGBW ControllerAU" config="fibaro/fgrgbwm441.xml"/>
 		<Product type="0900" id="4000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0c00" id="1000" name="FGSS101 Smoke Sensor" config="fibaro/fgss101.xml" />
 		<Product type="0c02" id="1002" name="FGSD002 Smoke Sensor" config="fibaro/fgsd002.xml" />
 		<Product type="0d01" id="1000" name="FGGC001 Swipe" config="fibaro/fggc001.xml" />
 		<Product type="0d01" id="2000" name="FGGC001 Swipe" config="fibaro/fggc001.xml"/>
+		<Product type="0d01" id="3000" name="FGGC001 SwipeAu" config="fibaro/fggc001.xml"/>
 		<Product type="0f01" id="1000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
 		<Product type="0f01" id="2000" name="FGPB101 Button" config="fibaro/fgpb101.xml" />
+		<Product type="0f01" id="3000" name="FGPB101 ButtonAu" config="fibaro/fgpb101.xml" />
 		<Product type="1001" id="1000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
 		<Product type="1001" id="2000" name="FGKF601 Keyfob" config="fibaro/fgkf601.xml" />
+		<Product type="1001" id="3000" name="FGKF601 KeyfobAu" config="fibaro/fgkf601.xml" />
 		<Product type="1201" id="1000" name="FGSD001 CO Sensor" config="fibaro/fgcd001.xml" />
 		<Product type="1301" id="1000" name="FGT001 Heat Controller" config="fibaro/fgt001.xml"/>
 	</Manufacturer>


### PR DESCRIPTION
Added Fibaro AU items (RGBW, and Shutter2 controller), plus added AU to ANZ fibaro and Aeotec devices. This aids configuration debugging as not all devices are identified correctly (fibaro FGD211 in my case)
