### PR TITLE
Initial NetBSD port

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -57,6 +57,9 @@ endif
 endif
 # For 10.2 and later, use iconv from base, no extra include path required.
 
+else ifeq ($(UNAME),NetBSD)
+CFLAGS += -I/usr/pkg/include/libusb-1.0
+LDFLAGS+= -shared -L/usr/pkg/lib -lusb-1.0 -Wl,-rpath=/usr/pkg/lib
 else
 LDFLAGS += -shared -Wl,-soname,$(SHARED_LIB_NAME)
 LIBS 	+= -ludev
@@ -72,6 +75,8 @@ ifeq ($(UNAME),Darwin)
 SOURCES_HIDAPI =$(top_srcdir)/cpp/hidapi/mac
 else ifeq ($(UNAME),FreeBSD)
 SOURCES_HIDAPI =$(top_srcdir)/cpp/hidapi/libusb
+else ifeq ($(UNAME),NetBSD)
+SOURCES_HIDAPI =$(top_srcdir)/cpp/hidapi/libusb
 else
 SOURCES_HIDAPI =$(top_srcdir)/cpp/hidapi/linux
 endif
@@ -81,13 +86,14 @@ SOURCES		:= $(top_srcdir)/cpp/src $(top_srcdir)/cpp/src/command_classes $(top_sr
 	$(top_srcdir)/cpp/src/value_classes $(top_srcdir)/cpp/src/platform $(top_srcdir)/cpp/src/platform/unix $(SOURCES_HIDAPI) $(top_srcdir)/cpp/src/aes/
 VPATH = $(top_srcdir)/cpp/src:$(top_srcdir)/cpp/src/command_classes:$(top_srcdir)/cpp/tinyxml:\
 	$(top_srcdir)/cpp/src/value_classes:$(top_srcdir)/cpp/src/platform:$(top_srcdir)/cpp/src/platform/unix:$(SOURCES_HIDAPI):$(top_srcdir)/cpp/src/aes/
-	
 
 tinyxml := $(notdir $(wildcard $(top_srcdir)/cpp/tinyxml/*.cpp))
 
 ifeq ($(UNAME),Darwin)
 hidapi := $(notdir $(wildcard $(top_srcdir)/cpp/hidapi/mac/*.c))
 else ifeq ($(UNAME),FreeBSD)
+hidapi := $(notdir $(wildcard $(top_srcdir)/cpp/hidapi/libusb/*.c))
+else ifeq ($(UNAME),NetBSD)
 hidapi := $(notdir $(wildcard $(top_srcdir)/cpp/hidapi/libusb/*.c))
 else
 hidapi := $(notdir $(wildcard $(top_srcdir)/cpp/hidapi/linux/*.c)) # we do not want the libusb version
@@ -130,7 +136,7 @@ $(top_srcdir)/cpp/src/vers.cpp:
 	@echo 'uint16_t ozw_vers_minor = $(VERSION_MIN);' >> $(top_srcdir)/cpp/src/vers.cpp
 	@echo 'uint16_t ozw_vers_revision = $(VERSION_REV);' >> $(top_srcdir)/cpp/src/vers.cpp
 	@echo 'char ozw_version_string[] = "$(GITVERSION)";' >> $(top_srcdir)/cpp/src/vers.cpp
-	
+
 
 #$(OBJDIR)/vers.o:	$(top_builddir)/vers.cpp
 
@@ -176,7 +182,7 @@ $(top_builddir)/ozw_config: $(top_srcdir)/cpp/build/ozw_config.in
 		-e 's|[@]pkgconfigfile@|$(pkgconfigdir)/libopenzwave.pc|g' \
 		< "$<" > "$@"
 	@chmod +x $(top_builddir)/ozw_config
-	
+
 ifeq ($(DOT),)
 HAVE_DOT = -e 's|[@]HAVE_DOT@|NO|g' 
 else
@@ -234,7 +240,7 @@ install: $(LIBDIR)/$(SHARED_LIB_NAME) doc $(top_builddir)/libopenzwave.pc $(top_
 	@cp $(top_builddir)/ozw_config $(DESTDIR)/$(PREFIX)/bin/ozw_config
 	@chmod 755 $(DESTDIR)/$(PREFIX)/bin/ozw_config
 
-	
+
 
 .SUFFIXES:	.d .cpp .o .a
 .PHONY:	default clean install doc

--- a/cpp/build/support.mk
+++ b/cpp/build/support.mk
@@ -123,15 +123,18 @@ export top_builddir
 OBJDIR = $(top_builddir)/.lib
 DEPDIR = $(top_builddir)/.dep
 
-
-
+ifeq ($(UNAME),NetBSD)
+FMTCMD = fmt -g 1
+else
+FMTCMD = fmt -1
+endif
 
 $(OBJDIR)/%.o : %.cpp
 	@echo "Building $(notdir $@)"
 	@$(CXX) -MM $(CFLAGS) $(INCLUDES) $< > $(DEPDIR)/$*.d
 	@mv -f $(DEPDIR)/$*.d $(DEPDIR)/$*.d.tmp
 	@$(SED) -e 's|.*:|$(OBJDIR)/$*.o: $(DEPDIR)/$*.d|' < $(DEPDIR)/$*.d.tmp > $(DEPDIR)/$*.d;
-	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | fmt -1 | \
+	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | $(FMTCMD) | \
 	  $(SED) -e 's/^ *//' -e 's/$$/:/' >> $(DEPDIR)/.$*.d;
 	@rm -f $(DEPDIR)/$*.d.tmp
 	@$(CXX) $(CFLAGS) $(TARCH) $(INCLUDES) -o $@ $<
@@ -142,7 +145,7 @@ $(OBJDIR)/%.o : %.c
 	@$(CC) -MM $(CFLAGS) $(INCLUDES) $< > $(DEPDIR)/$*.d
 	@mv -f $(DEPDIR)/$*.d $(DEPDIR)/$*.d.tmp
 	@$(SED) -e 's|.*:|$(OBJDIR)/$*.o: $(DEPDIR)/$*.d|' < $(DEPDIR)/$*.d.tmp > $(DEPDIR)/$*.d;
-	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | fmt -1 | \
+	@$(SED) -e 's/.*://' -e 's/\\$$//' < $(DEPDIR)/$*.d.tmp | $(FMTCMD) | \
 	  $(SED) -e 's/^ *//' -e 's/$$/:/' >> $(DEPDIR)/.$*.d;
 	@rm -f $(DEPDIR)/$*.d.tmp
 	@$(CC) $(CFLAGS) $(TARCH) $(INCLUDES) -o $@ $<

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -53,6 +53,8 @@ LDFLAGS+= -L/usr/local/lib -liconv
 endif
 endif
 
+else ifeq ($(UNAME),NetBSD)
+LDFLAGS+= -L/usr/pkg/lib -lusb-1.0
 endif
 
 $(OBJDIR)/MinOZW:	$(patsubst %.cpp,$(OBJDIR)/%.o,$(minozwsrc))

--- a/cpp/hidapi/libusb/hid.c
+++ b/cpp/hidapi/libusb/hid.c
@@ -369,7 +369,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	inbytes = len-2;
 	outptr = (char*) wbuf;
 	outbytes = sizeof(wbuf);
-	res = iconv(ic, &inptr, &inbytes, &outptr, &outbytes);
+	res = iconv(ic, (const char ** restrict)&inptr, &inbytes, &outptr, &outbytes);
 	if (res == (size_t)-1) {
 		LOG("iconv() failed\n");
 		goto err;

--- a/cpp/src/platform/unix/EventImpl.cpp
+++ b/cpp/src/platform/unix/EventImpl.cpp
@@ -52,7 +52,9 @@ EventImpl::EventImpl
 	
 	pthread_condattr_t ca;
 	pthread_condattr_init( &ca );
+#ifndef __NetBSD__
 	pthread_condattr_setpshared( &ca, PTHREAD_PROCESS_PRIVATE );
+#endif
 	pthread_cond_init( &m_condition, &ca );
 	pthread_condattr_destroy( &ca );
 }

--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -185,7 +185,11 @@ bool SerialControllerImpl::Init
 	
 	Log::Write( LogLevel_Info, "Trying to open serial port %s (attempt %d)", device.c_str(), _attempts );
 	
+#ifdef __NetBSD__
+	m_hSerialController = open( device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+#else
 	m_hSerialController = open( device.c_str(), O_RDWR | O_NOCTTY, 0 );
+#endif
 
 	if( -1 == m_hSerialController )
 	{


### PR DESCRIPTION
These are the changes I had to make to get open-zwave working (with domoticz) under NetBSD/amd64-current. There's just a very small handful:

- help the build system find libusb-1.0, so it can build the USB bits
- correct for a command line option difference in the fmt(1) utility
- drop a call to an unimplemented phtreads function (the call just sets what's default, anyway, so nfc)
- open the USB serial device O_NONBLOCK, so the call to open(2) doesn't hang

With these changes, domoticz happily uses my Aeotec and Z-Wave.Me USB sticks.