### PR TITLE
Adds GetValueMin/Max{value data type} methods.

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -1663,6 +1663,7 @@ void Manager::SetValueHelp(ValueID const& _id, string const& _value, int32 _pos)
 	OZW_ERROR(OZWException::OZWEXCEPTION_INVALID_VALUEID, "Invalid ValueID passed to SetValueHelp");
 }
 
+
 //-----------------------------------------------------------------------------
 // <Manager::GetValueMin>
 // Gets the minimum for a value
@@ -1675,7 +1676,7 @@ int32 Manager::GetValueMin(ValueID const& _id)
 		Internal::LockGuard LG(driver->m_nodeMutex);
 		if (Internal::VC::Value* value = driver->GetValue(_id))
 		{
-			limit = value->GetMin();
+			limit = (int32) value->GetMin();
 			value->Release();
 		}
 		else
@@ -1699,7 +1700,7 @@ int32 Manager::GetValueMax(ValueID const& _id)
 		Internal::LockGuard LG(driver->m_nodeMutex);
 		if (Internal::VC::Value* value = driver->GetValue(_id))
 		{
-			limit = value->GetMax();
+			limit = (int32) value->GetMax();
 			value->Release();
 		}
 		else
@@ -1710,6 +1711,8 @@ int32 Manager::GetValueMax(ValueID const& _id)
 
 	return limit;
 }
+
+
 
 //-----------------------------------------------------------------------------
 // <Manager::IsValueReadOnly>

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -36,6 +36,7 @@
 #include <deque>
 
 #include "Defs.h"
+#include "Utils.h"
 #include "Driver.h"
 #include "Group.h"
 #include "value_classes/ValueID.h"
@@ -1020,6 +1021,58 @@ namespace OpenZWave
 			int32 GetValueMin(ValueID const& _id);
 
 			/**
+			 * \brief Gets the minimum for a byte value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value minimum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			uint8 Manager::GetValueMinByte(ValueID const& _id)
+			{
+				return _GetValueMin<uint8>(_id);
+			}
+
+			/**
+			 * \brief Gets the minimum for a short value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value minimum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			int16 Manager::GetValueMinShort(ValueID const& _id)
+			{
+				return _GetValueMin<int16>(_id);
+			}
+
+			/**
+			 * \brief Gets the minimum for an int value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value minimum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			int32 Manager::GetValueMinInt(ValueID const& _id)
+			{
+				return _GetValueMin<int32>(_id);
+			}
+
+			/**
+			 * \brief Gets the minimum for a decimal value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value minimum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			float Manager::GetValueMinDecimal(ValueID const& _id)
+			{
+				return _GetValueMin<float>(_id);
+			}
+
+			/**
 			 * \brief Gets the maximum that this value may contain.
 			 * \param _id The unique identifier of the value.
 			 * \return The value maximum.
@@ -1028,6 +1081,100 @@ namespace OpenZWave
 			 * \see ValueID
 			 */
 			int32 GetValueMax(ValueID const& _id);
