### PR TITLE
Fixes line 312 build

### DIFF
--- a/cpp/src/command_classes/DoorLockLogging.cpp
+++ b/cpp/src/command_classes/DoorLockLogging.cpp
@@ -309,7 +309,9 @@ bool DoorLockLogging::HandleMsg
 			if (usercodelength > 0)
 				for (int i = 0; i < usercodelength; i++ )
 				{
-					snprintf(usercode, sizeof(usercode), "%s %d", usercode, (int)_data[12+i]);
+					char* tmp = strndup(usercode, sizeof(usercode));
+					snprintf(usercode, sizeof(usercode), "%s %d", tmp, (int)_data[12+i]);
+					free(tmp);
 				}
 
 			if (valid) {


### PR DESCRIPTION
Right now I have following error:

```
Building DoorLockLogging.o
/tmp/finkel/trizen-finkel/openzwave/src/open-zwave-1.5/cpp/src/command_classes/DoorLockLogging.cpp: In member function ‘virtual bool OpenZWave::DoorLockLogging::HandleMsg(const uint8*, uint32, uint32)’:
/tmp/finkel/trizen-finkel/openzwave/src/open-zwave-1.5/cpp/src/command_classes/DoorLockLogging.cpp:312:15: error: passing argument 1 to restrict-qualified parameter aliases with argument 4 [-Werror=restrict]
      snprintf(usercode, sizeof(usercode), "%s %d", usercode, (int)_data[12+i]);
               ^~~~~~~~                             ~~~~~~~~
cc1plus: all warnings being treated as errors
```