### PR TITLE
Updated support for Aeotec NanoMote Quad

### DIFF
--- a/config/aeotec/zwa003.xml
+++ b/config/aeotec/zwa003.xml
@@ -17,11 +17,16 @@ ZWA003 NanoMote Quad
 				Available settings: 0-255.
 			</Help>
 		</Value>
+		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+			<Help>Enable/disable the sending central scene notification</Help>
+			<Item label="Disable" value="0" />
+			<Item label="Enable" value="1" />
+		</Value>
 		<Value type="list" genre="config" instance="1" index="43" label="Battery low buzzer alarm" min="0" max="1" value="1" size="1">
-            		<Help>Enable/disable the buzzer alarm when battery is running low</Help>
-            		<Item label="Disable" value="0"/>
-            		<Item label="Enable" value="1"/>
-		</Value>    
+			<Help>Enable/disable the buzzer alarm when battery is running low</Help>
+			<Item label="Disable" value="0"/>
+			<Item label="Enable" value="1"/>
+		</Value>
 	</CommandClass>
 	<!-- Association Groups -->
 	<CommandClass id="133">
@@ -36,5 +41,14 @@ ZWA003 NanoMote Quad
 			<Group index="8" max_associations="5" label="On/Off control via Button 4"/>
 			<Group index="9" max_associations="5" label="Dimmer control via Button 4"/>
 		</Associations>
+	</CommandClass>
+	<!-- Central Scene Reports -->
+	<CommandClass id="91">
+		<Instance index="1" />
+		<Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="1" label="Button One" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="2" label="Button Two" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="3" label="Button Three" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="4" label="Button Four" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
 	</CommandClass>
 </Product>

--- a/config/aeotec/zwa003.xml
+++ b/config/aeotec/zwa003.xml
@@ -11,7 +11,7 @@ ZWA003 NanoMote Quad
 				Range: 10% - 50%.
 			</Help>
 		</Value>
-		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" min="0" max="1" size="1">
 			<Help>Enable/disable the sending central scene notification</Help>
 			<Item label="Disable" value="0" />
 			<Item label="Enable" value="1" />
@@ -45,10 +45,10 @@ ZWA003 NanoMote Quad
 	<!-- Central Scene Reports -->
 	<CommandClass id="91">
 		<Instance index="1" />
-		<Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
-		<Value type="int" genre="user" instance="1" index="1" label="Button One" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
-		<Value type="int" genre="user" instance="1" index="2" label="Button Two" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
-		<Value type="int" genre="user" instance="1" index="3" label="Button Three" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
-		<Value type="int" genre="user" instance="1" index="4" label="Button Four" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="system" instance="1" index="0" label="Scene Count" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="1" label="Button One" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="2" label="Button Two" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="3" label="Button Three" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="0" />
+		<Value type="int" genre="user" instance="1" index="4" label="Button Four" units="" read_only="true" write_only="false" verify_changes="false" min="-2147483648" max="2147483647" value="0" />
 	</CommandClass>
 </Product>

--- a/config/aeotec/zwa003.xml
+++ b/config/aeotec/zwa003.xml
@@ -11,11 +11,6 @@ ZWA003 NanoMote Quad
 				Range: 10% - 50%.
 			</Help>
 		</Value>
-		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" min="0" max="1" size="1">
-			<Help>Enable/disable the sending central scene notification</Help>
-			<Item label="Disable" value="0" />
-			<Item label="Enable" value="1" />
-		</Value>
 		<Value type="byte" index="42" genre="config" label="Duration of the command switch multilevel" units="" min="0" max="255" value="255">
 			<Help>
 				Setting the duration value of the command switch multilevel.

--- a/config/aeotec/zwa003.xml
+++ b/config/aeotec/zwa003.xml
@@ -11,16 +11,16 @@ ZWA003 NanoMote Quad
 				Range: 10% - 50%.
 			</Help>
 		</Value>
+		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
+			<Help>Enable/disable the sending central scene notification</Help>
+			<Item label="Disable" value="0" />
+			<Item label="Enable" value="1" />
+		</Value>
 		<Value type="byte" index="42" genre="config" label="Duration of the command switch multilevel" units="" min="0" max="255" value="255">
 			<Help>
 				Setting the duration value of the command switch multilevel.
 				Available settings: 0-255.
 			</Help>
-		</Value>
-		<Value type="list" genre="config" instance="1" index="41" label="Enable send central scene notification" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
-			<Help>Enable/disable the sending central scene notification</Help>
-			<Item label="Disable" value="0" />
-			<Item label="Enable" value="1" />
 		</Value>
 		<Value type="list" genre="config" instance="1" index="43" label="Battery low buzzer alarm" min="0" max="1" value="1" size="1">
 			<Help>Enable/disable the buzzer alarm when battery is running low</Help>


### PR DESCRIPTION
Added support for the 4 buttons.
Source: https://products.z-wavealliance.org/products/2817
https://aeotec.freshdesk.com/support/solutions/articles/6000184697-nanomote-quad-technical-specifications-
https://aeotec.freshdesk.com/support/solutions/articles/6000184696-nanomote-quad-user-guide-

Added support for Config value 41--Enable send central scene notification.
source: https://products.z-wavealliance.org/Products/2817/XML