### PR TITLE
Drop a number of unused variables

### DIFF
--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -539,8 +539,8 @@ Group::AssociationCommand::AssociationCommand
 ):
 	m_length( _length )
 {
-	m_data = new uint8[_length];
-	memcpy( m_data, _data, _length );
+	m_data = new uint8[m_length];
+	memcpy( m_data, _data, m_length );
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueBool.cpp
+++ b/cpp/src/value_classes/ValueBool.cpp
@@ -57,8 +57,7 @@ ValueBool::ValueBool
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Bool, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( false ),
-	m_newValue( false )
+	m_valueCheck( false )
 {
 }
 

--- a/cpp/src/value_classes/ValueBool.h
+++ b/cpp/src/value_classes/ValueBool.h
@@ -63,7 +63,6 @@ namespace OpenZWave
 	private:
 		bool	m_value;				// the current index in the m_items vector
 		bool	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		bool	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -57,8 +57,7 @@ ValueByte::ValueByte
 ):
 	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Byte, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( false ),
-	m_newValue( false )
+	m_valueCheck( false )
 {
 	m_min = 0;
 	m_max = 255;

--- a/cpp/src/value_classes/ValueByte.h
+++ b/cpp/src/value_classes/ValueByte.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		uint8	m_value;				// the current value
 		uint8	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		uint8	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueDecimal.cpp
+++ b/cpp/src/value_classes/ValueDecimal.cpp
@@ -57,7 +57,6 @@ ValueDecimal::ValueDecimal
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Decimal, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
 	m_valueCheck( "" ),
-	m_newValue( "" ),
 	m_precision( 0 )
 {
 }

--- a/cpp/src/value_classes/ValueDecimal.h
+++ b/cpp/src/value_classes/ValueDecimal.h
@@ -70,8 +70,7 @@ namespace OpenZWave
 
 		string	m_value;				// the current value
 		string	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		string	m_newValue;				// a new value to be set on the appropriate device
-	        uint8	m_precision;
+		uint8	m_precision;
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueInt.cpp
+++ b/cpp/src/value_classes/ValueInt.cpp
@@ -58,8 +58,7 @@ ValueInt::ValueInt
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Int, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = INT_MIN;
 	m_max = INT_MAX;
@@ -74,8 +73,7 @@ ValueInt::ValueInt
 ):
   	Value(),
 	m_value( 0 ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 
 {
 	m_min = INT_MIN;

--- a/cpp/src/value_classes/ValueInt.h
+++ b/cpp/src/value_classes/ValueInt.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		int32	m_value;				// the current value
 		int32	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		int32	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -60,7 +60,6 @@ ValueList::ValueList
 	m_items( _items ),
 	m_valueIdx( _valueIdx ),
 	m_valueIdxCheck( 0 ),
-	m_newValueIdx( 0 ),
 	m_size( _size )
 {
 }
@@ -76,7 +75,6 @@ ValueList::ValueList
 	m_items( ),
 	m_valueIdx(),
 	m_valueIdxCheck( 0 ),
-	m_newValueIdx( 0 ),
 	m_size(0)
 {
 }

--- a/cpp/src/value_classes/ValueList.h
+++ b/cpp/src/value_classes/ValueList.h
@@ -82,7 +82,6 @@ namespace OpenZWave
 		vector<Item>	m_items;
 		int32			m_valueIdx;					// the current index in the m_items vector
 		int32			m_valueIdxCheck;			// the previous index in the m_items vector (used for double-checking spurious value reads)
-		int32			m_newValueIdx;				// a new value to be set on the appropriate device
 		uint8			m_size;
 	};
 

--- a/cpp/src/value_classes/ValueShort.cpp
+++ b/cpp/src/value_classes/ValueShort.cpp
@@ -58,8 +58,7 @@ ValueShort::ValueShort
 ):
   	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_Short, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = SHRT_MIN;
 	m_max = SHRT_MAX;
@@ -74,8 +73,7 @@ ValueShort::ValueShort
 ):
 	Value(),
 	m_value( 0 ),
-	m_valueCheck( 0 ),
-	m_newValue( 0 )
+	m_valueCheck( 0 )
 {
 	m_min = SHRT_MIN;
 	m_max = SHRT_MAX;

--- a/cpp/src/value_classes/ValueShort.h
+++ b/cpp/src/value_classes/ValueShort.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		int16	m_value;				// the current value
 		int16	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		int16	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave

--- a/cpp/src/value_classes/ValueString.cpp
+++ b/cpp/src/value_classes/ValueString.cpp
@@ -55,8 +55,7 @@ ValueString::ValueString
 ):
 	Value( _homeId, _nodeId, _genre, _commandClassId, _instance, _index, ValueID::ValueType_String, _label, _units, _readOnly, _writeOnly, false, _pollIntensity ),
 	m_value( _value ),
-	m_valueCheck( "" ),
-	m_newValue( "" )
+	m_valueCheck( "" )
 {
 }
 

--- a/cpp/src/value_classes/ValueString.h
+++ b/cpp/src/value_classes/ValueString.h
@@ -62,7 +62,6 @@ namespace OpenZWave
 	private:
 		string	m_value;				// the current value
 		string	m_valueCheck;			// the previous value (used for double-checking spurious value reads)
-		string	m_newValue;				// a new value to be set on the appropriate device
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
On FreeBSD 11.2 (clang 6.0) build fails due to unused instance variables

```
In file included from /usr/home/johan/dev/open-zwave/cpp/src/value_classes/ValueList.cpp:29:                      
/usr/home/johan/dev/open-zwave/cpp/src/value_classes/ValueList.h:85:11: error: private field 'm_newValueIdx' is not used [-Werror,-Wunused-private-field]            
                int32                   m_newValueIdx;                          // a new value to be set on the appropriate device
                                        ^                                       
1 error generated.                                                                      
```

and similar.

This MR removes the unused variables in the Value classes, and makes use of it in the Group.cpp class (seems sensible to keep m_length together with raw byte byffer m_data)