### PR TITLE
 Expose a function that allows to send raw data on the network interface.

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -4755,3 +4755,30 @@ void Manager::GetNodeStatistics
 	}
 
 }
+
+//-----------------------------------------------------------------------------
+// <Manager::SendRawData>
+// Send a custom message to a node.
+//-----------------------------------------------------------------------------
+void Manager::SendRawData
+(
+	uint32 const  _homeId,
+	uint8  const  _nodeId,
+	string const& _logText,
+	uint8  const  _msgType,
+	uint8  const* _content,
+	uint8  const  _length
+)
+{
+	if ( Driver *driver = GetDriver( _homeId ) )
+	{
+		Msg* msg = new Msg( _logText, _nodeId, _msgType, FUNC_ID_ZW_SEND_DATA, true );
+		for( uint8 i = 0; i < _length; i++ )
+		{
+			msg->Append( _content[i] );
+		}
+		msg->Append( driver->GetTransmitOptions() );
+		driver->SendMsg( msg, Driver::MsgQueue_Send );
+	}
+}
+

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -4766,19 +4766,28 @@ void Manager::SendRawData
 	uint8  const  _nodeId,
 	string const& _logText,
 	uint8  const  _msgType,
+	bool   const  _sendSecure,
 	uint8  const* _content,
 	uint8  const  _length
 )
 {
 	if ( Driver *driver = GetDriver( _homeId ) )
 	{
-		Msg* msg = new Msg( _logText, _nodeId, _msgType, FUNC_ID_ZW_SEND_DATA, true );
-		for( uint8 i = 0; i < _length; i++ )
+		Node* node = driver->GetNode( _nodeId );
+		if ( node )
 		{
-			msg->Append( _content[i] );
+			Msg* msg = new Msg( _logText, _nodeId, _msgType, FUNC_ID_ZW_SEND_DATA, true );
+			for( uint8 i = 0; i < _length; i++ )
+			{
+				msg->Append( _content[i] );
+			}
+			msg->Append( driver->GetTransmitOptions() );
+			if ( _sendSecure )
+			{
+				msg->setEncrypted();
+			}
+			driver->SendMsg( msg, Driver::MsgQueue_Send );
 		}
-		msg->Append( driver->GetTransmitOptions() );
-		driver->SendMsg( msg, Driver::MsgQueue_Send );
 	}
 }
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -2377,8 +2377,24 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		 */
 		void GetNodeStatistics( uint32 const _homeId, uint8 const _nodeId, Node::NodeData* _data );
 
+	//-----------------------------------------------------------------------------
+	// Raw interface
+	//-----------------------------------------------------------------------------
+	/** \name Raw Interface
+	 *  Commands for sending raw messages.
+	 */
+	/*@{*/
+	public:
+		/**
+		 *  \brief Send a custom message to a node.
+		 */
+		void SendRawData(uint32 const _homeId, uint8 const _nodeId, string const& _logText, uint8 const _msgType, uint8 const* _content, uint8 const _length);
+
+	/*@}*/
+
 	};
 	/*@}*/
+
 } // namespace OpenZWave
 
 #endif // _Manager_H

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -2388,7 +2388,7 @@ OPENZWAVE_EXPORT_WARNINGS_ON
 		/**
 		 *  \brief Send a custom message to a node.
 		 */
-		void SendRawData(uint32 const _homeId, uint8 const _nodeId, string const& _logText, uint8 const _msgType, uint8 const* _content, uint8 const _length);
+		void SendRawData(uint32 const _homeId, uint8 const _nodeId, string const& _logText, uint8 const _msgType, const bool _sendSecure, uint8 const* _content, uint8 const _length);
 
 	/*@}*/
 


### PR DESCRIPTION
This adds the ability to send hand-crafted messages to a node.
It may come in handy when accessing proprietary features of a device.
Fixes #859.