### PR TITLE
Remove unused variables causing compilation errors on FreeBSD

### DIFF
--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -536,8 +536,7 @@ Group::AssociationCommand::AssociationCommand
 (
 	uint8 const _length,
 	uint8 const* _data
-):
-	m_length( _length )
+)
 {
 	m_data = new uint8[_length];
 	memcpy( m_data, _data, _length );

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -101,7 +101,6 @@ namespace OpenZWave
 			~AssociationCommand();
 
 		private:
-			uint8	m_length;
 			uint8*	m_data;
 		};
 

--- a/cpp/src/value_classes/ValueBool.cpp
+++ b/cpp/src/value_classes/ValueBool.cpp
@@ -57,8 +57,7 @@ ValueBool::ValueBool
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Bool, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( false ),
-	m_newValue( false )
+	m_valueCheck( false )
 {
 }
 

--- a/cpp/src/value_classes/ValueBool.h
+++ b/cpp/src/value_classes/ValueBool.h
@@ -63,7 +63,6 @@ namespace OpenZWave
 	private:
 		bool	m_value;				// the current index in the m_items vector
 		bool	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		bool	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -57,8 +57,7 @@ ValueByte::ValueByte
 ):
 	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Byte, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( false ),
-	m_newValue( false )
+	m_valueCheck( false )
 {
 	m_min = 0;
 	m_max = 255;

--- a/cpp/src/value_classes/ValueByte.h
+++ b/cpp/src/value_classes/ValueByte.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		uint8	m_value;				// the current value
 		uint8	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		uint8	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueInt.cpp
+++ b/cpp/src/value_classes/ValueInt.cpp
@@ -58,8 +58,7 @@ ValueInt::ValueInt
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Int, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = INT_MIN;
 	m_max = INT_MAX;
@@ -74,8 +73,7 @@ ValueInt::ValueInt
 ):
   	Value(),
 	m_value( 0 ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 
 {
 	m_min = INT_MIN;

--- a/cpp/src/value_classes/ValueInt.h
+++ b/cpp/src/value_classes/ValueInt.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		int32	m_value;				// the current value
 		int32	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		int32	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -60,7 +60,6 @@ ValueList::ValueList
 	m_items( _items ),
 	m_valueIdx( _valueIdx ),
 	m_valueIdxCheck( 0 ),
-	m_newValueIdx( 0 ),
 	m_size( _size )
 {
 }
@@ -76,7 +75,6 @@ ValueList::ValueList
 	m_items( ),
 	m_valueIdx(),
 	m_valueIdxCheck( 0 ),
-	m_newValueIdx( 0 ),
 	m_size(0)
 {
 }

--- a/cpp/src/value_classes/ValueList.h
+++ b/cpp/src/value_classes/ValueList.h
@@ -82,7 +82,6 @@ namespace OpenZWave
 		vector<Item>	m_items;
 		int32			m_valueIdx;					// the current index in the m_items vector
 		int32			m_valueIdxCheck;			// the previous index in the m_items vector (used for double-checking spurious value reads)
-		int32			m_newValueIdx;				// a new value to be set on the appropriate device
 		uint8			m_size;
 	};
 

--- a/cpp/src/value_classes/ValueShort.cpp
+++ b/cpp/src/value_classes/ValueShort.cpp
@@ -58,8 +58,7 @@ ValueShort::ValueShort
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Short, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = SHRT_MIN;
 	m_max = SHRT_MAX;
@@ -74,8 +73,7 @@ ValueShort::ValueShort
 ):
 	Value(),
 	m_value( 0 ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = SHRT_MIN;
 	m_max = SHRT_MAX;

--- a/cpp/src/value_classes/ValueShort.h
+++ b/cpp/src/value_classes/ValueShort.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		int16	m_value;				// the current value
 		int16	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		int16	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
A number of unused variables cause compilation errors in FreeBSD 11.2.