### PR TITLE
Added GoControl LB30Z-1 BR30 bulb

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="46" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="47" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1069,6 +1069,7 @@
     <Product config="linear/ngd00z.xml" id="3530" name="GD00Z-4 Garage Door Opener Remote Controller" type="4744"/>
     <Product config="linear/gd00z-7.xml" id="3531" name="GD00Z-7 Garage Door Opener Remote Controller" type="4744"/>
     <Product config="linear/LB60Z-1.xml" id="3038" name="LB60Z-1 Dimmable LED Light Bulb" type="4754"/>
+    <Product config="linear/LB60Z-1.xml" id="4252" name="LB30Z-1 Dimmable LED Light Bulb" type="4754"/>
     <Product id="3133" name="FS20Z Isolated Contact Fixture Module" type="5246"/>
     <Product id="3030" name="PS15Z-2 Plug-in Appliance Module" type="5250"/>
     <Product id="3530" name="WO15Z-1 Single Wall Outlet" type="5252"/>


### PR DESCRIPTION
The GoControl LB30Z is functionally the same as the LB60Z, just in a different form factor. Adding the specific device (which I own and validated) for support.