### PR TITLE
Added ramp rate control option to zen22v2.xml

### DIFF
--- a/config/zooz/zen22v2.xml
+++ b/config/zooz/zen22v2.xml
@@ -17,6 +17,11 @@
       <Item value="0" label="Enabled"/>
       <Item value="1" label="Disabled"/>
     </Value>
+    <Value genre="config" index="4" value="0" label="Ramp Rate Control" units="" size="1" min="0" max="255" type="list">
+      <Help>Choose how fast you want to turn the light on and off</Help>
+      <Item value="0" label="Slow"/>
+      <Item value="1" label="Fast"/>
+    </Value>
   </CommandClass>
 
   <!-- Association Groups -->


### PR DESCRIPTION
The documentation that came with my zooz zen22 version 2 light indicates this option should exist. I've added it on my own setup and it is working as described. Quote from the documentation:

> **Ramp Rate Control**
> Parameter 4: Choose from 2 ramp rate options (fade-in / fade-out effect for on / off operation)
> Values: 0 - light turns on to 100% brightness within 2 seconds, turns off within 4 seconds (default); 1 - light turns on to 100% brightness instantly, turns off within 1 second
> Size: 1 byte dec.