### PR TITLE
Added missing include for shared_ptr

### DIFF
--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <memory>
 #include "Defs.h"
 #include "value_classes/ValueID.h"
 #include "value_classes/ValueList.h"


### PR DESCRIPTION
Solves the following compile issue under travis:

> /home/travis/build/open-zwave-read-only/cpp/src/Node.h:566:32: error: ‘std::shared_ptr’ has not been declared