### PR TITLE
Fix issue with $pkgconfigdir not being used as an absolute path

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -228,8 +228,8 @@ install: $(LIBDIR)/$(SHARED_LIB_NAME) doc $(top_builddir)/libopenzwave.pc $(top_
 	@cp -r $(top_srcdir)/docs/* $(DESTDIR)/$(docdir)
 	@if [ -d "$(top_builddir)/docs/html/" ]; then cp -r $(top_builddir)/docs/html/* $(DESTDIR)/$(docdir); fi
 	@echo "Installing Pkg-config Files"
-	@install -d $(DESTDIR)/$(pkgconfigdir) 
-	@cp $(top_builddir)/libopenzwave.pc $(DESTDIR)/$(pkgconfigdir)
+	@install -d $(pkgconfigdir) 
+	@cp $(top_builddir)/libopenzwave.pc $(pkgconfigdir)
 	@install -d $(DESTDIR)/$(PREFIX)/bin/
 	@cp $(top_builddir)/ozw_config $(DESTDIR)/$(PREFIX)/bin/ozw_config
 	@chmod 755 $(DESTDIR)/$(PREFIX)/bin/ozw_config


### PR DESCRIPTION
In the Makefile during the install step, `$pkgconfigdir` is prefixed with `$DESTDIR`. However, `$pkgconfigdir` is an absolute path already and this causes the package configuration files to be placed in an incorrect directory (aka, not recognized by `pkg-config`) whenever the `$DESTDIR` is not `/`. This is for example the case when cross-compiling.

This change fixes the install step for such scenarios without any impact to builds targetting `/`.