### PR TITLE
Fix compilation error in regards to -Werror=restrict

### DIFF
--- a/cpp/src/command_classes/DoorLockLogging.cpp
+++ b/cpp/src/command_classes/DoorLockLogging.cpp
@@ -304,12 +304,13 @@ bool DoorLockLogging::HandleMsg
 			}
 			uint8 userid = (_data[10]);
 			uint8 usercodelength = (_data[11]);
-			char usercode[254];
+			char usercode[254], tmpusercode[254];
 			snprintf(usercode, sizeof(usercode), "UserCode:");
 			if (usercodelength > 0)
 				for (int i = 0; i < usercodelength; i++ )
 				{
-					snprintf(usercode, sizeof(usercode), "%s %d", usercode, (int)_data[12+i]);
+					strncpy(tmpusercode, usercode, sizeof(tmpusercode));
+                                        snprintf(usercode, sizeof(usercode), "%s %d", tmpusercode, (int)_data[12+i]);
 				}
 
 			if (valid) {


### PR DESCRIPTION
/usr/share/domoticz/open-zwave/cpp/src/command_classes/DoorLockLogging.cpp: In member function �virtual bool OpenZWave::DoorLockLogging::HandleMsg(const uint8*, uint32, uint32)�:
/usr/share/domoticz/open-zwave/cpp/src/command_classes/DoorLockLogging.cpp:312:15: error: passing argument 1 to restrict-qualified parameter aliases with argument 4 [-Werror=restrict]
      snprintf(usercode, sizeof(usercode), "%s %d", usercode, (int)_data[12+i]);
               ^~~~~~~~                             ~~~~~~~~