### PR TITLE
Add ZWP PA-100 support

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -2273,6 +2273,7 @@
 		<Product type="b111" id="1e1c" name="ZEN21 Switch V2.0" config="zooz/zen21.xml" />
 	</Manufacturer>
 	<Manufacturer id="0315" name="zwaveproducts.com">
+		<Product type="4447" id="3031" name="PA-100" config="zwp/PA-100.xml"/>
 		<Product type="4447" id="3034" name="WD-100" config="zwp/WD-100.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0021" name="Zykronix">

--- a/config/zwp/PA-100.xml
+++ b/config/zwp/PA-100.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+ZLINK Products Plug-In Appliance Module, ZL-PA-100
+https://www.zwaveproducts.com/shop/z-wave-lighting/z-wave-plugin-modules/zlink-products-plug-in-appliance-module-zl-pa-100
+-->
+<Product xmlns="http://code.google.com/p/open-zwave/">
+
+  <!-- Configuration Parameters -->
+  <CommandClass id="112">
+    <Value genre="config" instance="1" index="3" value="0" label="Nightlight" units="" size="1" min="0" max="2" type="list">
+      <Help>DEFAULT: the LED indicator will be OFF when the connected appliance is ON, and the LED indicator will be ON when the connected appliance is OFF.
+INVERTED: the LED indicator will be OFF when the connected appliance is OFF, and the LED indicator will be ON when the connected appliance is ON.
+OFF: the LED indicator will be always OFF regardless of the load status.</Help>
+      <Item value="0" label="Default"/>
+      <Item value="1" label="Inverted"/>
+      <Item value="2" label="Off"/>
+    </Value>
+  </CommandClass>
+
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="1">
+      <Group index="1" label="Lifeline" max_associations="1" />
+    </Associations>
+  </CommandClass>
+
+</Product>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -573,6 +573,7 @@ DISTFILES =	.gitignore \
 	config/zwave.me/popp_kfob-c.xml \
 	config/zwave.me/zweather.xml \
 	config/zwcfg.xsd \
+	config/zwp/PA-100.xml \
 	config/zwp/WD-100.xml \
 	config/zwscene.xsd \
 	cpp/build/Makefile \


### PR DESCRIPTION
Add support for zwaveproducts.com Plug-In Appliance Module, ZL-PA-100 https://www.zwaveproducts.com/shop/z-wave-lighting/z-wave-plugin-modules/zlink-products-plug-in-appliance-module-zl-pa-100