### PR TITLE
Add support for Zooz ZSE29

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1814,6 +1814,7 @@
     <Product config="zooz/zen21.xml" id="1e1c" name="ZEN21 Switch V2.0" type="b111"/>
     <Product config="zooz/zse19.xml" id="0003" name="ZSE19 S2 Multisiren" type="000c"/>
     <Product config="zooz/zen20v2.xml" id="a004" name="ZEN20 V2.0 Power Strip" type="a000"/>
+    <Product config="zooz/zse29.xml" id="0005" name="ZSE29 Outdoor Motion Sensor" type="0001"/>
   </Manufacturer>
   <Manufacturer id="015d" name="Zooz (Willis Electric)">
     <Product config="zooz/zen20.xml" id="f51c" name="ZEN20 Power Strip" type="0651"/>

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -4,7 +4,7 @@
 
     <!-- Association Groups -->
     <CommandClass id="133">
-        <Associations num_groups="4">
+        <Associations num_groups="2">
             <Group index="1" max_associations="1" label="Lifeline"/>
             <Group index="2" max_associations="4" label="PIR Control"/>
         </Associations>

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
+    <!-- Zooz ZSE29 Outdoor Motion Sensor -->
+
+    <!-- Association Groups -->
+    <CommandClass id="133">
+        <Associations num_groups="4">
+            <Group index="1" max_associations="1" label="Lifeline"/>
+            <Group index="2" max_associations="4" label="PIR Control"/>
+        </Associations>
+    </CommandClass>
+</Product>


### PR DESCRIPTION
Adds support for the ZSE29 Outdoor Motion Sensor from Zooz. The device does not
use Z-Wave for configuration. There are manual knobs on the device to configure
the device.

Z-Wave Product Catalog page for reference:
https://products.z-wavealliance.org/products/3081

Tested this with an actual device using OpenZWave through Home Assistant.

Resolves #1809.