### PR TITLE
Update Idlock 150 config file for 1.6 firmware

### DIFF
--- a/config/idlock/idlock150.xml
+++ b/config/idlock/idlock150.xml
@@ -131,7 +131,7 @@ FACTORY RESET DOOR LOCK FIRMWARE:
       <Item label="Always valid" value="7"/>
       <Item label="12 Hours used" value="8"/>
       <Item label="24 Hours used" value="9"/>
-      <Item label="Disabled (PIN and Service PIN)" value="" />
+      <Item label="Disabled (PIN and Service PIN)" value="254" />
     </Value>
     <Value genre="config" index="7" label="Door Lock Model Type" max="150" min="101" read_only="true" type="byte" units="" value="150">
       <Help>
@@ -170,7 +170,6 @@ FACTORY RESET DOOR LOCK FIRMWARE:
     </Value>
   </CommandClass>
   <!-- Association Groups -->
-  <!--COMMAND_CLASS_ASSOCIATION_V2-->
   <CommandClass id="133">
     <Instance index="1"/>
     <Associations num_groups="1">

--- a/config/idlock/idlock150.xml
+++ b/config/idlock/idlock150.xml
@@ -1,35 +1,35 @@
-<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
-    <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0373:0001:0003</MetaDataItem>
-    <MetaDataItem name="ProductPic">images/idlock/idlock150.png</MetaDataItem>
-    <MetaDataItem id="0001" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2780/</MetaDataItem>
-    <MetaDataItem name="ProductManual">https://Products.Z-WaveAlliance.org/ProductManual/File?folder=&amp;filename=Manuals/2780/IDLock150_ZWave_UserManual_v2.1.pdf</MetaDataItem>
-    <MetaDataItem name="ExclusionDescription">Exclusion – (Puts your device in exclusion mode)
-
-• Push and hold key button until all LEDs on touch panel activates (with ID Lock in an unlocked state).
-• Release button.
-• Enter Master PIN followed by * on touch panel.
-• Press digit "2" for settings followed by * on touch panel.
-• Press digit “5” on touch panel.
-
-Exclusion mode starts immediately. LED indicator below logo signals this by flashing blue.</MetaDataItem>
-    <MetaDataItem name="InclusionDescription">Inclusion – (Puts your device in inclusion mode)
-
-• Push and hold key button until all LEDs on touch panel activates (with ID Lock in an unlocked state).
-• Release button.
-• Enter Master PIN followed by * on touch panel.
-• Press digit "2" for settings followed by * on touch panel.
-• Press digit “5” on touch panel.
-
-Inclusion mode starts immediately. LED indicator below logo signals this by flashing blue.</MetaDataItem>
+    <MetaDataItem name="Name">ID Lock 150 Z-Wave module</MetaDataItem>
     <MetaDataItem name="Description">A module enabling your ID Lock digital door lock to a Z-Wave Plus enabled digital door Lock.
 
 The module is compatible with ID Lock 101 and ID Lock 150.
 
 It enables your ID Lock to operate in a Z-Wave network with numerous access control funtions and notifications.</MetaDataItem>
-    <MetaDataItem id="0001" name="FrequencyName" type="0003">CEPT (Europe)</MetaDataItem>
+    <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0373:0001:0003</MetaDataItem>
+    <MetaDataItem name="ProductPage">https://idlock.no/z-wave/</MetaDataItem>
+    <MetaDataItem name="ProductSupport">https://idlock.no/kundesenter/</MetaDataItem>
+    <MetaDataItem name="ProductPic">images/idlock/idlock150.png</MetaDataItem>
+    <MetaDataItem name="ProductManual">https://idlock.no/wp-content/uploads/2019/08/IDLock150_ZWave_UserManual_v3.02.pdf</MetaDataItem>
     <MetaDataItem name="WakeupDescription">Activate by touching the touch panel with finger(s), the palm of the hand on the outside unit or by pushing the key button on the inside unit.</MetaDataItem>
