### PR TITLE
Fixes crash when node = NULL

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1184,7 +1184,7 @@ bool Driver::WriteMsg(string const &msg)
 
 	Log::Write(LogLevel_Detail, "");
 
-	if (m_nonceReportSent > 0)
+	if (m_nonceReportSent > 0 && node != NULL)
 	{
 		/* send a new NONCE report */
 		SendNonceKey(m_nonceReportSent, node->GenerateNonceKey());


### PR DESCRIPTION
Experienced a crash here. node was NULL. This is checked everywhere in this function except on this location