### PR TITLE
MultiCmd: implement sanity checks and improve logging

### DIFF
--- a/cpp/src/command_classes/MultiCmd.cpp
+++ b/cpp/src/command_classes/MultiCmd.cpp
@@ -49,18 +49,49 @@ namespace OpenZWave
 			{
 				if (MultiCmdCmd_Encap == (MultiCmdCmd) _data[0])
 				{
-					Log::Write(LogLevel_Info, GetNodeId(), "Received encapsulated multi-command from node %d", GetNodeId());
+					int commands;
 
-					if (Node const* node = GetNodeUnsafe())
+					if (_length < 3)
+					{
+						Log::Write(LogLevel_Error, GetNodeId(), "Multi-command frame received is invalid, _length is < 3");
+						return false;
+					}
+					else
+					{
+						commands = _data[1];
+						Log::Write(LogLevel_Info, GetNodeId(), "Multi-command frame received, encapsulates %d command(s)", commands);
+					}
+
+					if (Node const *node = GetNodeUnsafe())
 					{
 						// Iterate over commands
-						uint8 base = 2;
-						for (uint8 i = 0; i < _data[1]; ++i)
+						int base = 2;
+						// Highest possible index is _length minus two because
+						// array is zero-based and _data starts at second byte of command frame
+						int highest_index = _length - 2;
+						for (uint8 i = 1; i <= commands; ++i)
 						{
+							if (base > highest_index)
+							{
+								Log::Write(LogLevel_Error, GetNodeId(),
+										   "Multi-command command part %d is invalid, frame is too short: base > highest_index (%d > %d)",
+										   i, base, highest_index);
+								return false;
+							}
+
 							uint8 length = _data[base];
+							int end = base + length;
+							if (end > highest_index)
+							{
+								Log::Write(LogLevel_Error, GetNodeId(),
+										   "Multi-command command part %d with base %d is invalid, end > highest_index (%d > %d)",
+										   i, base, end, highest_index);
+								return false;
+							}
+
 							uint8 commandClassId = _data[base + 1];
 
-							if (CommandClass* pCommandClass = node->GetCommandClass(commandClassId))
+							if (CommandClass *pCommandClass = node->GetCommandClass(commandClassId))
 							{
 								if (!pCommandClass->IsAfterMark())
 									pCommandClass->HandleMsg(&_data[base + 2], length - 1);
@@ -72,7 +103,7 @@ namespace OpenZWave
 						}
 					}
 
-					Log::Write(LogLevel_Info, GetNodeId(), "End of encapsulated multi-command from node %d", GetNodeId());
+					Log::Write(LogLevel_Info, GetNodeId(), "Multi-command, all %d command(s) processed", commands);
 					return true;
 				}
 				return false;


### PR DESCRIPTION
This stops creating bogus data, as reported here:
"Labels of PST02 in Secure Mode are wrong in ozwcp"
https://github.com/OpenZWave/open-zwave/issues/1899

This is the first step in fixing that issue, the next step is supporting multipart secure messages

This PR was tested by using both a real PST02 and data simulated by injecting valid and invalid data.

The PST02 sends a multipart secure message, the first part now logs:

```
2019-09-04 09:51:13.429 Info, Node013, Multi-command frame received, encapsulates 4 command(s)
2019-09-04 09:51:13.431 Info, Node013, Received Battery report from node 13: level=100
2019-09-04 09:51:13.434 Detail, Node013, Refreshed Value: old value=100, new value=100, type=byte
2019-09-04 09:51:13.435 Detail, Node013, Changes to this value are not verified
2019-09-04 09:51:13.437 Info, Node013, Received Notification report (>v1): Type: Home Security (7) Event: Motion Detected at Unknown Location (8) Status: true, Param Length: 0
2019-09-04 09:51:13.440 Detail, Node013, Refreshed Value: old value=2, new value=2, type=list
2019-09-04 09:51:13.445 Detail, Node013, Changes to this value are not verified
2019-09-04 09:51:13.447 Info, Node013, Received SensorMultiLevel report from node 13, instance 1, Illuminance: value=99%
2019-09-04 09:51:13.449 Detail, Node013, Refreshed Value: old value=98, new value=99, type=decimal
2019-09-04 09:51:13.451 Detail, Node013, Changes to this value are not verified
2019-09-04 09:51:13.454 Error, Node013, Multi-command command part 4 with base 22 is invalid, end > highest_index (28 > 24)
2019-09-04 09:51:13.456 Warning, Node013, CommandClass COMMAND_CLASS_MULTI_CMD HandlerMsg Returned False
```

This stops the creation of a 4th value, based on whatever data is after the truncated frame...

Also tested if it still works on valid data:

```
2019-09-04 09:51:04.057 Info, Node013, Multi-command frame received, encapsulates 1 command(s)
2019-09-04 09:51:04.059 Info, Node013, Received SensorMultiLevel report from node 13, instance 1, Air Temperature: value=71F
2019-09-04 09:51:04.062 Detail, Node013, Refreshed Value: old value=-40.0, new value=71, type=decimal
2019-09-04 09:51:04.064 Detail, Node013, Changes to this value are not verified
2019-09-04 09:51:04.066 Info, Node013, Multi-command, all 1 command(s) processed
```

