### PR TITLE
Add support for GE 29169 and 12718 Plug-in Products

### DIFF
--- a/config/ge/28169-plugin-switch.xml
+++ b/config/ge/28169-plugin-switch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+GE Plug-in Smart Switch, Single Outlet 28169
+http://products.z-wavealliance.org/products/2533
+ -->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<CommandClass id="112">
+		<Value type="list" index="3" genre="config" label="LED Light" size="1" value="0">
+			<Help>
+				When shipped from the factory, the LED is set to turn ON when the connected light is turned OFF. 
+				This is the default setting and can be changed if your primary controller supports the node configuration function. 
+				To make the LED turn ON when the light is turned ON, change parameter 3s value to 1. 
+				To turn the LED OFF at all times, change parameter 3s value to 2.
+			</Help>
+			<Item label="LED Light on when Z-Wave turned OFF" value="0" />
+			<Item label="LED Light on when Z-Wave turned ON" value="1" />
+			<Item label="LED Light Always Off" value="2" />
+		</Value>
+	</CommandClass>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<Group index="1" max_associations="1" label="Lifeline" />
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -639,6 +639,7 @@
 		<Product type="4952" id="3032" name="12722 On/Off Relay Switch" config="ge/relay.xml"/>
 		<Product type="4952" id="3033" name="12727 In-Wall Smart Switch (Toggle)"/>
 		<Product type="4953" id="3032" name="32563 Hinge Pin Smart Door Sensor" config="ge/hinge-pin.xml"/>
+		<Product type="5044" id="3031" name="12718 Plug-In Two-Outlet Smart Dimmer" config="ge/dimmer_module.xml"/>
 		<Product type="5052" id="3031" name="12719 Plug-in Smart Switch" config="ge/12719-plugin-switch.xml"/>
 		<Product type="5052" id="3033" name="14282 Plug-In Two-Outlet Smart Switch" config="ge/14282-plugin-switch.xml"/>
 		<Product type="5052" id="3038" name="28169 Plug-In One-Outlet Smart Switch" config="ge/28169-plugin-switch.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -641,6 +641,7 @@
 		<Product type="4953" id="3032" name="32563 Hinge Pin Smart Door Sensor" config="ge/hinge-pin.xml"/>
 		<Product type="5052" id="3031" name="12719 Plug-in Smart Switch" config="ge/12719-plugin-switch.xml"/>
 		<Product type="5052" id="3033" name="14282 Plug-In Two-Outlet Smart Switch" config="ge/14282-plugin-switch.xml"/>
+		<Product type="5052" id="3038" name="28169 Plug-In One-Outlet Smart Switch" config="ge/28169-plugin-switch.xml"/>
 		<Product type="6363" id="3533" name="ZW4001 In-Wall Decora Style On/Off Relay Switch" config="ge/zw4001-switch.xml"/>
 		<Product type="4c42" id="3031" name="ZW7101 Smart LED Light Bulb ZE26I" config="ge/ze26i.xml"/>
 		<Product type="4953" id="3133" name="ZW6302 Portable Smart Motion Sensor" config="ge/zw6302.xml"/>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -244,6 +244,7 @@ DISTFILES =	.gitignore \
 	config/ge/26931-motion-switch.xml \
 	config/ge/26933-motion-dimmer.xml \
 	config/ge/28167-plugin-dimmer.xml \
+	config/ge/29169-plugin-switch.xml \
 	config/ge/dimmer.xml \
 	config/ge/dimmer_module.xml \
 	config/ge/hinge-pin.xml \


### PR DESCRIPTION
These two commits add support for GE 29169 switch and GE 12718 Dimmer products.  The switch was new, but the dimmer is identical from a z-wave configuration perspective to the ge-dimmer-module.xml, so I have just referenced it here.  I have both devices available on my network for testing and questions.