### PR TITLE
Update manufacturer_specific.xml

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1187,7 +1187,9 @@
 		<Product type="0001" id="0001" name="UZB Z-Wave USB Adapter"/>
 	</Manufacturer>
 	<Manufacturer id="0267" name="Simon">
-		<Product type="0001" id="0000" name="Simon iO Switch" config="simon/10002034-13X.xml"/>
+		<Product type="0001" id="0000" name="S100 iO Switch Simon" config="simon/10002034-13X.xml"/>
+		<Product type="0001" id="00da" name="S100 iO Switch Simon" config="simon/10002034-13X.xml"/>
+		<Product type="0009" id="0022" name="S100 iO Socket Simon" config="simon/10002041-13X.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0045" name="Sine Wireless">
 	</Manufacturer>


### PR DESCRIPTION
Added id for Simon iO Switch and product type "0009" and id "0022" for Simon iO 100 Socket.
Can you include the file XML in the simon folder?

[10002041-13X.xml.zip](https://github.com/OpenZWave/open-zwave/files/2753612/10002041-13X.xml.zip)