### PR TITLE
Synchronized access to devices database (s_manufacturerMap, s_productMap).

### DIFF
--- a/cpp/src/command_classes/ManufacturerSpecific.h
+++ b/cpp/src/command_classes/ManufacturerSpecific.h
@@ -30,6 +30,7 @@
 
 #include <map>
 #include "command_classes/CommandClass.h"
+#include "platform/Mutex.h"
 
 namespace OpenZWave
 {
@@ -108,6 +109,7 @@ namespace OpenZWave
 		static map<uint16,string>	s_manufacturerMap;
 		static map<int64,Product*>	s_productMap;
 		static bool					s_bXmlLoaded;
+		static Mutex*				s_xmlMutex;
 	};
 
 } // namespace OpenZWave


### PR DESCRIPTION
I had recently problem with getting USB dongle manufacturer specific informations on OpenZWave start.

OpenZWave library generated ozw_cfg.xml file:
```xml
        <Node id="1" name="" location="" basic="2" generic="2" specific="1" type="Static PC Controller" listening="true" frequentListening="false" beaming="true" routing="false" max_baud_rate="40000" version="4" query_stage="Complete">
                <Manufacturer id="115" name="Unknown: id=0115">
                        <Product type="400" id="1" name="Unknown: type=0400, id=0001" />
                </Manufacturer>
                <CommandClasses>
                        <CommandClass id="32" name="COMMAND_CLASS_BASIC" version="1" after_mark="true">
                                <Instance index="1" />
                                <Value type="byte" genre="basic" instance="1" index="0" label="Basic" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
                        </CommandClass>
                </CommandClasses>
        </Node>
```
I have checked the **manufacturer_specific.xml** file and id had entries for this manufacturer, product and typeId:
```xml
	<Manufacturer id="0115" name="Z-Wave.Me">
		<Product type="0400" id="0001" name="ZME_UZB1 USB Stick"/>
	</Manufacturer>
```
And in ozw.log i had:
```
2018-09-14 18:05:45.349 Info, contrlr,     Node 001 - New
2018-09-14 18:05:45.392 Info, Node001, Essential node queries are complete
2018-09-14 18:05:45.393 Info, Node001, Essential node queries are complete
2018-09-14 18:05:45.418 Info, Product name collision: VRS15-1LZ Switch type 301 id 209 manufacturerid 1d, collides with VRS15-1LZ Binary Scene Switch, type 301 id 209 manufacturerid 1d
2018-09-14 18:05:45.418 Info, Product name collision: VRF01-1LZ Multilevel Scene Switch - 1.5A Fan type 1001 id 209 manufacturerid 1d, collides with VRF01-1LZ Quiet Fan Speed Control, type 1001 id 209 manufacturerid 1d
```

Unfortunately this didn't helped too much and I added at beginning of `ManufacturerSpecific::LoadProductXML`:
```c++
	Log::Write( LogLevel_Info, "Loading ProductXML (manufacturer_specific.xml)" );
```
and at end:
```c++
	Log::Write( LogLevel_Info, "Loaded ProductXML (manufacturer_specific.xml)" );
```
I have also extended logging for `ManufacturerSpecific::SetProductDetails` (added else with log message):
```c++
// Try to get the real manufacturer and product names
		map<uint16,string>::iterator mit = s_manufacturerMap.find( manufacturerId );
		if( mit != s_manufacturerMap.end() )
		{
			// Replace the id with the real name
			manufacturerName = mit->second;

			// Get the product
			map<int64,Product*>::iterator pit = s_productMap.find( Product::GetKey( manufacturerId, productType, productId ) );
			if( pit != s_productMap.end() )
			{
				productName = pit->second->GetProductName();
				configPath = pit->second->GetConfigPath();
			} else {
				Log::Write( LogLevel_Info, node->GetNodeId(), "ProductId=%.4x type=%.4x for ManufacturerId=%.4x  not found in manufacturer_specific.xml.",
					    productId, productType, manufacturerId );
			}
		} else {
			Log::Write( LogLevel_Info, node->GetNodeId(), "ManufacturerId=%.4x not found in manufacturer_specific.xml.",
					    manufacturerId );
		}
```