-    <MetaDataItem id="0001" name="Identifier" type="0003">ID-150</MetaDataItem>
+    <MetaDataItem name="InclusionDescription">Inclusion – (Puts your device in inclusion mode)
+
+•	 Push and hold key button until all LEDs on touch panel activates (with ID Lock in an unlocked state).
+•	 Release button.
+•	 Enter Master PIN followed by * on touch panel.
+•	 Press digit "2" for settings followed by * on touch panel.
+•	 Press digit “5” on touch panel.
+
+Inclusion mode starts immediately. LED indicator below logo signals this by flashing blue.</MetaDataItem>
+    <MetaDataItem name="ExclusionDescription">Exclusion – (Puts your device in exclusion mode)
+
+•	 Push and hold key button until all LEDs on touch panel activates (with ID Lock in an unlocked state).
+•	 Release button.
+•	 Enter Master PIN followed by * on touch panel.
+•	 Press digit "2" for settings followed by * on touch panel.
+•	 Press digit “5” on touch panel.
+
+Exclusion mode starts immediately. LED indicator below logo signals this by flashing blue.</MetaDataItem>
     <MetaDataItem name="ResetDescription">Device reset – (This will reset RF interface module to factory default settings)
 Warning: Please do only proceed with the following reset procedure, if primary network controller is missing or otherwise inoperable.
 
@@ -45,14 +45,16 @@ If the Z-wave module is not included in a Z-wave network the door lock will also
 
 FACTORY RESET DOOR LOCK FIRMWARE:
 
-• Push and hold inside lock/unlock button while inserting the fourth battery.
-• Receive reset sound.
-• Release button.
-• Receive confirmation sound.
-</MetaDataItem>
-    <MetaDataItem name="Name">ID Lock 150 Z-Wave module</MetaDataItem>
+•	 Push and hold inside lock/unlock button while inserting the fourth battery.
+•	 Receive reset sound.
+•	 Release button.
+•	 Receive confirmation sound.</MetaDataItem>
+    <MetaDataItem id="0001" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2780/</MetaDataItem>
+    <MetaDataItem id="0001" name="FrequencyName" type="0003">CEPT (Europe)</MetaDataItem>
+    <MetaDataItem id="0001" name="Identifier" type="0003">ID-150</MetaDataItem>
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2780/xml</Entry>
+      <Entry author="Eirik Hodne" date="25 Aug 2019" revision="3">Update as per the 1.4.9/1.6 firmware specification</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->

--- a/config/idlock/idlock150.xml
+++ b/config/idlock/idlock150.xml
@@ -65,39 +65,32 @@ FACTORY RESET DOOR LOCK FIRMWARE:
       <Help>
         Door Lock Mode
         Autolock Mode, Manual lock mode, Activate Away Mode, Deactivate Away Mode
-        Default Value : 1 ( Disable Away / Auto Lock Mode )
+        Default Value : 1 ( Auto lock, Away off )
       </Help>
-      <Item label="Disable Away, Manual Lock" value="0"/>
-      <Item label="Disable Away, Auto Lock" value="1"/>
-      <Item label="Enable Away, Manual Lock" value="2"/>
-      <Item label="Enable Away, Auto Lock" value="3"/>
+      <Item label="Manual lock, Away off" value="0"/>
+      <Item label="Auto lock, Away off" value="1"/>
+      <Item label="Manual lock, Away on" value="2"/>
+      <Item label="Auto lock, Away on" value="3"/>
     </Value>
-    <Value genre="config" index="2" label="RFID Registration Configuration" max="8" min="1" size="1" type="list" units="" value="5">
+    <Value genre="config" index="2" label="RFID Mode" max="9" min="5" size="1" type="list" units="" value="5">
       <Help>
-        RFID Registration Configuration
-        IDLocks can use up to 50 RFID cards. In order to use a RFID, RFID has to be registered by z-wave configuration command class.
-
-        RFID Configuration with Z-wave is only valid for ID Lock 101.
-
-        Configuration Parameters are as below. Default value is 0x05 (Not in progress).
-        ID Lock 150 will always report 0x05 as this feature is not supported by this door lock model.
-
-        Configuration Set in case of starting to register from gateway
+        RFID Mode
+        RFID activated
+        RFID deactivated
+        Default Value: 5 (RFID activated)
       </Help>
