### PR TITLE
Set thread names on NetBSD

### DIFF
--- a/cpp/src/platform/unix/ThreadImpl.cpp
+++ b/cpp/src/platform/unix/ThreadImpl.cpp
@@ -89,8 +89,12 @@ bool ThreadImpl::Start
 	pthread_create ( &m_hThread, &ta, ThreadImpl::ThreadProc, this );
 	string threadname("OZW-");
 	threadname.append(m_name);
-#if !defined(__APPLE_CC__) && !defined(__FreeBSD__)
+#if !defined(__APPLE_CC__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
 	pthread_setname_np( m_hThread, threadname.c_str() );
+#elif defined(__NetBSD__)
+	if ( threadname.length() > PTHREAD_MAX_NAMELEN_NP )
+	  threadname.resize( PTHREAD_MAX_NAMELEN_NP );
+	pthread_setname_np( m_hThread, "%s", (void *)threadname.c_str() );
 #endif
 	//fprintf(stderr, "thread %s starting %08x\n", m_name.c_str(), m_hThread);
 	//fflush(stderr);


### PR DESCRIPTION
The parameter list for pthread_setname_np() is slightly different in the NetBSD implementation.