### PR TITLE
Replace localtime with localtime_r for thread safety

### DIFF
--- a/cpp/src/Defs.h
+++ b/cpp/src/Defs.h
@@ -205,6 +205,14 @@ namespace OpenZWave
 #define sscanf sscanf_s
 #define strncpy strncpy_s
 #define strncat strncat_s
+/* Windows doesn't have localtime_r - use the "secure" version instead */
+struct tm *localtime_r(time_t *_clock, struct tm *_result)
+{
+    _localtime64_s(_result, _clock);
+    return _result;
+}
+
+
 
 #endif
 

--- a/cpp/src/command_classes/TimeParameters.cpp
+++ b/cpp/src/command_classes/TimeParameters.cpp
@@ -178,21 +178,11 @@ bool TimeParameters::SetValue
 		time_t rawtime;
 		struct tm *timeinfo;
 		time(&rawtime);
-#ifdef WINAPI_FAMILY_APP
-#pragma warning(push)
-#pragma warning(disable:4996)
-		// localtime is threadsafe on Windows
-		// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64?view=vs-2019
-		// localtime uses a single tm structure per thread for the conversion
-		timeinfo = localtime(&rawtime);
-#pragma warning(pop)
-#else
 		// use threadsafe verion of localtime. Reported by nihilus, 2019-04
 		// https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html#Broken_002ddown-Time
 		struct tm xtm;
 		memset(&xtm, 0, sizeof(xtm));
 		timeinfo = localtime_r( &rawtime, &xtm);
-#endif
 
 		Msg* msg = new Msg( "TimeParametersCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId() );
 		msg->SetInstance( this, instance );

--- a/cpp/src/platform/unix/LogImpl.cpp
+++ b/cpp/src/platform/unix/LogImpl.cpp
@@ -263,8 +263,11 @@ string LogImpl::GetTimeStampString
 	// Get a timestamp
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-	struct tm *tm;
-	tm = localtime( &tv.tv_sec );
+	// use threadsafe verion of localtime. Reported by nihilus, 2019-04
+	// https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html#Broken_002ddown-Time
+	struct tm *tm, xtm;
+	memset(&xtm, 0, sizeof(xtm));
+	tm = localtime_r( &tv.tv_sec, &xtm);
 
 	// create a time stamp string for the log message
 	char buf[100];

--- a/cpp/src/platform/unix/TimeStampImpl.cpp
+++ b/cpp/src/platform/unix/TimeStampImpl.cpp
@@ -112,8 +112,11 @@ string TimeStampImpl::GetAsString
 )
 {
 	char str[100];
-	struct tm *tm;
-	tm = localtime( &m_stamp.tv_sec );
+    // use threadsafe verion of localtime. Reported by nihilus, 2019-04
+	// https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html#Broken_002ddown-Time
+	struct tm *tm, xtm;
+	memset(&xtm, 0, sizeof(xtm));
+	tm = localtime_r( &m_stamp.tv_sec, &xtm);
 
 	snprintf( str, sizeof(str), "%04d-%02d-%02d %02d:%02d:%02d:%03d ", 
 		  tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,


### PR DESCRIPTION

#1762 
Tested on Mac llvm + gcc, not tested on Windows.