### PR TITLE
Adds Manager->GetNodeClassIds and Node->GetCommandClassIds

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -1315,7 +1315,7 @@ bool Manager::IsNodeInfoReceived(uint32 const _homeId, uint8 const _nodeId)
 }
 
 //-----------------------------------------------------------------------------
-// <Manager::GetNodeClassAvailable>
+// <Manager::GetNodeClassInformation>
 // Helper method to return whether a particular class is available in a node
 //-----------------------------------------------------------------------------
 bool Manager::GetNodeClassInformation(uint32 const _homeId, uint8 const _nodeId, uint8 const _commandClassId, string *_className, uint8 *_classVersion)

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -1315,6 +1315,37 @@ bool Manager::IsNodeInfoReceived(uint32 const _homeId, uint8 const _nodeId)
 }
 
 //-----------------------------------------------------------------------------
+// <Manager::GetNodeClassIds>
+// Helper method to collect all of the command class id's a node supports
+//-----------------------------------------------------------------------------
+bool Manager::GetNodeClassIds(uint32 const _homeId, uint8 const _nodeId, std::vector<uint8> *classIds)
+{
+	bool res = false;
+
+	if (classIds)
+	{
+		if (Driver* driver = GetDriver(_homeId))
+		{
+			Node *node;
+
+			// Need to lock and unlock nodes to check this information
+			Internal::LockGuard LG(driver->m_nodeMutex);
+			if ((node = driver->GetNode(_nodeId)) != NULL)
+			{
+				if (node->NodeInfoReceived())
+				{
+					classIds->clear();
+					node->GetCommandClassIds(classIds);
+					res = true;
+				}
+			}
+		}
+	}
+	return res;
+}
+
+
+//-----------------------------------------------------------------------------
 // <Manager::GetNodeClassInformation>
 // Helper method to return whether a particular class is available in a node
 //-----------------------------------------------------------------------------

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -822,6 +822,16 @@ namespace OpenZWave
 			bool IsNodeInfoReceived(uint32 const _homeId, uint8 const _nodeId);
 
 			/**
+			 * \brief Get all of the command class id's a node supports
+			 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
+			 * \param _nodeId The ID of the node to query.
+			 * \param classIds Pointer to a vector of uint8 that will be filled with
+			 * command class id's. The vector will be cleared before the items are added.
+			 * \return True if the node has been loaded else False
+			 */
+            bool GetNodeClassIds(uint32 const _homeId, uint8 const _nodeId, std::vector<uint8> *classIds);
+
+			/**
 			 * \brief Get whether the node has the defined class available or not
 			 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
 			 * \param _nodeId The ID of the node to query.
@@ -1440,7 +1450,7 @@ namespace OpenZWave
 			bool GetBitMask(ValueID const& _id, int32* o_mask);
 
 			/**
-			 * \brief Gets the size of a BitMask ValueID 
+			 * \brief Gets the size of a BitMask ValueID
 			 * Gets the size of a BitMask ValueID - Either 1, 2 or 4
 			 * \param _id The unique identifier of the integer value.
 			 * \param o_size The Size of the BitSet

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -440,7 +440,7 @@ void Node::AdvanceQueries()
 						}
 						else
 						{
-							// set the Version to 1 
+							// set the Version to 1
 							cc->SetVersion(1);
 						}
 					}
@@ -1086,7 +1086,7 @@ void Node::ReadXML(TiXmlElement const* _node)
 
 //-----------------------------------------------------------------------------
 // <Node::ReadDeviceProtocolXML>
-// Read the device's protocol configuration from a device config file (Not 
+// Read the device's protocol configuration from a device config file (Not
 // cache)
 //-----------------------------------------------------------------------------
 void Node::ReadDeviceProtocolXML(TiXmlElement const* _ccsElement)
@@ -2057,6 +2057,22 @@ Internal::CC::CommandClass* Node::GetCommandClass(uint8 const _commandClassId) c
 
 	// Not found
 	return NULL;
+}
+
+//-----------------------------------------------------------------------------
+// <Node::GetCommandClassIds>
+// Get the the supported command class id's
+//-----------------------------------------------------------------------------
+void Node::GetCommandClassIds(std::vector<uint8> *classIds)
+{
+	map<uint8, Internal::CC::CommandClass*>::const_iterator it = m_commandClassMap.begin();
+
+	while (it != m_commandClassMap.end())
+	{
+		uint8 command_class_id = it->first;
+		classIds->push_back(command_class_id);
+		it++;
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -505,6 +505,13 @@ namespace OpenZWave
 			 * \see CommandClass, m_commandClassMap
 			 */
 			Internal::CC::CommandClass* GetCommandClass(uint8 const _commandClassId) const;
+
+			/**
+			 * This function fills a supplied vector of uint8 with the command class id's the node supports.
+			 * \param classIds Pointer to a vector of uint8 to be filled with the id's.
+			 */
+			void GetCommandClassIds(std::vector<uint8> *classIds);
+
 			void ApplicationCommandHandler(uint8 const* _data, bool encrypted);
 
 			/**


### PR DESCRIPTION
More efficient mechanism for obtaining supported command class ids.

The way it was done before.

Here is the setup.. you have 100 nodes on a network. the application
wants to be able to provide to controls depending on what command
classes they support.

so of the 50-60 or so application command classes in the ZWave protocol
(I know that OZW does not support all of them) in order to be able to
know what command classes a node supports you would have to call
OpenZWave::Manager->GetNodeClassInformation over and over again for
each of the command classes on each of the nodes.

so some simple math here 60 * 100 = 6000 function calls to determine
this really simple tidbit of information..

This new method takes the home id the node id and a pointer to an empty
vector<uint8>. If the method is successful it will return True and fill
the vector with the command class ids that the node supports. This
reduces the number of calls needed down to 100, the number of nodes.
And also no need to create and fill variables with information that is not 
going to get used.

I set up the method so that it will empty the vector before filling it.
So the same vector can get used between iteration loops over the nodes.