### PR TITLE
Add Oomi multisensor european version

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -977,9 +977,11 @@
 	<Manufacturer id="0040" name="Novar EDS">
 	</Manufacturer>
 	<Manufacturer id="016a" name="Oomi">
-		<!-- US-market products start with type prefix "01" -->
+		<!-- EU-market products seems to start with type prefix "00" -->
+                <!-- US-market products start with type prefix "01" -->
 		<!-- AU-market products start with type prefix "02" -->
 		<!-- CN-market products start with type prefix "1D" -->
+		<Product type="0002" id="0064" name="FT100 MultiSensor 6" config="oomi/ft100.xml" />
 		<Product type="0102" id="0064" name="FT100 MultiSensor 6" config="oomi/ft100.xml" />
 		<Product type="0202" id="0064" name="FT100 MultiSensor 6" config="oomi/ft100.xml" />
 		<Product type="1D02" id="0064" name="FT100 MultiSensor 6" config="oomi/ft100.xml" />

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -978,7 +978,7 @@
 	</Manufacturer>
 	<Manufacturer id="016a" name="Oomi">
 		<!-- EU-market products seems to start with type prefix "00" -->
-                <!-- US-market products start with type prefix "01" -->
+		<!-- US-market products start with type prefix "01" -->
 		<!-- AU-market products start with type prefix "02" -->
 		<!-- CN-market products start with type prefix "1D" -->
 		<Product type="0002" id="0064" name="FT100 MultiSensor 6" config="oomi/ft100.xml" />


### PR DESCRIPTION
First PR, so be gentle.

Added one line to add type "0002" of the Oomi Multisensor unit. I have this unit myself.
Two commits because of indentation error.