### PR TITLE
Implement Manager::HasExtendedTxStatus

### DIFF
--- a/cpp/examples/MinOZW/Main.cpp
+++ b/cpp/examples/MinOZW/Main.cpp
@@ -212,6 +212,18 @@ void OnNotification
 		case Notification::Type_DriverReady:
 		{
 			g_homeId = _notification->GetHomeId();
+			printf("Driver ready with HomeID: 0x%.8x\n", g_homeId);
+			bool ext_tx = Manager::Get()->HasExtendedTxStatus(g_homeId);
+
+			if (ext_tx)
+			{
+				printf("Controller has extended TxStatus.\n");
+			}
+			else
+			{
+				printf("Controller does not have extended TxStatus.\n");
+			}
+
 			break;
 		}
 

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -2565,8 +2565,29 @@ void Driver::HandleSerialAPISetupResponse
 		uint8* _data
 )
 {
+	// See INS13954 for description of FUNC_ID_SERIAL_API_SETUP with command 
+	// SERIAL_API_SETUP_CMD_TX_STATUS_REPORT
+	// Note: SERIAL_API_SETUP can do more things than enable this report...
+
 	Log::Write( LogLevel_Info, "Received reply to FUNC_ID_SERIAL_API_SETUP");
 
+	switch (_data[0])
+	{
+	case 1:
+		Log::Write(LogLevel_Info, "Successfully enabled extended txStatusReport.");
+		m_hasExtendedTxStatus = true;
+		break;
+
+	case 0:
+		Log::Write(LogLevel_Info, "Failed to enable extended txStatusReport. Controller might not support it.");
+		m_hasExtendedTxStatus = false;
+		break;
+
+	default:
+		Log::Write(LogLevel_Info, "FUNC_ID_SERIAL_API_SETUP returned unknown status: %u", _data[0]);
+		m_hasExtendedTxStatus = false;
+		break;
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -217,6 +217,7 @@ namespace OpenZWave
 		bool IsBridgeController()const{ return (m_libraryType == 7); }
 		bool IsInclusionController()const{ return ((m_controllerCaps & ControllerCaps_SIS) != 0); }
 
+		bool HasExtendedTxStatus()const{ return m_hasExtendedTxStatus; }
 
 		uint32 GetHomeId()const{ return m_homeId; }
 		uint8 GetControllerNodeId()const{ return m_Controller_nodeId; }
@@ -285,6 +286,7 @@ namespace OpenZWave
 		uint8					m_initVersion;								// Version of the Serial API used by the controller.
 		uint8					m_initCaps;									// Set of flags indicating the serial API capabilities (See IsSlave, HasTimerSupport, IsPrimaryController and IsStaticUpdateController above).
 		uint8					m_controllerCaps;							// Set of flags indicating the controller's capabilities (See IsInclusionController above).
+		bool					m_hasExtendedTxStatus;						// True if the controller accepted SERIAL_API_SETUP_CMD_TX_STATUS_REPORT
 		uint8					m_Controller_nodeId;						// Z-Wave Controller's own node ID.
 		Node*					m_nodes[256];								// Array containing all the node objects.
 		Mutex*					m_nodeMutex;								// Serializes access to node data

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -554,6 +554,24 @@ bool Manager::IsBridgeController
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::HasExtendedTxStatus>
+//
+//-----------------------------------------------------------------------------
+bool Manager::HasExtendedTxStatus
+(
+		uint32 const _homeId
+)
+{
+	if( Driver* driver = GetDriver( _homeId ) )
+	{
+		return driver->HasExtendedTxStatus();
+	}
+
+	Log::Write( LogLevel_Info, "mgr,     HasExtendedTxStatus() failed - _homeId %d not found", _homeId );
+	return false;
+}
+
+//-----------------------------------------------------------------------------
 // <Manager::GetLibraryVersion>
 //
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -298,6 +298,15 @@ namespace OpenZWave
 		bool IsBridgeController( uint32 const _homeId );
 
 		/**
+		 * \brief Query if the controller support "extended status information"
+		 * On IMA enabled targets build on SDK >= 6.60.00
+		 * ZW_SendData can return information about TX time, route tries and more.
+		 * \param _homeId The Home ID of the Z-Wave controller.
+		 * \return true if the controller accepted to turn on extended status.
+		 */
+		bool HasExtendedTxStatus( uint32 const _homeId );
+
+		/**
 		 * \brief Get the version of the Z-Wave API library used by a controller.
 		 * \param _homeId The Home ID of the Z-Wave controller.
 		 * \return a string containing the library version. For example, "Z-Wave 2.48".


### PR DESCRIPTION
After testing and logging the controller response, to the "enable extended status" serial command, this method should return true if this status is supported.

MinOZW updated to print this status.

Tested on a UZB1 with recent firmware, not tested on a controller which lacks the capability, because I do not have one...