### PR TITLE
Add Australia/New Zealand to Aeotec ZWA005

### DIFF
--- a/config/aeotec/zwa005.xml
+++ b/config/aeotec/zwa005.xml
@@ -1,6 +1,6 @@
 <!--
 ZWA005 TriSensor
---><Product Revision="5" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0371:0005:0002</MetaDataItem>
     <MetaDataItem name="ProductPic">images/aeotec/zwa005.png</MetaDataItem>
@@ -28,6 +28,9 @@ If it is the S2 encryption network, please enter the first 5 digits of DSK.
     <MetaDataItem id="0005" name="ZWProductPage" type="0102">https://products.z-wavealliance.org/products/2919/</MetaDataItem>
     <MetaDataItem id="0005" name="Identifier" type="0102">ZWA005-A</MetaDataItem>
     <MetaDataItem id="0005" name="FrequencyName" type="0102">U.S. / Canada / Mexico</MetaDataItem>
+    <MetaDataItem id="0005" name="ZWProductPage" type="0202">https://products.z-wavealliance.org/products/2920/</MetaDataItem>
+    <MetaDataItem id="0005" name="Identifier" type="0202">ZWA005-B</MetaDataItem>
+    <MetaDataItem id="0005" name="FrequencyName" type="0202">Australia / New Zealand</MetaDataItem>
   </MetaData>
   <!-- Configuration Parameters -->
   <CommandClass id="32">

--- a/config/aeotec/zwa005.xml
+++ b/config/aeotec/zwa005.xml
@@ -24,6 +24,7 @@ If it is the S2 encryption network, please enter the first 5 digits of DSK.
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2898/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2919/xml</Entry>
+      <Entry author="David Goodlad - david@goodlad.net" date="28 Jul 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2920/xml</Entry>
     </ChangeLog>
     <MetaDataItem id="0005" name="ZWProductPage" type="0102">https://products.z-wavealliance.org/products/2919/</MetaDataItem>
     <MetaDataItem id="0005" name="Identifier" type="0102">ZWA005-A</MetaDataItem>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -205,6 +205,7 @@
     <Product config="aeotec/zwa004.xml" id="0004" name="ZWA004 NanoMote One" type="0102"/>
     <Product config="aeotec/zwa005.xml" id="0005" name="ZWA005 TriSensor" type="0002"/>
     <Product config="aeotec/zwa005.xml" id="0005" name="ZWA005 TriSensor" type="0102"/>
+    <Product config="aeotec/zwa005.xml" id="0005" name="ZWA005 TriSensor" type="0202"/>
     <Product config="aeotec/zw162.xml" id="00a2" name="ZW162 Doorbell 6" type="0003"/>
     <Product config="aeotec/zw162.xml" id="00a2" name="ZW162 Doorbell 6" type="0103"/>
     <Product config="aeotec/zw162.xml" id="00a2" name="ZW162 Doorbell 6" type="0203"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="42" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="43" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>


### PR DESCRIPTION
The Aeotec ZWA005 is available here in :australia:, this change adds the appropriate entries to its configuration.