### PR TITLE
Adding device id and type for YKFCON with ZW+/S2

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -219,6 +219,7 @@
 		<Product type="6600" id="0002" name="Yale Conexis L1 (SD-L1000-CH)" config="assa_abloy/ConexisL1.xml"/>
 		<Product type="0007" id="0001" name="Keyless Connected (YD-01-CON)" config="assa_abloy/KeyfreeConnected-plus.xml"/>
 		<Product type="0006" id="0001" name="Yale Keyfree Connected Smart Lock (YKFCON)" config="assa_abloy/KeyfreeConnected-plus.xml"/>
+		<Product type="0600" id="0000" name="Yale Keyfree Connected Smart Lock (YKFCON)" config="assa_abloy/KeyfreeConnected-plus.xml"/>
 		<Product type="8001" id="0b00" name="Yale nexTouch Wireless Push Button (NTB610)" config="assa_abloy/nexTouch.xml"/>
 		<Product type="8003" id="0b00" name="Yale nexTouch Wireless Push Button (NTB620)" config="assa_abloy/nexTouch.xml"/>
 	</Manufacturer>


### PR DESCRIPTION
 Hi. Ive got a Yale YKFCON lock equipped with the new (dark blue) Zwave+/S2 module and it's device type and id doesnt match the config file, so i amended it.
Sorry if not following the process, im a complete github noob.