### PR TITLE
open-zwave: fix build break due to strncat length warning with Werror

### DIFF
--- a/cpp/src/command_classes/DoorLockLogging.cpp
+++ b/cpp/src/command_classes/DoorLockLogging.cpp
@@ -304,7 +304,7 @@ bool DoorLockLogging::HandleMsg
 			}
 			uint8 userid = (_data[10]);
 			uint8 usercodelength = (_data[11]);
-			char usercode[254], tmpusercode[254];
+			char usercode[255], tmpusercode[254];
 			snprintf(usercode, sizeof(usercode), "UserCode: ");
 			if (usercodelength > 0)
 				for (int i = 0; i < usercodelength; i++ )


### PR DESCRIPTION
Alpine build on ppc64le fails with error:
```
Building DoorLockLogging.o
/home/mksully/trees/open-zwave/cpp/src/command_classes/DoorLockLogging.cpp: In member function 'virtual bool OpenZWave::DoorLockLogging::HandleMsg(const uint8*, uint32, uint32)':
/home/mksully/trees/open-zwave/cpp/src/command_classes/DoorLockLogging.cpp:313:48: error: 'char* strncat(char*, const char*, size_t)' output may be truncated copying between 0 and 253 bytes from a string of length 253 [-Werror=stringop-truncation]
                                         strncat(usercode, tmpusercode, sizeof(usercode) - strlen(usercode) - 1 );
                                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
With gcc 8.3.0 and compiler option -Werror on ppc64le this code will fail unless extra length in usercode array allows for max length plus the null termination character. This patch does this.