### PR TITLE
Published IsMultiInstance from Group to Manager

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -5976,6 +5976,25 @@ uint8 Driver::GetMaxAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Driver::IsMultiInstance>
+// Returns true if group supports multi instance
+//-----------------------------------------------------------------------------
+bool Driver::IsMultiInstance
+(
+		uint8 const _nodeId,
+		uint8 const _groupIdx
+)
+{
+	bool multiInstance = false;
+	LockGuard LG(m_nodeMutex);
+	if( Node* node = GetNode( _nodeId ) )
+	{
+		multiInstance = node->IsMultiInstance( _groupIdx );
+	}
+	return multiInstance;
+}
+
+//-----------------------------------------------------------------------------
 // <Driver::GetGroupLabel>
 // Gets the label for a particular group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -766,6 +766,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, uint8** o_associations );
 		uint32 GetAssociations( uint8 const _nodeId, uint8 const _groupIdx, InstanceAssociation** o_associations );
 		uint8 GetMaxAssociations( uint8 const _nodeId, uint8 const _groupIdx );
+		bool IsMultiInstance( uint8 const _nodeId, uint8 const _groupIdx );
 		string GetGroupLabel( uint8 const _nodeId, uint8 const _groupIdx );
 		void AddAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 		void RemoveAssociation( uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -72,13 +72,13 @@ namespace OpenZWave
 		uint8 GetMaxAssociations()const{ return m_maxAssociations; }
 		uint8 GetIdx()const{ return m_groupIdx; }
 		bool Contains( uint8 const _nodeId, uint8 const _instance = 0x00 );
+        bool IsMultiInstance()const{ return m_multiInstance; }
 
 	private:
 		bool IsAuto()const{ return m_auto; }
 		void SetAuto( bool const _state ){ m_auto = _state; }
 		void CheckAuto();
 
-		bool IsMultiInstance()const{ return m_multiInstance; }
 		void SetMultiInstance( bool const _state ){ m_multiInstance = _state; }
 
 		void AddAssociation( uint8 const _nodeId, uint8 const _instance = 0x00 );

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3669,6 +3669,24 @@ uint8 Manager::GetMaxAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::IsMultiInstance>
+// Returns true is group supports multi instance.
+//-----------------------------------------------------------------------------
+bool Manager::IsMultiInstance
+(
+		uint32 const _homeId,
+		uint8 const _nodeId,
+		uint8 const _groupIdx
+)
+{
+	if( Driver* driver = GetDriver( _homeId ) )
+	{
+		return driver->IsMultiInstance( _nodeId, _groupIdx );
+	}
+	return 0;
+}
+
+//-----------------------------------------------------------------------------
 // <Manager::GetGroupLabel>
 // Gets the label for a particular group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1634,6 +1634,16 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		uint8 GetMaxAssociations( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx );
 
 		/**
+		 * \brief Returns true is group supports multi instance.
+		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
+		 * \param _nodeId The ID of the node whose associations we are interested in.
+		 * \param _groupIdx one-based index of the group (because Z-Wave product manuals use one-based group numbering).
+		 * \return True if group supports multi instance.
+		 * \see GetNumGroups, AddAssociation, RemoveAssociation, GetAssociations, GetMaxAssociations
+		 */
+		bool IsMultiInstance( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx );
+
+		/**
 		 * \brief Returns a label for the particular group of a node.
 		 * This label is populated by the device specific configuration files.
 		 * \param _homeId The Home ID of the Z-Wave controller that manages the node.

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -2901,6 +2901,23 @@ uint8 Node::GetMaxAssociations
 }
 
 //-----------------------------------------------------------------------------
+// <Node::IsMultiInstance>
+// Returns true if group supports multi instance
+//-----------------------------------------------------------------------------
+bool Node::IsMultiInstance
+(
+		uint8 const _groupIdx
+)
+{
+	bool multiInstance = false;
+	if( Group* group = GetGroup( _groupIdx ) )
+	{
+		multiInstance = group->IsMultiInstance();
+	}
+	return multiInstance;
+}
+
+//-----------------------------------------------------------------------------
 // <Node::GetGroupLabel>
 // Gets the label for a particular group
 //-----------------------------------------------------------------------------

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -561,6 +561,7 @@ namespace OpenZWave
 			uint32 GetAssociations( uint8 const _groupIdx, uint8** o_associations );
 			uint32 GetAssociations( uint8 const _groupIdx, InstanceAssociation** o_associations );
 			uint8 GetMaxAssociations( uint8 const _groupIdx );
+			bool IsMultiInstance( uint8 const _groupIdx );
 			string GetGroupLabel( uint8 const _groupIdx );
 			void AddAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );
 			void RemoveAssociation( uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance = 0x00 );


### PR DESCRIPTION
(Change to Dev branch for pull request #1584)
Group in ZWave can have multi instance availability or not.
This is correctly programmed in Group.h/Group.cpp but it is not available to end user (user of OpenZWave library).
I have created a patch, that publishesh Group.h `IsMultiInstance` to Manager.h:
```c++
/**
 * \brief Returns true is group supports multi instance.
 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
 * \param _nodeId The ID of the node whose associations we are interested in.
 * \param _groupIdx one-based index of the group (because Z-Wave product manuals use one-based group numbering).
 * \return True if group supports multi instance.
 * \see GetNumGroups, AddAssociation, RemoveAssociation, GetAssociations
 */
bool IsMultiInstance( uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx );
```

