### PR TITLE
Fixes an access violation on the NextSibling after a child has been removed

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -7304,8 +7304,10 @@ void Driver::ReloadNode
 					// Get the node Id from the XML
 					if( TIXML_SUCCESS == nodeElement->ToElement()->QueryIntAttribute( "id", &intVal ) )
 					{
-						if (intVal == _nodeId)
+						if (intVal == _nodeId) {
 							driverElement->RemoveChild(nodeElement);
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Also there's no reason to continue the loop once the node has been found and removed.
Fixes #1609 / https://github.com/OpenZWave/openzwave-dotnet-uwp/issues/22