### PR TITLE
Add config for Schlage BE468ZP Connect Smart Deadbolt

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1402,6 +1402,7 @@
     <Product config="schlage/BE469.xml" id="5044" name="BE469 Touchscreen Deadbolt" type="6341"/>
     <Product config="schlage/BE468.xml" id="5044" name="BE468 Touchscreen Deadbolt" type="6349"/>
     <Product config="schlage/BE469ZP.xml" id="0469" name="BE469ZP Connect Smart Deadbolt" type="0001"/>
+    <Product config="schlage/BE468ZP.xml" id="0468" name="BE468ZP Connect Smart Deadbolt" type="0001"/>
   </Manufacturer>
   <Manufacturer id="0097" name="Schlage Link (Wintop)">
     <Product config="schlagelink/itemp.xml" id="4501" name="iTemp Dual Sensor" type="1182"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="21" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="23" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="23" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="21" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/schlage/BE468ZP.xml
+++ b/config/schlage/BE468ZP.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
+	<CommandClass id="112">
+		<Value type="list" index="3" genre="config" label="Beeper" units="" min="1" max="255" value="255" size="1">
+			<Help>
+				Enable or disable the keypad beeper.
+			</Help>
+			<Item label="Enable" value="255" />
+			<Item label="Disable" value="0" />
+		</Value>
+		<Value type="list" index="4" genre="config" label="Vacation Mode" units="" min="1" max="255" value="0" size="1">
+			<Help>
+				Enable or disable vacation mode.
+				Disables all user codes, preventing all codes from unlocking the deadbolt.
+				Enable for extra security while you are away for an extended period of time.
+			</Help>
+			<Item label="Enable" value="255" />
+			<Item label="Disable" value="0" />
+		</Value>
+		<Value type="list" index="5" genre="config" label="Lock and Leave Mode" units="" min="1" max="255" value="255" size="1">
+			<Help>
+				Enable or disable Lock and Leave Mode. 
+				When enabled: Press the Schlage button on the keypad to lock the deadbolt (Default setting).
+				When disabled: Press the Schlage button on the keypad and then enter a user code to lock the deadbolt.
+			</Help>
+			<Item label="Enable" value="255" />
+			<Item label="Disable" value="0" />
+		</Value>
+		<Value type="int" index="12" genre="config" label="Electronic transition count" read_only="true" size="4">
+			<Help>
+				Indicates the number of transitions from locked to unlocked or unlocked to locked state via electronic activation.
+			</Help>
+		</Value>
+		<Value type="int" index="13" genre="config" label="Mechanical transition count" read_only="true" size="4">
+			<Help>
+				Indicates the number of transitions from locked to unlocked or unlocked to locked state via mechanical activation.
+			</Help>
+		</Value>
+		<Value type="int" index="14" genre="config" label="Electronic failed count" read_only="true" size="4">
+			<Help>
+				Indicates the number of failed electronic activation attempts for this lock.
+			</Help>
+		</Value>
+		<Value type="list" index="15" genre="config" label="Auto Lock" units="" min="0" max="255" value="0" size="1">
+			<Help>
+				When enabled, the lock will automatically relock 30 seconds after unlocking. (Disabled by default.)
+			</Help>
+			<Item label="Enable" value="255" />
+			<Item label="Disable" value="0" />
+		</Value>
+		<Value type="byte" index="16" genre="config" label="User code legnth " units="" min="4" max="8" value="4" size="1">
+			<Help>
+				Choose user code length between 4 and 8 digits.
+				IMPORTANT: All user codes must be the same length.
+			</Help>
+		</Value>
+		<Value type="int" index="17" genre="config" label="Electrical High Preload Transition Count" read_only="true" size="4">
+			<Help>
+				Indicates the number of transitions from locked to unlocked or unlocked to locked state via electronic activation that indicated a high preload on the deadbolt.
+				This is a subset of Electronic transition count.
+				High preload occurs when the bolt is obstructed and the motor needs to use more power to throw the bolt.
+				Adjust door and strike plate to ensure the bolt can move freely. This will save battery power. 
+			</Help>
+		</Value>
+		<Value type="byte" index="18" genre="config" label="Bootloader Version" read_only="true" size="1">
+			<Help>The version of the bootloader in the lock.</Help>
+		</Value>
+	</CommandClass>
+	
+	<CommandClass id="133">
+		<Associations num_groups="1">
+			<Group index="1" max_associations="2" label="LifeLine" />
+		</Associations>
+	</CommandClass>
+
+	<CommandClass id="113">
+		<!-- These Door Locks don't send a DoorLockReport when the
+		Lock Status is Changed, but instead send a Alarm Message -
+		So we trigger a Refresh of the DoorLock Command Class when
+		we recieve a Alarm Message Instead -->
+		<TriggerRefreshValue Genre="user" Index="0" Instance="1">
+			<RefreshClassValue CommandClass="98" RequestFlags="0" Index="1" Instance="1" />
+		</TriggerRefreshValue>
+	</CommandClass>
+</Product>

--- a/distfiles.mk
+++ b/distfiles.mk
@@ -778,6 +778,7 @@ DISTFILES =	.gitignore \
 	config/remotec/zxt-310.xml \
 	config/remotec/zxt-600.xml \
 	config/schlage/BE468.xml \
+	config/schlage/BE468ZP.xml \
 	config/schlage/BE469.xml \
 	config/schlage/BE469ZP.xml \
 	config/schlage/fe599.xml \


### PR DESCRIPTION
Add support for the Schlage BE468ZP, which is now available on the market, and similar to the BE469ZP, but without the built-in alarm.  (It also has a white keypad instead of blue.)
https://products.z-wavealliance.org/products/3028