### PR TITLE
localtime_r first argument should be const

### DIFF
--- a/cpp/src/Utils.cpp
+++ b/cpp/src/Utils.cpp
@@ -210,7 +210,7 @@ namespace OpenZWave
 #if (defined _WINDOWS || defined WIN32 || defined _MSC_VER) && (!defined MINGW && !defined __MINGW32__ && !defined __MINGW64__)
 
 /* Windows doesn't have localtime_r - use the "secure" version instead */
-struct tm *localtime_r(time_t *_clock, struct tm *_result)
+struct tm *localtime_r(const time_t *_clock, struct tm *_result)
 {
 	_localtime64_s(_result, _clock);
 	return _result;

--- a/cpp/src/Utils.h
+++ b/cpp/src/Utils.h
@@ -261,7 +261,7 @@ namespace OpenZWave
 /* keep this outside of the namespace */
 #if (defined _WINDOWS || defined WIN32 || defined _MSC_VER) && (!defined MINGW && !defined __MINGW32__ && !defined __MINGW64__)
 #include <ctime>
-struct tm *localtime_r(time_t *_clock, struct tm *_result);
+struct tm *localtime_r(const time_t *_clock, struct tm *_result);
 #endif
 
 #endif


### PR DESCRIPTION
Currently it is not declared as 'const' and this is causing compilation issues for applications that also introduces their own localtime_r implementation that is using the arguments as declared in the spec