-      <Item label="Begin RFID Registering mode on the door lock" value="1"/>
-      <Item label="Not in progress" value="5"/>
-      <Item label="RFID Database clear" value="7"/>
-      <Item label="RFID Registering mode stop" value="8"/>
+      <Item label="RFID activated" value="5"/>
+      <Item label="RFID deactivated" value="9"/>
     </Value>
-    <Value genre="config" index="3" label="Door Hinge Position" max="3" min="0" size="1" type="list" units="" value="0">
+    <Value genre="config" index="3" label="Door Hinge Direction" max="1" min="0" size="1" type="list" units="" value="0">
       <Help>
         Door Hinge Position
-        Default Value : 0 (Right Handle)
+        Default Value : 0 (Right hinged operation)
       </Help>
-      <Item label="Right Handle" value="0"/>
-      <Item label="Left Handle" value="1"/>
+      <Item label="Right hinged operation" value="0"/>
+      <Item label="Left hinged operation" value="1"/>
     </Value>
-    <Value genre="config" index="4" label="Door Audio Volume Level" max="6" min="0" size="1" type="list" units="" value="5" write_only="true">
+    <Value genre="config" index="4" label="Door Audio Volume" max="6" min="0" size="1" type="list" units="" value="5" write_only="true">
       <Help>
         Door Audio Volume Level
         This parameter is a set only parameter. If the value is changed locally on the door lock, this value will not change.
@@ -123,7 +116,9 @@ FACTORY RESET DOOR LOCK FIRMWARE:
       <Help>
         Service PIN Mode
         A configuration get command on this parameter returns the latest set parameter value (set by Z-wave).
-        This is a set only value, if changed locally on keypad these values are not changed on Z-wave module. Value 5, 6 and 7 are for future use on door lock.
+        This is a set only value, if changed locally on keypad these values are not changed on Z-wave module. Value 5 and 6 are for future use on door lock.
+        Disabled: Disables both PIN and Service PIN menu on door lock
+
         Default Value: 0 (Deactivated)
       </Help>
       <Item label="Deactivated" value="0"/>
@@ -133,9 +128,10 @@ FACTORY RESET DOOR LOCK FIRMWARE:
       <Item label="10 times used" value="4"/>
       <Item label="Not used (for future use)" value="5"/>
       <Item label="Not used (for future use)" value="6"/>
-      <Item label="Not used (for future use)" value="7"/>
+      <Item label="Always valid" value="7"/>
       <Item label="12 Hours used" value="8"/>
       <Item label="24 Hours used" value="9"/>
+      <Item label="Disabled (PIN and Service PIN)" value="" />
     </Value>
     <Value genre="config" index="7" label="Door Lock Model Type" max="150" min="101" read_only="true" type="byte" units="" value="150">
       <Help>
@@ -143,6 +139,25 @@ FACTORY RESET DOOR LOCK FIRMWARE:
         This configuration is only accepted by configuration get command
         It is a read only parameter. Default value depends on the door lock model type.
       </Help>
+    </Value>
+    <Value genre="config" index="8" label="Updater Mode" max="3" min="0" type="list" units="" value="0">
+      <Help>
+        Updater Mode
+
+        Enables use of the Updater app.
+        Default Value: 0 (Off, no sound)
+      </Help>
+      <Item label="Off (no sound)" value="0"/>
+      <Item label="On (no sound)" value="1"/>
+      <Item label="Off" value="2"/>
+      <Item label="On" value="3"/>
+    </Value>
+    <Value genre="config" index="9" label="Master PIN Unlock Mode" max="1" min="0" read_only="true" type="list" units="" value="1">
+      <Help>
+        Master PIN Unlock Mode
+      </Help>
+      <Item label="Disabled" value="0"/>
+      <Item label="Enabled" value="1"/>
     </Value>
     <Value genre="config" index="10" label="Retrieve RFID Information" type="int" units="">
       <Help>

