### PR TITLE
Revert "Fix issue with $pkgconfigdir not being used as an absolute path"

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -234,8 +234,8 @@ install: $(LIBDIR)/$(SHARED_LIB_NAME) doc $(top_builddir)/libopenzwave.pc $(top_
 	@cp -r $(top_srcdir)/docs/* $(DESTDIR)/$(docdir)
 	@if [ -d "$(top_builddir)/docs/html/" ]; then cp -r $(top_builddir)/docs/html/* $(DESTDIR)/$(docdir); fi
 	@echo "Installing Pkg-config Files"
-	@install -d $(pkgconfigdir) 
-	@cp $(top_builddir)/libopenzwave.pc $(pkgconfigdir)
+	@install -d $(DESTDIR)/$(pkgconfigdir) 
+	@cp $(top_builddir)/libopenzwave.pc $(DESTDIR)/$(pkgconfigdir)
 	@install -d $(DESTDIR)/$(PREFIX)/bin/
 	@cp $(top_builddir)/ozw_config $(DESTDIR)/$(PREFIX)/bin/ozw_config
 	@chmod 755 $(DESTDIR)/$(PREFIX)/bin/ozw_config


### PR DESCRIPTION
Reverts OpenZWave/open-zwave#1495 as it breaks packaging. See #1508 