### PR TITLE
Fix Help text localization index strtol (change base 16 to 10)

### DIFF
--- a/cpp/src/Localization.cpp
+++ b/cpp/src/Localization.cpp
@@ -390,13 +390,13 @@ namespace OpenZWave
 				return;
 			}
 			char* pStopChar;
-			uint16 indexId = (uint16) strtol(str, &pStopChar, 16);
+			uint16 indexId = (uint16) strtol(str, &pStopChar, 10);
 
 			uint32 pos = -1;
 			str = valueElement->Attribute("pos");
 			if (str)
 			{
-				pos = (uint32) strtol(str, &pStopChar, 16);
+				pos = (uint32) strtol(str, &pStopChar, 10);
 			}
 
 			TiXmlElement const* valueIDElement = valueElement->FirstChildElement();


### PR DESCRIPTION
Solves Help text of "Seismic Intensity" is wrong: "Tank Capacity Sensor Value".

https://github.com/OpenZWave/open-zwave/issues/1887

Corrects help text of all IDs > decimal 9.

Requires node refresh or delete ozwcache to (re)write cached Help text.