--- a/config/idlock/idlock150.xml
+++ b/config/idlock/idlock150.xml
@@ -57,14 +57,14 @@ FACTORY RESET DOOR LOCK FIRMWARE:
   </MetaData>
   <!-- Configuration Parameters -->
 
-	<!--COMMAND_CLASS_CONFIGURATION_V1-->
+  <!--COMMAND_CLASS_CONFIGURATION_V1-->
   <CommandClass id="112">
     <Value genre="config" index="1" label="Door Lock Mode" max="3" min="0" size="1" type="list" units="" value="1">
       <Help>
-				Door Lock Mode
-				Autolock Mode, Manual lock mode, Activate Away Mode, Deactivate Away Mode
-				Default Value : 1 ( Disable Away / Auto Lock Mode )
-			</Help>
+        Door Lock Mode
+        Autolock Mode, Manual lock mode, Activate Away Mode, Deactivate Away Mode
+        Default Value : 1 ( Disable Away / Auto Lock Mode )
+      </Help>
       <Item label="Disable Away, Manual Lock" value="0"/>
       <Item label="Disable Away, Auto Lock" value="1"/>
       <Item label="Enable Away, Manual Lock" value="2"/>
@@ -72,16 +72,16 @@ FACTORY RESET DOOR LOCK FIRMWARE:
     </Value>
     <Value genre="config" index="2" label="RFID Registration Configuration" max="8" min="1" size="1" type="list" units="" value="5">
       <Help>
-				RFID Registration Configuration
-				IDLocks can use up to 50 RFID cards. In order to use a RFID, RFID has to be registered by z-wave configuration command class.
+        RFID Registration Configuration
+        IDLocks can use up to 50 RFID cards. In order to use a RFID, RFID has to be registered by z-wave configuration command class.
 
-				RFID Configuration with Z-wave is only valid for ID Lock 101.
+        RFID Configuration with Z-wave is only valid for ID Lock 101.
 
-				Configuration Parameters are as below. Default value is 0x05 (Not in progress).
-				ID Lock 150 will always report 0x05 as this feature is not supported by this door lock model.
+        Configuration Parameters are as below. Default value is 0x05 (Not in progress).
+        ID Lock 150 will always report 0x05 as this feature is not supported by this door lock model.
 
-				Configuration Set in case of starting to register from gateway
-			</Help>
+        Configuration Set in case of starting to register from gateway
+      </Help>
       <Item label="Begin RFID Registering mode on the door lock" value="1"/>
       <Item label="Not in progress" value="5"/>
       <Item label="RFID Database clear" value="7"/>
@@ -89,18 +89,18 @@ FACTORY RESET DOOR LOCK FIRMWARE:
     </Value>
     <Value genre="config" index="3" label="Door Hinge Position" max="3" min="0" size="1" type="list" units="" value="0">
       <Help>
-				Door Hinge Position
-				Default Value : 0 (Right Handle)
-			</Help>
+        Door Hinge Position
+        Default Value : 0 (Right Handle)
+      </Help>
       <Item label="Right Handle" value="0"/>
       <Item label="Left Handle" value="1"/>
     </Value>
     <Value genre="config" index="4" label="Door Audio Volume Level" max="6" min="0" size="1" type="list" units="" value="5" write_only="true">
       <Help>
-				Door Audio Volume Level
-				This parameter is a set only parameter. If the value is changed locally on the door lock, this value will not change.
-				Default Value : 5
-			</Help>
+        Door Audio Volume Level
+        This parameter is a set only parameter. If the value is changed locally on the door lock, this value will not change.
+        Default Value : 5
+      </Help>
       <Item label="No Sound" value="0"/>
       <Item label="Level 1" value="1"/>
       <Item label="Level 2" value="2"/>
