### PR TITLE
Fix Invalid MultiInstanceEncap Report

### DIFF
--- a/cpp/src/command_classes/MultiInstance.cpp
+++ b/cpp/src/command_classes/MultiInstance.cpp
@@ -350,6 +350,11 @@ void MultiInstance::HandleMultiInstanceEncap
 			pCommandClass->ReceivedCntIncr();
 			pCommandClass->HandleMsg( &_data[3], _length-3, instance );
 		}
+		else
+		{
+			Log::Write( LogLevel_Warning, GetNodeId(), "Received invalid MultiInstanceReport from node %d. Attempting to process as MultiChannel", GetNodeId());
+			HandleMultiChannelEncap( _data, _length );
+		}
 	}
 }
 


### PR DESCRIPTION
This is related to issue #1179 .. The fix was merged to the master branch and it was tested by @danbowkley according to https://github.com/OpenZWave/open-zwave/issues/1179#issuecomment-430701315 .. This PR has the same commit as @Fishwaldo's https://github.com/OpenZWave/open-zwave/commit/805dc33fa5584182861868a79546ce2eadbb7ed3 commit to the master branch and is intended to add that same fix to the Dev branch.

Cheers,