### PR TITLE
Fix Qubin PWM Thermostat ThermostatSetpoint

### DIFF
--- a/config/qubino/ZMNHLDx.xml
+++ b/config/qubino/ZMNHLDx.xml
@@ -17,7 +17,7 @@
    		</SupportedModes>
 	</CommandClass>
 
-    <CommandClass id="67" override_precision="2"  />
+    <CommandClass id="67" override_precision="2" base="0" />
     
 	<!-- Configuration -->
 	<CommandClass id="112">


### PR DESCRIPTION
Fixes #1319

Without this you can't set a temperature for the thermostat.