@@ -111,19 +111,19 @@ FACTORY RESET DOOR LOCK FIRMWARE:
     </Value>
     <Value genre="config" index="5" label="Door ReLock Mode" max="1" min="0" size="1" type="list" units="" value="1">
       <Help>
-				Door ReLock Mode
-				Default Value: 1 (Enabled)
-			</Help>
+        Door ReLock Mode
+        Default Value: 1 (Enabled)
+      </Help>
       <Item label="Disabled" value="0"/>
       <Item label="Enabled" value="1"/>
     </Value>
     <Value genre="config" index="6" label="Service PIN Mode" max="9" min="0" size="1" type="list" units="" value="0" write_only="true">
       <Help>
-				Service PIN Mode
-				A configuration get command on this parameter returns the latest set parameter value (set by Z-wave).
-				This is a set only value, if changed locally on keypad these values are not changed on Z-wave module. Value 5, 6 and 7 are for future use on door lock.
-				Default Value: 0 (Deactivated)
-			</Help>
+        Service PIN Mode
+        A configuration get command on this parameter returns the latest set parameter value (set by Z-wave).
+        This is a set only value, if changed locally on keypad these values are not changed on Z-wave module. Value 5, 6 and 7 are for future use on door lock.
+        Default Value: 0 (Deactivated)
+      </Help>
       <Item label="Deactivated" value="0"/>
       <Item label="1 times used" value="1"/>
       <Item label="2 times used" value="2"/>
@@ -137,23 +137,23 @@ FACTORY RESET DOOR LOCK FIRMWARE:
     </Value>
     <Value genre="config" index="7" label="Door Lock Model Type" max="150" min="101" read_only="true" type="byte" units="" value="150">
       <Help>
-				Door Lock Model Type
-				This configuration is only accepted by configuration get command
-				It is a read only parameter. Default value depends on the door lock model type.
-			</Help>
+        Door Lock Model Type
+        This configuration is only accepted by configuration get command
+        It is a read only parameter. Default value depends on the door lock model type.
+      </Help>
     </Value>
     <Value genre="config" index="10" label="Retrieve RFID Information" type="int" units="">
       <Help>
-				Configuration Report for retriving the RFID information
-				Byte 1: Para1 (msb)
-				Byte 2: Para2
-				Byte 3: Para3
-				Byte 4: Para4 (lsb)
-			</Help>
+        Configuration Report for retriving the RFID information
+        Byte 1: Para1 (msb)
+        Byte 2: Para2
+        Byte 3: Para3
+        Byte 4: Para4 (lsb)
+      </Help>
     </Value>
   </CommandClass>
   <!-- Association Groups -->
-	<!--COMMAND_CLASS_ASSOCIATION_V2-->
+  <!--COMMAND_CLASS_ASSOCIATION_V2-->
   <CommandClass id="133">
     <Instance index="1"/>
     <Associations num_groups="1">

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -925,7 +925,7 @@
   <Manufacturer id="0011" name="iCOM Technology b.v."></Manufacturer>
   <Manufacturer id="0106" name="Icontrol Networks"></Manufacturer>
   <Manufacturer id="0373" name="ID Lock AS">
-    <Product config="idlock/idlock150.xml" id="0001" name="150" type="0003"/>
+    <Product config="idlock/idlock150.xml" id="0001" name="ID-150 Z-Wave Module" type="0003"/>
   </Manufacturer>
   <Manufacturer id="019E" name="iEXERGY GmbH"></Manufacturer>
   <Manufacturer id="031C" name="Ilevia srl"></Manufacturer>


### PR DESCRIPTION
This updates the config for the IDlock 150 module based on the spec of the latest 1.6 firmware from the manufacturer ([documentation](https://idlock.no/wp-content/uploads/2019/08/IDLock150_ZWave_UserManual_v3.02.pdf)).

I've also reordered the metadata items so they have the same order as the config template, and made some naming/text adjustments as per the Adding Devices wiki page.

There is a breaking change here for config index=2 regarding RFID mode, but the device reports the same type so I'm not sure how to be backwards compatible?