+			/**
+			 * \brief Gets the maximum for a byte value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value maximum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			uint8 GetValueMaxByte(ValueID const& _id)
+			{
+				return _GetValueMax<uint8>(_id);
+			}
+
+			/**
+			 * \brief Gets the maximum for a short value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value maximum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			int16 GetValueMaxShort(ValueID const& _id)
+			{
+				return _GetValueMax<int16>(_id);
+			}
+
+			/**
+			 * \brief Gets the maximum for an int value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value maximum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			int32 GetValueMaxInt(ValueID const& _id)
+			{
+				return _GetValueMax<int32>(_id);
+			}
+
+			/**
+			 * \brief Gets the maximum for a decimal value.
+			 * \param _id The unique identifier of the value.
+			 * \return The value maximum.
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_VALUEID if the ValueID is invalid
+			 * \throws OZWException with Type OZWException::OZWEXCEPTION_INVALID_HOMEID if the Driver cannot be found
+			 * \see ValueID
+			 */
+			float GetValueMaxDecimal(ValueID const& _id)
+			{
+				return _GetValueMax<float>(_id);
+			}
+
+		private:
+			template <class T>
+			T _GetValueMax(ValueID const& _id)
+			{
+				T limit;
+				if (Driver* driver = GetDriver(_id.GetHomeId()))
+				{
+					Internal::LockGuard LG(driver->m_nodeMutex);
+					if (Internal::VC::Value* value = driver->GetValue(_id))
+					{
+						limit = value->GetMax();
+						value->Release();
+					}
+					else
+					{
+						OZW_ERROR(OZWException::OZWEXCEPTION_INVALID_VALUEID, "Invalid ValueID passed to GetValueMax");
+					}
+				}
+				return limit;
+			}
+
+			template <class T>
+			T _GetValueMin(ValueID const& _id)
+			{
+				T limit;
+				if (Driver* driver = GetDriver(_id.GetHomeId()))
+				{
+					Internal::LockGuard LG(driver->m_nodeMutex);
+					if (Internal::VC::Value* value = driver->GetValue(_id))
+					{
+						limit = value->GetMin();
+						value->Release();
+					}
+					else
+					{
+						OZW_ERROR(OZWException::OZWEXCEPTION_INVALID_VALUEID, "Invalid ValueID passed to GetValueMin");
+					}
+				}
+				return limit;
+			}
+
+		public:
 
 			/**
 			 * \brief Test whether the value is read-only.
@@ -1449,7 +1596,7 @@ namespace OpenZWave
 			bool GetBitMask(ValueID const& _id, int32* o_mask);
 
 			/**
-			 * \brief Gets the size of a BitMask ValueID 
+			 * \brief Gets the size of a BitMask ValueID
 			 * Gets the size of a BitMask ValueID - Either 1, 2 or 4
 			 * \param _id The unique identifier of the integer value.
 			 * \param o_size The Size of the BitSet

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -247,16 +247,37 @@ namespace OpenZWave
 						// Add supported setpoint
 						if (index < ThermostatSetpoint_Count)
 						{
+							if (Internal::VC::ValueDecimal* value = static_cast<Internal::VC::ValueDecimal*>(GetValue(_instance, index)))
+							{
+								float floatMin = stof((const string)minValue, (size_t *)minValue.length());
+								float floatMax = stof((const string)maxValue, (size_t *)maxValue.length());
+
+								value->SetUnits(scale ? "F" : "C");
+
+								if (value->GetPrecision() != precision)
+								{
+									value->SetPrecision(precision);
+								}
+								if (value->GetMin() != floatMin)
+								{
+									value->SetMin(floatMin);
+								}
+								if (value->GetMax() != floatMax)
+								{
+									value->SetMax(floatMax);
+								}
+
+								value->Release();
+							}
+
 							string setpointName = c_setpointName[index];
 
 							node->CreateValueDecimal(ValueID::ValueGenre_User, GetCommandClassId(), _instance, ValueID_Index_ThermostatSetpoint::Unused_0_Minimum + index, setpointName + "_minimum", "C", false, false, minValue, 0);
 							node->CreateValueDecimal(ValueID::ValueGenre_User, GetCommandClassId(), _instance, ValueID_Index_ThermostatSetpoint::Unused_0_Maximum + index, setpointName + "_maximum", "C", false, false, maxValue, 0);
 							Log::Write(LogLevel_Info, GetNodeId(), "    Added setpoint: %s", setpointName.c_str());
 						}
-
 					}
 				}
-
 				return false;
 			}
 

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -57,7 +57,7 @@ namespace OpenZWave
 // Constructor
 //-----------------------------------------------------------------------------
 			Value::Value(uint32 const _homeId, uint8 const _nodeId, ValueID::ValueGenre const _genre, uint8 const _commandClassId, uint8 const _instance, uint16 const _index, ValueID::ValueType const _type, string const& _label, string const& _units, bool const _readOnly, bool const _writeOnly, bool const _isSet, uint8 const _pollIntensity) :
-					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_id(_homeId, _nodeId, _genre, _commandClassId, _instance, _index, _type), m_units(_units), m_readOnly(_readOnly), m_writeOnly(_writeOnly), m_isSet(_isSet), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(_pollIntensity)
+					m_refreshTime(0), m_verifyChanges(false), m_id(_homeId, _nodeId, _genre, _commandClassId, _instance, _index, _type), m_units(_units), m_readOnly(_readOnly), m_writeOnly(_writeOnly), m_isSet(_isSet), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(_pollIntensity)
 			{
 				SetLabel(_label);
 			}
@@ -67,7 +67,7 @@ namespace OpenZWave
 // Constructor (from XML)
 //-----------------------------------------------------------------------------
 			Value::Value() :
-					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_readOnly(false), m_writeOnly(false), m_isSet(false), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(0)
+					m_refreshTime(0), m_verifyChanges(false), m_readOnly(false), m_writeOnly(false), m_isSet(false), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(0)
 			{
 			}
 
@@ -189,16 +189,6 @@ namespace OpenZWave
 					m_verifyChanges = !strcmp(verifyChanges, "true");
 				}
 
-				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("min", &intVal))
-				{
-					m_min = intVal;
-				}
-
-				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("max", &intVal))
-				{
-					m_max = intVal;
-				}
-
 				TiXmlElement const* helpElement = _valueElement->FirstChildElement();
 				while (helpElement)
 				{
@@ -240,12 +230,6 @@ namespace OpenZWave
 
 				snprintf(str, sizeof(str), "%d", m_pollIntensity);
 				_valueElement->SetAttribute("poll_intensity", str);
-
-				snprintf(str, sizeof(str), "%d", m_min);
-				_valueElement->SetAttribute("min", str);
-
-				snprintf(str, sizeof(str), "%d", m_max);
-				_valueElement->SetAttribute("max", str);
 
 				if (m_affectsAll)
 				{

--- a/cpp/src/value_classes/Value.h
+++ b/cpp/src/value_classes/Value.h
@@ -107,13 +107,16 @@ namespace OpenZWave
 						m_pollIntensity = _intensity;
 					}
 
-					int32 GetMin() const
-					{
-						return m_min;
+					int32 GetMin() {
+						return 0;
 					}
-					int32 GetMax() const
-					{
-						return m_max;
+
+					int32 GetMax() {
+						return 0;
+					}
+
+					int16 GetPrecision() {
+						return 0;
 					}
 
 					void SetChangeVerified(bool _verify)

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -95,6 +95,18 @@ namespace OpenZWave
 				{
 					Log::Write(LogLevel_Info, "Missing default byte value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
 				}
+
+				uint8 uintVal;
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("min", (int *)&uintVal))
+				{
+					m_min = uintVal;
+				}
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("max", (int *)&uintVal))
+				{
+					m_max = uintVal;
+				}
 			}
 
 //-----------------------------------------------------------------------------
@@ -108,6 +120,12 @@ namespace OpenZWave
 				char str[8];
 				snprintf(str, sizeof(str), "%d", m_value);
 				_valueElement->SetAttribute("value", str);
+
+				snprintf(str, sizeof(str), "%d", m_min);
+				_valueElement->SetAttribute("min", str);
+
+				snprintf(str, sizeof(str), "%d", m_max);
+				_valueElement->SetAttribute("max", str);
 			}
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueByte.h
+++ b/cpp/src/value_classes/ValueByte.h
@@ -67,7 +67,18 @@ namespace OpenZWave
 						return m_value;
 					}
 
+					uint8 GetMin() const
+					{
+						return m_min;
+					}
+					uint8 GetMax() const
+					{
+						return m_max;
+					}
+
 				private:
+					uint8 m_min = 0;
+					uint8 m_max = 255;
 					uint8 m_value;				// the current value
 					uint8 m_valueCheck;			// the previous value (used for double-checking spurious value reads)
 			};

--- a/cpp/src/value_classes/ValueDecimal.cpp
+++ b/cpp/src/value_classes/ValueDecimal.cpp
@@ -65,8 +65,19 @@ namespace OpenZWave
 				{
 					Log::Write(LogLevel_Info, "Missing default decimal value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
 				}
-			}
 
+				float floatVal;
+
+				if (TIXML_SUCCESS == _valueElement->QueryFloatAttribute("min",&floatVal))
+				{
+					m_min = floatVal;
+				}
+
+				if (TIXML_SUCCESS == _valueElement->QueryFloatAttribute("max", &floatVal))
+				{
+					m_max = floatVal;
+				}
+			}
 //-----------------------------------------------------------------------------
 // <ValueDecimal::WriteXML>
 // Write ourselves to an XML document
@@ -75,6 +86,8 @@ namespace OpenZWave
 			{
 				Value::WriteXML(_valueElement);
 				_valueElement->SetAttribute("value", m_value.c_str());
+				_valueElement->SetDoubleAttribute("min", (double)m_min);
+				_valueElement->SetDoubleAttribute("max", (double)m_max);
 			}
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueDecimal.h
+++ b/cpp/src/value_classes/ValueDecimal.h
@@ -85,7 +85,28 @@ namespace OpenZWave
 						m_precision = _precision;
 					}
 
+					float GetMin() const
+					{
+						return m_min;
+					}
+					float GetMax() const
+					{
+						return m_max;
+					}
+
+					void SetMin(float _min)
+					{
+						m_min = _min;
+					}
+
+					void SetMax(float _max)
+					{
+						m_max = _max;
+					}
+
 				private:
+					float m_min = (float)(double)(-3.4e38);
+					float m_max = (float)(double)3.4e38;
 
 					string m_value;				// the current value
 					string m_valueCheck;			// the previous value (used for double-checking spurious value reads)

--- a/cpp/src/value_classes/ValueInt.cpp
+++ b/cpp/src/value_classes/ValueInt.cpp
@@ -94,6 +94,18 @@ namespace OpenZWave
 				{
 					Log::Write(LogLevel_Info, "Missing default integer value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
 				}
+
+				int32 iVal;
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("min", (int *)&iVal))
+				{
+					m_min = iVal;
+				}
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("max", (int *)&iVal))
+				{
+					m_max = iVal;
+				}
 			}
 
 //-----------------------------------------------------------------------------
@@ -107,6 +119,12 @@ namespace OpenZWave
 				char str[16];
 				snprintf(str, sizeof(str), "%d", m_value);
 				_valueElement->SetAttribute("value", str);
+
+				snprintf(str, sizeof(str), "%d", m_min);
+				_valueElement->SetAttribute("min", str);
+
+				snprintf(str, sizeof(str), "%d", m_max);
+				_valueElement->SetAttribute("max", str);
 			}
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueInt.h
+++ b/cpp/src/value_classes/ValueInt.h
@@ -29,6 +29,7 @@
 #define _ValueInt_H
 
 #include <string>
+#include <limits.h>
 #include "Defs.h"
 #include "value_classes/Value.h"
 
@@ -67,7 +68,18 @@ namespace OpenZWave
 						return m_value;
 					}
 
+					int32 GetMin() const
+					{
+						return m_min;
+					}
+					int32 GetMax() const
+					{
+						return m_max;
+					}
+
 				private:
+					int32 m_min = INT_MIN;
+					int32 m_max = INT_MAX;
 					int32 m_value;				// the current value
 					int32 m_valueCheck;			// the previous value (used for double-checking spurious value reads)
 			};

--- a/cpp/src/value_classes/ValueShort.cpp
+++ b/cpp/src/value_classes/ValueShort.cpp
@@ -97,6 +97,18 @@ namespace OpenZWave
 				{
 					Log::Write(LogLevel_Info, "Missing default short value from xml configuration: node %d, class 0x%02x, instance %d, index %d", _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
 				}
+
+				int16 iVal;
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("min", (int *)&iVal))
+				{
+					m_min = iVal;
+				}
+
+				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("max", (int *)&iVal))
+				{
+					m_max = iVal;
+				}
 			}
 
 //-----------------------------------------------------------------------------
@@ -110,6 +122,12 @@ namespace OpenZWave
 				char str[16];
 				snprintf(str, sizeof(str), "%d", m_value);
 				_valueElement->SetAttribute("value", str);
+
+				snprintf(str, sizeof(str), "%d", m_min);
+				_valueElement->SetAttribute("min", str);
+
+				snprintf(str, sizeof(str), "%d", m_max);
+				_valueElement->SetAttribute("max", str);
 			}
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/value_classes/ValueShort.h
+++ b/cpp/src/value_classes/ValueShort.h
@@ -29,6 +29,7 @@
 #define _ValueShort_H
 
 #include <string>
+#include <limits.h>
 #include "Defs.h"
 #include "value_classes/Value.h"
 
@@ -67,7 +68,18 @@ namespace OpenZWave
 						return m_value;
 					}
 
+					int16 GetMin() const
+					{
+						return m_min;
+					}
+					int16 GetMax() const
+					{
+						return m_max;
+					}
+
 				private:
+					int16 m_min = SHRT_MIN;
+					int16 m_max = SHRT_MAX;
 					int16 m_value;				// the current value
 					int16 m_valueCheck;			// the previous value (used for double-checking spurious value reads)
 			};


### PR DESCRIPTION
I added separate data type gets for min and max for the values. The
original GetValueMin and GetValueMax are still in place. the new methods are

GetValueMinByte
GetValueMinShort
GetValueMinInt
GetValueMinDecimal

GetValueMaxByte
GetValueMaxShort
GetValueMaxInt
GetValueMaxDecimal

These methods return the following data types

uint_8: Byte
int16: Short
int32: Int
float: Decimal

The min and max are only written to and gotten from the config file for
ValueByte, ValueShort, ValueInt and ValueDecimal.

I believe that the user can evaluate the value in order to know which
method to call. I did add type conversion to int32 for GetValueMin and
GetValueMax. I am aware that I did not have to create the Byte, Short
and Int methods because int32 covers uint_8 and int16 also. I did it to
keep the flow for the API

From what I can from the ZWave specification only
COMMAND_CLASS_THERMOSTAT_SETPOINT version 3+ uses the decimal min and
max. I looked at the code for that command class and it appeared as tho
there were additional values that were created to handle the min and
max values. I think this was because there was no direct way to add
them other then what I have done. I did not remove these additional values.
I did set the max and min for the setpoint value so there really is no
need to have those other values in place.

This is a proof of concept and I am sure that changes will need to be made.
It compiles without error. I do not have a thermostat to be able to
test the GetValueMinDecimal and GetValueMaxDecimal. hopefully someone
that does will be willing to give it a go and see what happens.

I also fixed the GetValuePrecision app crash
