### PR TITLE
Add new product type and id for the 2GIG CT101

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -16,6 +16,7 @@
 		<Product type="6401" id="01fd" name="CT100 Thermostat USA" config="2gig/ct100.xml"/>
 		<Product type="6402" id="0100" name="CT100 Plus Thermostat" config="2gig/ct100.xml"/>
 		<Product type="6402" id="0001" name="CT100 Plus Thermostat" config="2gig/ct100.xml"/>
+		<Product type="6501" id="000b" name="CT101 Thermostat" config="2gig/ct101.xml"/>
 		<Product type="6501" id="000c" name="CT101 Thermostat (Iris)" config="2gig/ct101.xml"/>
 		<Product type="6501" id="000d" name="CT101 Thermostat" config="2gig/ct101.xml"/>
 	</Manufacturer>


### PR DESCRIPTION
New product type and id for 2GIG CT101. Confirmed full functionality/testing with actual hardware. While OpenHAB reports this device as a CT100, it does have a humidity sensor which makes it a CT101.