### PR TITLE
Fixed Z wave plus command class name

### DIFF
--- a/cpp/src/command_classes/ZWavePlusInfo.cpp
+++ b/cpp/src/command_classes/ZWavePlusInfo.cpp
@@ -2,7 +2,7 @@
 //
 //	ZWavePlusInfo.cpp
 //
-//	Implementation of the Z-Wave COMMAND_CLASS_ZWAVE_PLUS_INFO
+//	Implementation of the Z-Wave COMMAND_CLASS_ZWAVEPLUS_INFO
 //
 //	Copyright (c) 2015
 //

--- a/cpp/src/command_classes/ZWavePlusInfo.h
+++ b/cpp/src/command_classes/ZWavePlusInfo.h
@@ -2,7 +2,7 @@
 //
 //	ZWavePlusInfo.h
 //
-//	Implementation of the Z-Wave COMMAND_CLASS_ZWAVE_PLUS_INFO
+//	Implementation of the Z-Wave COMMAND_CLASS_ZWAVEPLUS_INFO
 //
 //	Copyright (c) 2015
 //
@@ -32,7 +32,7 @@
 
 namespace OpenZWave
 {
-	/** \brief Implements COMMAND_CLASS_ZWAVE_PLUS_INFO (0x5E), a Z-Wave device command class.
+	/** \brief Implements COMMAND_CLASS_ZWAVEPLUS_INFO (0x5E), a Z-Wave device command class.
 	 */
 	class ZWavePlusInfo: public CommandClass
 	{
@@ -41,7 +41,7 @@ namespace OpenZWave
 		virtual ~ZWavePlusInfo(){}
 
 		static uint8 const StaticGetCommandClassId(){ return 0x5E; }
-		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_ZWAVE_PLUS_INFO"; }
+		static string const StaticGetCommandClassName(){ return "COMMAND_CLASS_ZWAVEPLUS_INFO"; }
 
 		// From CommandClass
 		virtual bool RequestState( uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue );


### PR DESCRIPTION
The correct command class name for z-wave plus, according to [this wiki](http://wiki.micasaverde.com/index.php/ZWave_Command_Classes) and other official sources, is `COMMAND_CLASS_ZWAVEPLUS_INFO` instead of `COMMAND_CLASS_ZWAVE_PLUS_INFO`.

I updated all of the instances where I found this in the repo.