### PR TITLE
Fix hangs during Manager::Destroy calls

### DIFF
--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -134,7 +134,7 @@ void SerialControllerImpl::ReadThreadProc
 )
 {  
 	uint32 attempts = 0;
-	while( true )
+	while( !_exitEvent->IsSignalled() )
 	{
 		// Init must have been called successfully during Open, so we
 		// don't do it again until the end of the loop
@@ -142,7 +142,7 @@ void SerialControllerImpl::ReadThreadProc
 		{
 			// Enter read loop.  Call will only return if
 			// an exit is requested or an error occurs
-			Read();
+			Read(_exitEvent);
 
 			// Reset the attempts, so we get a rapid retry for temporary errors
 			attempts = 0;
@@ -315,11 +315,12 @@ SerialOpenFailure:
 //-----------------------------------------------------------------------------
 void SerialControllerImpl::Read
 (
+    Event* _exitEvent
 )
 {
 	uint8 buffer[256];
 
-	while( 1 )
+	while( !_exitEvent->IsSignalled() )
         {
 		int32 bytesRead;
 		int err;

--- a/cpp/src/platform/unix/SerialControllerImpl.h
+++ b/cpp/src/platform/unix/SerialControllerImpl.h
@@ -59,7 +59,7 @@ namespace OpenZWave
 		uint32 Write( uint8* _buffer, uint32 _length );
 
 		bool Init( uint32 const _attempts );
-		void Read();
+		void Read(Event* _exitEvent);
 
 		SerialController*	m_owner;
 		int			m_hSerialController;


### PR DESCRIPTION
The current version of OpenZWave hangs on macOS when the interface is being closed. Add event polling to fix this.