With such extended logging I have repeated test and I have:
```
2018-09-17 14:18:49.854 Info, contrlr,     Node 001 - New
2018-09-17 14:18:49.854 Info, Node001, Initializing Node. New Node: false (false)
2018-09-17 14:18:49.869 Info, contrlr, Sending (Command) message (Callback ID=0x00, Expected Reply=0x06) - FUNC_ID_SERIAL_API_SET_TIMEOUTS: 0x01, 0x05, 0x00, 0x06, 0x64, 0x0f, 0x97
2018-09-17 14:18:49.871 Info, contrlr, Received reply to FUNC_ID_SERIAL_API_SET_TIMEOUTS
2018-09-17 14:18:49.872 Info, contrlr, Sending (Command) message (Callback ID=0x00, Expected Reply=0x00) - FUNC_ID_SERIAL_API_APPL_NODE_INFORMATION: 0x01, 0x07, 0x00, 0x03, 0x01, 0x02, 0x01, 0x00, 0xf9
2018-09-17 14:18:49.873 Info, Node001, Sending (Query) message (Callback ID=0x00, Expected Reply=0x41) - Get Node Protocol Info (Node=1): 0x01, 0x04, 0x00, 0x41, 0x01, 0xbb
2018-09-17 14:18:49.877 Info, Node001, Received reply to FUNC_ID_ZW_GET_NODE_PROTOCOL_INFO
2018-09-17 14:18:49.877 Info, Node001,   Protocol Info for Node 1:
2018-09-17 14:18:49.877 Info, Node001,     Listening     = true
2018-09-17 14:18:49.877 Info, Node001,     Beaming       = true
2018-09-17 14:18:49.877 Info, Node001,     Routing       = false
2018-09-17 14:18:49.878 Info, Node001,     Max Baud Rate = 40000
2018-09-17 14:18:49.878 Info, Node001,     Version       = 4
2018-09-17 14:18:49.878 Info, Node001,     Security      = false
2018-09-17 14:18:49.885 Info, Node001,   Basic device class    (0x02) - Static Controller
2018-09-17 14:18:49.885 Info, Node001,   Generic device Class  (0x02) - Static Controller
2018-09-17 14:18:49.886 Info, Node001,   Specific device class (0x01) - Static PC Controller
2018-09-17 14:18:49.886 Info, Node001,     COMMAND_CLASS_BASIC is not mapped
2018-09-17 14:18:49.886 Info, Node001,   Mandatory Command Classes for Node 1:
2018-09-17 14:18:49.886 Info, Node001,     None
2018-09-17 14:18:49.886 Info, Node001,   Mandatory Command Classes controlled by Node 1:
2018-09-17 14:18:49.886 Info, Node001,     COMMAND_CLASS_BASIC
2018-09-17 14:18:49.890 Info, Loading ProductXML (manufacturer_specific.xml)
2018-09-17 14:18:49.895 Info, Node001, ManufacturerId=0115 not found in manufacturer_specific.xml.
2018-09-17 14:18:49.895 Info, Node001, Essential node queries are complete
2018-09-17 14:18:49.896 Info, Node001, ManufacturerId=0115 not found in manufacturer_specific.xml.
2018-09-17 14:18:49.897 Info, Node001, Essential node queries are complete
2018-09-17 14:18:49.927 Info, Product name collision: VRS15-1LZ Switch type 301 id 209 manufacturerid 1d, collides with VRS15-1LZ Binary Scene Switch, type 301 id 209 manufacturerid 1d
2018-09-17 14:18:49.928 Info, Product name collision: VRF01-1LZ Multilevel Scene Switch - 1.5A Fan type 1001 id 209 manufacturerid 1d, collides with VRF01-1LZ Quiet Fan Speed Control, type 1001 id 209 manufacturerid 1d
2018-09-17 14:18:49.933 Info, Loaded ProductXML (manufacturer_specific.xml)
```
From logs above is looks like:
1. Method `ManufacturerSpecific::LoadProductXML` is called. First thing it does is `s_bXmlLoaded = true;`.
2. Method `ManufacturerSpecific::SetProductDetails` is called few more times and here `s_bXmlLoaded` is `true`.
3. Method `ManufacturerSpecific::SetProductDetails` tries to get data from `s_manufacturerMap` and `s_productMap` and fails with (additional log message):
```
2018-09-17 14:18:49.895 Info, Node001, ManufacturerId=0115 not found in manufacturer_specific.xml.
```
4. Method `ManufacturerSpecific::LoadProductXML` finishes to work after calls to `ManufacturerSpecific::SetProductDetails`:
```
2018-09-17 14:18:49.933 Info, Loaded ProductXML (manufacturer_specific.xml)
```

For me it looks like access to `s_manufacturerMap`, `s_productMap` and `s_bXmlLoaded` should be synchronized, therefor I have created a patch, that:
- adds static field to `ManufacturerSpecific`:
```c++
		static Mutex*				s_xmlMutex;
```
- uses this mutex when accessing one of `s_manufacturerMap`, `s_productMap`, `s_bXmlLoaded` using `LockGuard`.

I assumed that Mutex it is reentrant lock type (can be accessed many times from the same thread).
