### PR TITLE
Add GE (Jasco) 14299 In-Wall 1000W Smart Dimmer.

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -875,6 +875,7 @@
 		<Product type="4944" id="3131" name="14287 Fan Control Switch" config="ge/12724-dimmer.xml"/>
 		<Product type="4952" id="3134" name="14288 In-Wall Tamper Resistant Smart Outlet" config="ge/14288-outlet.xml"/>
 		<Product type="4944" id="3038" name="14294 In-Wall Smart Dimmer" config="ge/14294-dimmer.xml"/>
+		<Product type="4944" id="3039" name="14299 In-Wall 1000W Smart Dimmer" config="ge/14294-dimmer.xml"/>
 		<Product type="4944" id="3130" name="14295 In-Wall Smart Toggle Dimmer" config="ge/14295-dimmer-toggle.xml"/>
 		<Product type="494d" id="3032" name="26931 Smart Motion Switch" config="ge/26931-motion-switch.xml"/>
 		<Product type="494d" id="3034" name="26933 Smart Motion Dimmer" config="ge/26933-motion-dimmer.xml"/>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -348,6 +348,7 @@ DISTFILES =	.gitignore \
 	config/manufacturer_specific.xml \
 	config/manufacturer_specific.xsd \
 	config/mcohome/a8-9.xml \
+	config/mcohome/mh7h.xml \
 	config/mcohome/mh8fceu.xml \
 	config/mcohome/mh9co2.xml \
 	config/mcohome/mhp210.xml \
@@ -452,6 +453,7 @@ DISTFILES =	.gitignore \
 	config/remotec/zxt-600.xml \
 	config/schlage/BE468.xml \
 	config/schlage/BE469.xml \
+	config/schlage/BE469ZP.xml \
 	config/schlagelink/itemp.xml \
 	config/schlagelink/minikeypad.xml \
 	config/sensative/strips.xml \
@@ -479,6 +481,7 @@ DISTFILES =	.gitignore \
 	config/telldus/tzwp102.xml \
 	config/thermofloor/heatit021.xml \
 	config/thermofloor/heatit033.xml \
+	config/thermofloor/heatit056.xml \
 	config/trane/TZEMT400AB32MAA.xml \
 	config/trane/TZEMT400BB32MAA.xml \
 	config/trane/TZEMT524AA21MA.xml \
@@ -527,14 +530,18 @@ DISTFILES =	.gitignore \
 	config/zooz/zen07.xml \
 	config/zooz/zen15.xml \
 	config/zooz/zen20.xml \
+	config/zooz/zen20v2.xml \
 	config/zooz/zen21.xml \
 	config/zooz/zen22.xml \
 	config/zooz/zen22v2.xml \
 	config/zooz/zen23.xml \
 	config/zooz/zen24.xml \
+	config/zooz/zen26.xml \
+	config/zooz/zen27.xml \
 	config/zooz/zse08.xml \
 	config/zooz/zse09.xml \
 	config/zooz/zse18.xml \
+	config/zooz/zse19.xml \
 	config/zooz/zse30.xml \
 	config/zooz/zse33.xml \
 	config/zooz/zse40.xml \


### PR DESCRIPTION
The 14299 can use the same config as the 14294. Per the Z-Wave alliance, the configuration commands are identical:
* [In-Wall Smart 1000W Dimmer (14299/ZW3006)](https://products.z-wavealliance.org/products/2168/configs)
* [In-Wall Smart Dimmer (14294/ZW3005)](https://products.z-wavealliance.org/products/2105/configs)

Ran `make xmltest` without error.
Ran `make distupdate`, some missed files from earlier commits were added.