### PR TITLE
Add support for Heatit Z-TRM2fx

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1925,7 +1925,7 @@
 	</Manufacturer>
 	<Manufacturer id="019b" name="ThermoFloor AS">
 		<Product type="0001" id="0001" name="Heatit Thermostat TF 021" config="thermofloor/heatit021.xml"/>
-		<Product type="0003" id="0202" name="Heatit Thermostat TF 033" config="thermofloor/heatit033.xml"/>
+		<Product type="0003" id="0202" name="Heatit Thermostat TF 056" config="thermofloor/heatit056.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0317" name="Think Simple srl">
 	</Manufacturer>

--- a/config/thermofloor/heatit056.xml
+++ b/config/thermofloor/heatit056.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Heatit Z-Wave Thermostat Z-TRM2fx TF 056 -->
+<Product xmlns='https://products.z-wavealliance.org/products/3065'>
+
+	<CommandClass id="64" name="COMMAND_CLASS_THERMOSTAT_MODE">
+		<Value type="list" genre="user" instance="1" index="0" label="Mode" units="" read_only="false" write_only="false" min="0" max="0" value="0">
+			<Item label="Off" value="0"/>
+			<Item label="Heat" value="1"/>
+			<Item label="Cool" value="2"/>
+			<Item label="Energy Heat" value="11"/>
+		</Value>
+		<SupportedModes>
+			<Mode index="0" label="Off"/>
+			<Mode index="1" label="Heat"/>
+			<Mode index="2" label="Cool"/>
+			<Mode index="11" label="Energy Heat"/>
+		</SupportedModes>
+	</CommandClass>
+
+	<CommandClass id="49" name="COMMAND_CLASS_SENSOR_MULTILEVEL" version="1" request_flags="4" create_vars="true" base="0">
+      <Value type="decimal" genre="user" instance="1" index="0" label="External sensor" units="C" read_only="true" write_only="false" min="0" max="0" />
+      <Value type="decimal" genre="user" instance="2" index="1" label="Floor sensor" units="C" read_only="true" write_only="false" min="0" max="0" />
+  </CommandClass>
+
+	<CommandClass id="67" name="COMMAND_CLASS_THERMOSTAT_SETPOINT" version="1" request_flags="4" create_vars="true" base="0">
+		<Instance index="1"/>
+		<Value type="decimal" genre="user" instance="1" index="1" label="Heating" units="C" read_only="false" write_only="false" min="0" max="0" value="21"/>
+		<Value type="decimal" genre="user" instance="1" index="2" label="Cooling" units="C" read_only="false" write_only="false" min="0" max="0" value="21"/>
+		<Value type="decimal" genre="user" instance="1" index="11" label="Energy Heat" units="C" read_only="false" write_only="false" min="0" max="0" value="18"/>
+	</CommandClass>
+
+	<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION">
+		<Value type="list" genre="config" index="1" label="Operation mode" value="1">
+			<Help>Set operation mode</Help>
+			<Item label="Off" value="0"/>
+			<Item label="Heat" value="1"/>
+            <Item label="Cooling Mode (Not implemented)" value="2"/>
+			<Item label="Heat Energy Saving" value="11"/>
+		</Value>
+		<Value type="list" genre="config" instance="1" index="2" label="Sensor mode" value="1">
+			<Help>Set sensor mode</Help>
+			<Item label="F - Floor sensor" value="0"/>
+			<Item label="A2 - External room sensor" value="3"/>
+            <Item label="A2F - External sensor with floor limitation" value="4"/>
+		</Value>
+		<Value type="list" genre="config" instance="1" index="3" label="Floor sensor type" value="0">
+			<Help>Floor sensor type (10K NTC Default)</Help>
+			<Item label="10k ntc" value="0"/>
+			<Item label="12k ntc" value="1"/>
+			<Item label="15k ntc" value="2"/>
+			<Item label="22k ntc" value="3"/>
+			<Item label="33k ntc" value="4"/>
+			<Item label="47k ntc" value="5"/>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="4" label="Temperature control Hysteresis" min="3" max="30" size="1" value="5">
+			<Help>3-30 (0.3°C – 3.0°C) Default is 5 (0.5°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="5" label="Floor minimum temperature limit" min="50" max="400" size="2" value="50">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 50 (5.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="6" label="Floor maximum temperature limit" min="50" max="400" size="2" value="400">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 400 (40.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="7" label="Air (A2) minimum temperature limit" min="50" max="400" size="2" value="50">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 50 (5.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="8" label="Air (A2) maximum temperature limit" min="50" max="400" size="2" value="400">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 400 (40.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="9" label="Heating mode setpoint (CO)" min="50" max="400" size="2" value="210">
+			<Help>50 - 400 (5.0°C – 40.0°C) Default is 210 (21.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="10" label="Energy saving mode setpoint (ECO)" size="2" min="50" max="400" value="180">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 180 (18.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="11" label="Cooling setpoint (COOL)" size="2" min="50" max="400" value="210">
+			<Help>50-400 (5.0°C – 40.0°C) Default is 210 (21.0°C)</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="12" label="Floor sensor calibration" size="1" min="0" max="255" value="0">
+			<Help>-40 - 40 (-4.0°C – 4.0°C) Default is 0 (0.0°C) To set a negative value, use 255 and subtract the desired value.</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="13" label="External sensor calibration" size="1" min="0" max="255" value="0">
+			<Help>-40 - 40 (-4.0°C – 4.0°C) Default is 0 (0.0°C) To set a negative value, use 255 and subtract the desired value.</Help>
+		</Value>
+		<Value type="list" genre="config" instance="1" index="14" size="1" label="Temperature display" value="0">
+			<Help>Show setpoint or calculated temperature on display(</Help>
+			<Item label="Display setpoint temperature (Default)" value="0"/>
+			<Item label="Display measured temperature" value="1"/>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="15" label="Button brightness - Dimmed state" min="0" max="100" size="1" value="50">
+			<Help>0-100 (0 - 100%)</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="16" label="Button brightness - Active state" min="0" max="100" size="1" value="100">
+			<Help>0-100 (0 - 100%)</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="17" label="Display brightness - Dimmed state" min="0" max="100" size="1" value="50">
+			<Help>0-100 (0 - 100%)</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="18" label="Display brightness – Active state" min="0" max="100" size="1" value="100">
+			<Help>0-100 (0 - 100%)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="19" label="Temperature report interval" min="0" max="32767" size="2" value="60">
+			<Help>
+				0 (Report disabled)
+				30-32767 (30-32767 seconds)
+			</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="20" label="Temperature report hysteresis" min="1" max="100" size="1" value="10">
+			<Help>0-100 (0.1°C – 10.0°C) Default is 10 (1.0°C)</Help>
+		</Value>
+		<Value type="short" genre="config" instance="1" index="21" label="Meter report interval" min="0" max="32767" size="2" value="60">
+			<Help>
+				0 (Report disabled)
+				30-32767 (30-32767 seconds)
+			</Help>
+		</Value>
+		<Value type="byte" genre="config" instance="1" index="22" label="Meter report delta value" min="0" max="255" size="1" value="10">
+			<Help>0-127 A delta value of 0 – 12.7 kWh will result in a metering report. Default is 10 (1.0 kWh)</Help>
+		</Value>
+	</CommandClass>
+
+	<CommandClass id="133" name="COMMAND_CLASS_ASSOCIATION">
+		<Associations num_groups="4">
+			<Group index="1" max_associations="5" label="Lifeline"/>
+			<Group index="2" max_associations="5" label="Multilevel sensor reports - External sensor"/>
+			<Group index="3" max_associations="5" label="Multilevel sensor reports - Floor sensor"/>
+			<Group index="4" max_associations="5" label="On/Off switch of internal relay"/>
+		</Associations>
+	</CommandClass>
+
+	<!-- COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION_V2-->
+	<CommandClass id="142" ForceInstances="true" />
+
+	<!--COMMAND_CLASS_MULTI_CHANNEL_V2 Map endpoints to instances -->
+	<CommandClass id="96" mapping="endpoints" />
+
+</Product>

--- a/config/thermofloor/heatit056.xml
+++ b/config/thermofloor/heatit056.xml
@@ -34,7 +34,7 @@
 			<Help>Set operation mode</Help>
 			<Item label="Off" value="0"/>
 			<Item label="Heat" value="1"/>
-            <Item label="Cooling Mode (Not implemented)" value="2"/>
+            		<Item label="Cooling Mode" value="2"/>
 			<Item label="Heat Energy Saving" value="11"/>
 		</Value>
 		<Value type="list" genre="config" instance="1" index="2" label="Sensor mode" value="1">


### PR DESCRIPTION
Heatit Z-TRM2 is replaced with Z-TRM2fx. Z-TRM2 is withdrawn from marked and owners can send it back to Thermofloor to get a new Z-TRM2fx replacement.

Since both products have different config but share the same product type/id The XML files should be replaced with config for FX version as this is the only Z-TRM2 product in sale. 