### PR TITLE
Update manufacturer_specific.xml

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1421,6 +1421,7 @@
 		<Product type="0401" id="0002" name="ZST10 S2 Z-Wave Plus USB Stick" />
 		<Product type="a000" id="a001" name="ZEN26 S2 On Off Wall Switch" config="zooz/zen26.xml" />
 		<Product type="a000" id="a002" name="ZEN27 S2 Dimmer Wall Switch" config="zooz/zen27.xml" />
+		<Product type="b111" id="1e1c" name="ZEN21 Switch V2.0" config="zooz/zen21.xml" />
 	</Manufacturer>
 	<Manufacturer id="015d" name="Zooz">
 		<Product type="0651" id="f51c" name="ZEN20 Power Strip" config="zooz/zen20.xml" />


### PR DESCRIPTION
The Manufacturer id for the ZEN21 looks to be incorrect or has changed. Adding "Product type="b111" id="1e1c"" under "Manufacturer id="027a" name="Zooz"" resolves issues identifying/controlling this device.

Changes before and after as seen in the zwcfg.xml

Before:

        <Node id="28" name="" location="" basic="4" generic="16" specific="1" roletype="5" devicetype="7424" nodetype="0" type="Binary Power Switch" listening="true" frequentListenin
g="false" beaming="true" routing="true" max_baud_rate="40000" version="4" secured="true" query_stage="Complete">
                <Manufacturer id="27a" name="Zooz">
                        <Product type="b111" id="1e1c" name="Unknown: type=b111, id=1e1c" />

After:

        <Node id="28" name="" location="" basic="4" generic="16" specific="1" roletype="5" devicetype="7424" nodetype="0" type="Binary Power Switch" listening="true" frequentListenin
g="false" beaming="true" routing="true" max_baud_rate="40000" version="4" query_stage="Complete">
                <Manufacturer id="27a" name="Zooz">
                        <Product type="b111" id="1e1c" name="ZEN21 Switch V2.0" />