### PR TITLE
Fibaro Roller Shutter 3 fix for scene triggering by S2 - fgr232.xml #41 type=byte

### DIFF
--- a/config/fibaro/fgr223.xml
+++ b/config/fibaro/fgr223.xml
@@ -120,7 +120,7 @@
             </Help>
         </Value>
 
-        <Value type="list" genre="config" instance="1" index="41" label="S2 switch - scenes sent" size="1" value="0">
+        <Value type="byte" genre="config" instance="1" index="41" label="S2 switch - scenes sent" size="1" value="0">
             <Help>
                 This parameter determines which actions result in sending scene IDs assigned to them.
                 Sum of:


### PR DESCRIPTION
Typo fix for Fibaro Roller Shutter 3
Fixed type of parameter #41. Proper value is "byte"
Due to wrong type parameter was inactive and triggering scenes by S2 not possible.