### PR TITLE
Add custom config for Leviton VRCZ4

### DIFF
--- a/config/leviton/vrcz4.xml
+++ b/config/leviton/vrcz4.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Leviton 4 Button Zone Controller VRCZ4 / VRCZ4-MR
+https://products.z-wavealliance.org/products/288
+https://products.z-wavealliance.org/products/374
+-->
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+	<!-- Association Groups -->
+	<CommandClass id="133">
+		<Associations num_groups="4">
+		       <!-- Do not auto associate with Group 1 on this device -->
+		       <Group index="1" max_associations="232" label="Basic - Button 1" auto="false"/>
+		       <Group index="2" max_associations="232" label="Basic - Button 2"/>
+		       <Group index="3" max_associations="232" label="Basic - Button 3"/>
+		       <Group index="4" max_associations="232" label="Basic - Button 4"/>
+		</Associations>
+	</CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1238,14 +1238,14 @@
 		<Product type="0602" id="0209" name="VRMX1-1LZ Multilevel Scene Switch" config="leviton/vri10.xml"/>
 		<Product type="0602" id="0334" name="VRMX1-1LZ Multilevel Scene Switch" config="leviton/vri10.xml"/>
 		<Product type="0901" id="0215" name="VRC51-1LX One Scene Controller"/>
-		<Product type="0702" id="0261" name="VRCZ4-M0Z 4-Button Zone Controller"/>
+		<Product type="0702" id="0261" name="VRCZ4-M0Z 4-Button Zone Controller" config="leviton/vrcz4.xml"/>
 		<Product type="0b02" id="030b" name="VRC0P-1LW Plug-in Serial Interface Module"/>
 		<Product type="0c01" id="0206" name="VRCPG-SG RF Handheld Remote Controller" config="leviton/vrcpg.xml"/>
 		<Product type="0e01" id="0334" name="VRE06-1LZ Multilevel Scene Switch" config="leviton/vre06.xml"/>
 		<Product type="1001" id="0209" name="VRF01-1LZ Scene Capable Quiet Fan Speed Control" config="leviton/vrf01.xml"/>
 		<Product type="1001" id="0334" name="VRF01-1LZ Quiet Fan Speed Control" config="leviton/vrf01.xml"/>
 		<Product type="1102" id="0243" name="VRCS2-MRZ 2-Button Scene Controller with Switches"/>
-		<Product type="1202" id="0243" name="VRCZ4-MRZ 4-Button Zone Controller with Switch"/>
+		<Product type="1202" id="0243" name="VRCZ4-MRZ 4-Button Zone Controller with Switch" config="leviton/vrcz4.xml"/>
 		<Product type="1902" id="0334" name="DZPD3-1LW Plug-In Dimming Lamp Module"/>
 		<Product type="1a02" id="0334" name="DZPA1-1LW Plug-In Appliance Module"/>
 		<Product type="1b03" id="0334" name="DZMX1-1LZ Dimmer"/>


### PR DESCRIPTION
The Leviton VRCZ4 uses association groups 1-4 to set devices controlled (with basic set commands) with buttons 1-4.  It doesn't make sense to auto-add the controller to group 1 for this device.  Added a custom config to allow disabling that auto association, and give a slightly more descriptive name for those groups.