### PR TITLE
Fix parameter size and allowed values for HS-WD100+

### DIFF
--- a/config/homeseer/hs-wd100plus.xml
+++ b/config/homeseer/hs-wd100plus.xml
@@ -1,67 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Product xmlns='http://code.google.com/p/open-zwave/'>
-    <!-- Configuration Parameters -->
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
+        <!-- Configuration Parameters -->
     <CommandClass id="112">
         <Value type="list" index="4" genre="config" label="Invert switch" min="0" max="1" size="1" value="0">
             <Help>Change the top of the switch to OFF and the bottom of the switch to ON if the switch was installed upside down.</Help>
             <Item label="No" value="0"/>
             <Item label="Yes" value="1"/>
         </Value>
-        <Value type="byte" index="7" genre="config" label="Remote level percent" units="%" min="1" max="99" value="99">
+        <Value type="short" index="7" genre="config" label="Remote level percent" units="%" min="1" max="99" value="99">
             <Help>Indicates how much each level dims/brightens as a portion of the whole range when set remotely.</Help>
         </Value>
-        <Value type="list" index="8" genre="config" label="Remote duration per level" units="ms" size="2" min="1" max="22" value="22">
+        <Value type="short" index="8" genre="config" label="Remote duration per level" units="cs" min="1" max="255" value="22">
             <Help>Indicates the time duration of each level when set remotely.</Help>
-            <Item label="10" value="1"/>
-            <Item label="20" value="2"/>
-            <Item label="30" value="3"/>
-            <Item label="40" value="4"/>
-            <Item label="50" value="5"/>
-            <Item label="60" value="6"/>
-            <Item label="70" value="7"/>
-            <Item label="80" value="8"/>
-            <Item label="90" value="9"/>
-            <Item label="100" value="10"/>
-            <Item label="110" value="11"/>
-            <Item label="120" value="12"/>
-            <Item label="130" value="13"/>
-            <Item label="140" value="14"/>
-            <Item label="150" value="15"/>
-            <Item label="160" value="16"/>
-            <Item label="170" value="17"/>
-            <Item label="180" value="18"/>
-            <Item label="190" value="19"/>
-            <Item label="200" value="20"/>
-            <Item label="210" value="21"/>
-            <Item label="220" value="22"/>
         </Value>
-        <Value type="byte" index="9" genre="config" label="Local level percent" units="%" min="1" max="99" value="99">
+        <Value type="short" index="9" genre="config" label="Local level percent" units="%" min="1" max="99" value="99">
             <Help>Indicates how much each level dims/brightens as a portion of the whole range when set locally.</Help>
         </Value>
-        <Value type="list" index="10" genre="config" label="Local duration per level" units="ms" size="2" min="1" max="22" value="22">
+        <Value type="short" index="10" genre="config" label="Local duration per level" units="cs" min="1" max="255" value="22">
             <Help>Indicates the time duration of each level when set locally.</Help>
-            <Item label="10" value="1"/>
-            <Item label="20" value="2"/>
-            <Item label="30" value="3"/>
-            <Item label="40" value="4"/>
-            <Item label="50" value="5"/>
-            <Item label="60" value="6"/>
-            <Item label="70" value="7"/>
-            <Item label="80" value="8"/>
-            <Item label="90" value="9"/>
-            <Item label="100" value="10"/>
-            <Item label="110" value="11"/>
-            <Item label="120" value="12"/>
-            <Item label="130" value="13"/>
-            <Item label="140" value="14"/>
-            <Item label="150" value="15"/>
-            <Item label="160" value="16"/>
-            <Item label="170" value="17"/>
-            <Item label="180" value="18"/>
-            <Item label="190" value="19"/>
-            <Item label="200" value="20"/>
-            <Item label="210" value="21"/>
-            <Item label="220" value="22"/>
         </Value>
     </CommandClass>
     <!-- Association Groups -->

--- a/config/homeseer/hs-wd100plus.xml
+++ b/config/homeseer/hs-wd100plus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
-        <!-- Configuration Parameters -->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+    <!-- Configuration Parameters -->
     <CommandClass id="112">
         <Value type="list" index="4" genre="config" label="Invert switch" min="0" max="1" size="1" value="0">
             <Help>Change the top of the switch to OFF and the bottom of the switch to ON if the switch was installed upside down.</Help>


### PR DESCRIPTION
The changes allow the parameters to be set to their full allowable range of values, as specified in the documentation:
https://homeseer.com/wp-content/uploads/2018/06/HS-WD100-Manual-6a.pdf
The documentation specifies the size of parameters 7 and 9 as 1 byte, however defining them as bytes prevented OZW from updating the values: the values would always reset to 1, regardless of the supplied value. Using short works.