### PR TITLE
Support particulate matter 2.5

### DIFF
--- a/cpp/src/command_classes/SensorMultilevel.cpp
+++ b/cpp/src/command_classes/SensorMultilevel.cpp
@@ -83,6 +83,7 @@ enum SensorType
 	SensorType_Frequency,
 	SensorType_Time,
 	SensorType_TargetTemperature,
+	SensorType_ParticulateMatter,
 	SensorType_MaxType
 };
 
@@ -123,6 +124,7 @@ static char const* c_sensorTypeNames[] =
 		"Frequency",
 		"Time",
 		"Target Temperature",
+		"Particulate Matter 2.5",
 };
 
 static char const* c_tankCapcityUnits[] =
@@ -421,6 +423,7 @@ bool SensorMultilevel::HandleMsg
 				case SensorType_Frequency:				units = scale? "kHz" : "Hz";			break;
 				case SensorType_Time:					units = "s";					break;
 				case SensorType_TargetTemperature:			units = scale ? "F" : "C";			break;
+				case SensorType_ParticulateMatter:			units = scale? "ug/m3" : "mol/m3";		break;
 				default: {
 					Log::Write (LogLevel_Warning, GetNodeId(), "sensorType Value was greater than range. Dropping");
 					return false;

--- a/cpp/src/command_classes/SensorMultilevel.cpp
+++ b/cpp/src/command_classes/SensorMultilevel.cpp
@@ -82,6 +82,7 @@ enum SensorType
 	SensorType_Moisture,
 	SensorType_Frequency,
 	SensorType_Time,
+	SensorType_TargetTemperature,
 	SensorType_MaxType
 };
 
@@ -121,6 +122,7 @@ static char const* c_sensorTypeNames[] =
 		"Moisture",
 		"Frequency",
 		"Time",
+		"Target Temperature",
 };
 
 static char const* c_tankCapcityUnits[] =
@@ -418,6 +420,7 @@ bool SensorMultilevel::HandleMsg
 				break;
 				case SensorType_Frequency:				units = scale? "kHz" : "Hz";			break;
 				case SensorType_Time:					units = "s";					break;
+				case SensorType_TargetTemperature:			units = scale ? "F" : "C";			break;
 				default: {
 					Log::Write (LogLevel_Warning, GetNodeId(), "sensorType Value was greater than range. Dropping");
 					return false;

--- a/cpp/src/command_classes/SensorMultilevel.cpp
+++ b/cpp/src/command_classes/SensorMultilevel.cpp
@@ -81,6 +81,7 @@ enum SensorType
 	SensorType_Loudness,
 	SensorType_Moisture,
 	SensorType_Frequency,
+	SensorType_Time,
 	SensorType_MaxType
 };
 
@@ -119,6 +120,7 @@ static char const* c_sensorTypeNames[] =
 		"Loudness",
 		"Moisture",
 		"Frequency",
+		"Time",
 };
 
 static char const* c_tankCapcityUnits[] =
@@ -415,6 +417,7 @@ bool SensorMultilevel::HandleMsg
 				}
 				break;
 				case SensorType_Frequency:				units = scale? "kHz" : "Hz";			break;
+				case SensorType_Time:					units = "s";					break;
 				default: {
 					Log::Write (LogLevel_Warning, GetNodeId(), "sensorType Value was greater than range. Dropping");
 					return false;

--- a/cpp/src/command_classes/SensorMultilevel.cpp
+++ b/cpp/src/command_classes/SensorMultilevel.cpp
@@ -80,6 +80,7 @@ enum SensorType
 	SensorType_ElectricalConductivity,
 	SensorType_Loudness,
 	SensorType_Moisture,
+	SensorType_Frequency,
 	SensorType_MaxType
 };
 
@@ -116,7 +117,8 @@ static char const* c_sensorTypeNames[] =
 		"Electrical Resistivity",
 		"Electrical Conductivity",
 		"Loudness",
-		"Moisture"
+		"Moisture",
+		"Frequency",
 };
 
 static char const* c_tankCapcityUnits[] =
@@ -412,6 +414,7 @@ bool SensorMultilevel::HandleMsg
 					}
 				}
 				break;
+				case SensorType_Frequency:				units = scale? "kHz" : "Hz";			break;
 				default: {
 					Log::Write (LogLevel_Warning, GetNodeId(), "sensorType Value was greater than range. Dropping");
 					return false;


### PR DESCRIPTION
The purpose of this patch series is to add support of PM2.5 to OpenZWave. To achive this, 3 more SensorMultilevel types had to be added as the SensorType is sequential.