### PR TITLE
Set "Play Ringtone" to write_only in config/aeotec/zw056.xml

### DIFF
--- a/config/aeotec/zw056.xml
+++ b/config/aeotec/zw056.xml
@@ -21,7 +21,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584693
                 Value=1-100, Specify the ringtone as default.
             </Help>
         </Value>
-        <Value type="byte" index="6" genre="user" label="Play Ringtone" units="" min="0" max="255" value="0">
+        <Value type="byte" index="6" genre="user" label="Play Ringtone" units="" min="0" max="255" value="0" write_only="true">
             <Help>
                 Select a ringtone to play.
                 Value=0, stop playing.


### PR DESCRIPTION
Updated zw056.xml to make "Play Ringtone" write_only="true". Get commands after set commands were causing timeouts. The timeouts eventually trigger the node to be marked as dead.

[zw056.log](https://github.com/OpenZWave/open-zwave/files/2770497/zw056.log)
