### PR TITLE
replace getVersionAsString() with getVersionLongAsString()

### DIFF
--- a/cpp/examples/MinOZW/Main.cpp
+++ b/cpp/examples/MinOZW/Main.cpp
@@ -270,8 +270,11 @@ int main( int argc, char* argv[] )
 
 	pthread_mutex_lock( &initMutex );
 
+	// petergebruers replace getVersionAsString() with getVersionLongAsString() because
+	// the latter prints more information, based on the status of the repository
+	// when "make" was run. A Makefile gets this info from git describe --long --tags --dirty
 
-	printf("Starting MinOZW with OpenZWave Version %s\n", Manager::getVersionAsString().c_str());
+	printf("Starting MinOZW with OpenZWave Version %s\n", Manager::getVersionLongAsString().c_str());
 
 	// Create the OpenZWave Manager.
 	// The first argument is the path to the config files (where the manufacturer_specific.xml file is located

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -190,7 +190,10 @@ m_notificationMutex( new Mutex() )
 
 	CommandClasses::RegisterCommandClasses();
 	Scene::ReadScenes();
-	Log::Write(LogLevel_Always, "OpenZwave Version %s Starting Up", getVersionAsString().c_str());
+	// petergebruers replace getVersionAsString() with getVersionLongAsString() because
+	// the latter prints more information, based on the status of the repository
+	// when "make" was run. A Makefile gets this info from git describe --long --tags --dirty
+	Log::Write(LogLevel_Always, "OpenZwave Version %s Starting Up", getVersionLongAsString().c_str());
 	Log::Write(LogLevel_Always, "Using Language Localization %s", Localization::Get()->GetSelectedLang().c_str());
 	NotificationCCTypes::Create();
 


### PR DESCRIPTION
This would help me Without this change, all Dev logs start with "OpenZwave Version 1.5.3770 Starting Up" (based on tag info in git) so I am not sure if I'm linking agains a build that was based on the latest commit. With this change it prints "OpenZwave Version V1.5-3770-gd11ab62b-dirty Starting Up".