### PR TITLE
Fix GCC 8 build + return in GetXMLTagName

### DIFF
--- a/cpp/src/CompatOptionManager.cpp
+++ b/cpp/src/CompatOptionManager.cpp
@@ -432,8 +432,6 @@ string CompatOptionManager::GetXMLTagName
 			return "Compatibility";
 		case CompatOptionType_Discovery:
 			return "State";
-		default:
-			return "Unknown";
 	}
 }
 } /* namespace OpenZWave */

--- a/cpp/src/CompatOptionManager.cpp
+++ b/cpp/src/CompatOptionManager.cpp
@@ -111,7 +111,7 @@ void CompatOptionManager::EnableFlag
 		uint32_t defaultval
 )
 {
-	for (int i = 0; i < m_availableFlagsCount; i++) {
+	for (uint32_t i = 0; i < m_availableFlagsCount; i++) {
 		if (m_availableFlags[i].flag == flag) {
 			m_enabledCompatFlags[m_availableFlags[i].name] = flag;
 			m_CompatVals[flag].type = m_availableFlags[i].type;
@@ -416,7 +416,7 @@ string CompatOptionManager::GetFlagName
 		CompatOptionFlags flag
 ) const
 {
-	for (int i = 0; i < m_availableFlagsCount; i++) {
+	for (uint32_t i = 0; i < m_availableFlagsCount; i++) {
 		if (m_availableFlags[i].flag == flag) {
 			return m_availableFlags[i].name;
 		}
@@ -432,6 +432,8 @@ string CompatOptionManager::GetXMLTagName
 			return "Compatibility";
 		case CompatOptionType_Discovery:
 			return "State";
+		default:
+			return "Unknown";
 	}
 }
 } /* namespace OpenZWave */


### PR DESCRIPTION
Build on Mac with gmake -j 4 CXX=c++-8 LD=C++-8 revealed these issues.