### PR TITLE
Allow RemoveWatcher to be called from a watcher callback

### DIFF
--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1644,9 +1644,10 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		};
 
 OPENZWAVE_EXPORT_WARNINGS_OFF
-		list<Watcher*>		m_watchers;										// List of all the registered watchers.
+		list<Watcher*>					m_watchers;							// List of all the registered watchers.
+		list<list<Watcher*>::iterator*> m_watcherIterators;					// Iterators currently operating on the list of watchers
 OPENZWAVE_EXPORT_WARNINGS_ON
-		Mutex*				m_notificationMutex;
+		Mutex*							m_notificationMutex;
 
 	//-----------------------------------------------------------------------------
 	// Controller commands


### PR DESCRIPTION
Right now, it is not possible to remove a watcher from from the callback itself, because this causes the iterator in `NotifyWatchers` to be invalidated. In other words, there are scenario's in which it is unsafe to call `RemoveWatcher`.

As an example, it is currently not possible to write code like below without causing a fatal crash (simplified example):
```cpp
void OnNotification ( Notification const* _notification, void* _context ) {
    // Do something we only need to do once
    // ...

    // We no longer need notifications, remove this watcher
    Manager::Get()->RemoveWatcher( OnNotification, NULL );
}

Manager::Get()->AddWatcher( OnNotification, NULL );
```

In this simplified example it is of course a bit silly to want to remove the watcher, but in a more complex application it may make sense to remove watchers like this. Right now, an application creator could write some workaround code to be able to remove the watcher, but that introduces additional complexity for them solely to deal with an internal limitation of the library.

This proposed change removes this limitation by updating the `NotifyWatchers` iterator when removing a watcher, thus making the `RemoveWatcher` method safe to call even from a watcher callback.

Note that I opted to use a list of iterators instead of a single property for holding the current iterator, as that ensures this piece of code will not break when (possibly due to future changes) `NotifyWatchers` is called recursively. The overhead of using a list is expected to be negligible. Also, due to both methods locking the NotificationMutex this change is thread-safe.