### PR TITLE
Fix broken build process for macOS

### DIFF
--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -34,13 +34,15 @@ endif
 
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
+CFLAGS	+= -c -DDARWIN
 ifeq ($(DARWIN_MOJAVE_UP),1)
 # Newer macOS releases don't support i386 so only build 64-bit
 DARWIN_BUILD_TARGET = -arch x86_64
+# Disable an implicitly-set build flag that causes the build to needlessly fail
+CFLAGS	+= -Wno-unused-private-field
 else
 DARWIN_BUILD_TARGET = -arch i386 -arch x86_64
 endif
-CFLAGS	+= -c -DDARWIN -Wno-unused-private-field
 TARCH	+= $(DARWIN_BUILD_TARGET)
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
 LIBS	+= -framework IOKit -framework CoreFoundation $(DARWIN_BUILD_TARGET)

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -35,7 +35,13 @@ endif
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS	+= -c -DDARWIN -Wno-unused-private-field
+ifeq ($(DARWIN_MOJAVE_UP),1)
+# Newer macOS releases don't support i386 so only build 64-bit
 TARCH	+= -arch x86_64
+else
+# Support older versions of OSX that may need to build both 32-bit and 64-bit
+TARCH	+= -arch i386 -arch x86_64
+endif
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
 LIBS	+= -framework IOKit -framework CoreFoundation -arch x86_64
 else ifeq ($(UNAME),FreeBSD)

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -39,7 +39,7 @@ ifeq ($(DARWIN_MOJAVE_UP),1)
 # Newer macOS releases don't support i386 so only build 64-bit
 DARWIN_BUILD_TARGET = -arch x86_64
 # Disable an implicitly-set build flag that causes the build to needlessly fail
-CFLAGS	+= -Wno-unused-private-field
+CFLAGS += -Wno-unused-private-field
 else
 DARWIN_BUILD_TARGET = -arch i386 -arch x86_64
 endif

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -34,16 +34,16 @@ endif
 
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
-CFLAGS	+= -c -DDARWIN -Wno-unused-private-field
 ifeq ($(DARWIN_MOJAVE_UP),1)
 # Newer macOS releases don't support i386 so only build 64-bit
-TARCH	+= -arch x86_64
+DARWIN_BUILD_TARGET = -arch x86_64
 else
-# Support older versions of OSX that may need to build both 32-bit and 64-bit
-TARCH	+= -arch i386 -arch x86_64
+DARWIN_BUILD_TARGET = -arch i386 -arch x86_64
 endif
+CFLAGS	+= -c -DDARWIN -Wno-unused-private-field
+TARCH	+= $(DARWIN_BUILD_TARGET)
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
-LIBS	+= -framework IOKit -framework CoreFoundation -arch x86_64
+LIBS	+= -framework IOKit -framework CoreFoundation $(DARWIN_BUILD_TARGET)
 else ifeq ($(UNAME),FreeBSD)
 LDFLAGS+= -shared -lusb -Wl,-soname,$(SHARED_LIB_NAME)
 

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -35,9 +35,9 @@ endif
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS	+= -c -DDARWIN
-TARCH	+= -arch i386 -arch x86_64
+TARCH	+= -arch x86_64
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
-LIBS	+= -framework IOKit -framework CoreFoundation -arch i386 -arch x86_64
+LIBS	+= -framework IOKit -framework CoreFoundation -arch x86_64
 else ifeq ($(UNAME),FreeBSD)
 LDFLAGS+= -shared -lusb -Wl,-soname,$(SHARED_LIB_NAME)
 

--- a/cpp/build/Makefile
+++ b/cpp/build/Makefile
@@ -34,7 +34,7 @@ endif
 
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
-CFLAGS	+= -c -DDARWIN
+CFLAGS	+= -c -DDARWIN -Wno-unused-private-field
 TARCH	+= -arch x86_64
 LDFLAGS += -dynamiclib -install_name "$(DESTDIR)/$(instlibdir)/$(SHARED_LIB_NAME)"
 LIBS	+= -framework IOKit -framework CoreFoundation -arch x86_64

--- a/cpp/build/support.mk
+++ b/cpp/build/support.mk
@@ -13,6 +13,16 @@ USE_HID ?= 1
 
 #the System we are building on
 UNAME  := $(shell uname -s)
+# The version of macOS we might be building on
+DARWIN_VERSION = 0
+# A simple flag to help determine if we're building on 10.14 or greater
+# 0 = false, 1 = true
+DARWIN_MOJAVE_UP = 0
+ifeq ($(UNAME),Darwin)
+# Returns a macOS version number as `10.14`
+DARWIN_VERSION := $(shell sw_vers -productVersion)
+DARWIN_MOJAVE_UP := $(shell expr $(DARWIN_VERSION) \>= 10.14)
+endif
 #the location of Doxygen to generate our api documentation
 DOXYGEN := $(shell which doxygen)
 #dot is required for doxygen (part of Graphviz)

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -37,7 +37,13 @@ include $(top_srcdir)/cpp/build/support.mk
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS += -DDARWIN
-TARCH += -arch x86_64
+ifeq ($(DARWIN_MOJAVE_UP),1)
+# Newer macOS releases don't support i386 so only build 64-bit
+TARCH	+= -arch x86_64
+else
+# Support older versions of OSX that may need to build both 32-bit and 64-bit
+TARCH	+= -arch i386 -arch x86_64
+endif
 endif
 
 # Dup from main makefile, but that is not included when building here..

--- a/cpp/examples/MinOZW/Makefile
+++ b/cpp/examples/MinOZW/Makefile
@@ -37,7 +37,7 @@ include $(top_srcdir)/cpp/build/support.mk
 #if we are on a Mac, add these flags and libs to the compile and link phases 
 ifeq ($(UNAME),Darwin)
 CFLAGS += -DDARWIN
-TARCH += -arch i386 -arch x86_64
+TARCH += -arch x86_64
 endif
 
 # Dup from main makefile, but that is not included when building here..


### PR DESCRIPTION
I attempted to build OZW on macOS Mojave (10.14) but was blocked by a couple of issues with the **Darwin**-specific build process:

- Xcode's **make** no longer supports the `i386` architecture. I've removed these build targets from the OZW library as well as the MinOZW example application
- The build failed on several unused private fields defined within the various Value classes. The `-Wunused-private-field` gcc flag was being implicitly set somewhere (I couldn't identify where), but I was able to add an additional flag to ignore such errors.

I can confirm that, with these changes, OZW can now be built and installed on macOS 10.14 with a simple `make && sudo make install`.