### PR TITLE
Revert changes to Alarm.cpp that break v1 protocol for Lock's in Home Assistant

### DIFF
--- a/cpp/src/command_classes/Alarm.h
+++ b/cpp/src/command_classes/Alarm.h
@@ -60,6 +60,9 @@ namespace OpenZWave
 
 		virtual uint8 GetMaxVersion(){ return 3; }
 
+	protected:
+		virtual void CreateVars( uint8 const _instance );
+
 	private:
 		Alarm( uint32 const _homeId, uint8 const _nodeId );
 		multimap<uint8, uint8> m_TempValueIDs;


### PR DESCRIPTION
Changes to alarm.cpp mean that Home Assistant no longer receives the AlarmIndex_Type and AlarmIndex_Level notifications, which it uses to drive the lock functionality. Restoring this.