### PR TITLE
Fix DLL export warnings on windows

### DIFF
--- a/cpp/src/Bitfield.h
+++ b/cpp/src/Bitfield.h
@@ -75,8 +75,7 @@ namespace OpenZWave
 				Iterator End() const;
 
 			private:
-				OPENZWAVE_EXPORT_WARNINGS_OFF
-				vector<uint32> m_bits;OPENZWAVE_EXPORT_WARNINGS_ON
+				vector<uint32> m_bits;
 				uint32 m_numSetBits;
 				uint32 m_value;
 		};

--- a/cpp/src/Defs.h
+++ b/cpp/src/Defs.h
@@ -35,22 +35,21 @@
 
 // Compilation export flags
 #if (defined _WINDOWS || defined WIN32 || defined _MSC_VER) && (!defined MINGW && !defined __MINGW32__ && !defined __MINGW64__)
+// As discussd here https://github.com/OpenZWave/open-zwave/pull/1835
+// Disable certain  MSVC warnings here (instead of applying the pragma throughout the code as was done in the past).
+// Application and DLL should be built with same compiler and settings anyway.
+// See https://stackoverflow.com/questions/5661738/how-can-i-use-standard-library-stl-classes-in-my-dll-interface-or-abi
 #	if defined OPENZWAVE_MAKEDLL	// Create the dynamic library.
 #		define OPENZWAVE_EXPORT    __declspec(dllexport)
+		__pragma(warning(disable: 4251)) __pragma(warning(disable: 4275))
 #	elif defined OPENZWAVE_USEDLL	// Use the dynamic library
 #		define OPENZWAVE_EXPORT    __declspec(dllimport)
+		__pragma(warning(disable: 4251)) __pragma(warning(disable: 4275))
 #	else							// Create/Use the static library
 #		define OPENZWAVE_EXPORT
 #	endif
-// Disable export warnings
-#	define OPENZWAVE_EXPORT_WARNINGS_OFF	__pragma( warning(push) )\
-											__pragma( warning(disable: 4251) ) \
-											__pragma( warning(disable: 4275) )
-#	define OPENZWAVE_EXPORT_WARNINGS_ON		__pragma( warning(pop) )
 #else
 #	define OPENZWAVE_EXPORT
-#	define OPENZWAVE_EXPORT_WARNINGS_OFF
-#	define OPENZWAVE_EXPORT_WARNINGS_ON
 #endif
 
 #ifdef __GNUC__

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -328,7 +328,6 @@ namespace OpenZWave
 			string m_controllerPath;							// name or path used to open the controller hardware.
 			Internal::Platform::Controller* m_controller;								// Handles communications with the controller hardware.
 			uint32 m_homeId;									// Home ID of the Z-Wave controller.  Not valid until the DriverReady notification has been received.
-
 			string m_libraryVersion;							// Version of the Z-Wave Library used by the controller.
 			string m_libraryTypeName;							// Name describing the library type.
 			uint8 m_libraryType;								// Type of library used by the controller.
@@ -452,9 +451,8 @@ namespace OpenZWave
 			{
 					ValueID m_id;
 					uint8 m_pollCounter;
-			};OPENZWAVE_EXPORT_WARNINGS_OFF
+			};
 			list<PollEntry> m_pollList;									// List of nodes that need to be polled
-			OPENZWAVE_EXPORT_WARNINGS_ON
 			Internal::Platform::Mutex* m_pollMutex;								// Serialize access to the polling list
 			int32 m_pollInterval;								// Time interval during which all nodes must be polled
 			bool m_bIntervalBetweenPolls;					// if true, the library intersperses m_pollInterval between polls; if false, the library attempts to complete all polls within m_pollInterval
@@ -789,8 +787,7 @@ namespace OpenZWave
 					ControllerCommandItem* m_cci;
 			};
 
-			OPENZWAVE_EXPORT_WARNINGS_OFF
-			list<MsgQueueItem> m_msgQueue[MsgQueue_Count];OPENZWAVE_EXPORT_WARNINGS_ON
+			list<MsgQueueItem> m_msgQueue[MsgQueue_Count];
 			Internal::Platform::Event* m_queueEvent[MsgQueue_Count];		// Events for each queue, which are signaled when the queue is not empty
 			Internal::Platform::Mutex* m_sendMutex;						// Serialize access to the queues
 			Internal::Msg* m_currentMsg;
@@ -862,10 +859,7 @@ namespace OpenZWave
 		private:
 			void QueueNotification(Notification* _notification);				// Adds a notification to the list.  Notifications are queued until a point in the thread where we know we do not have any nodes locked.
 			void NotifyWatchers();												// Passes the notifications to all the registered watcher callbacks in turn.
-
-			OPENZWAVE_EXPORT_WARNINGS_OFF
 			list<Notification*> m_notifications;
-			OPENZWAVE_EXPORT_WARNINGS_ON
 			Internal::Platform::Event* m_notificationsEvent;
 
 			//-----------------------------------------------------------------------------
@@ -969,9 +963,7 @@ namespace OpenZWave
 
 			void SubmitEventMsg(EventMsg *);
 			void ProcessEventMsg();
-
-			OPENZWAVE_EXPORT_WARNINGS_OFF
-			list<EventMsg *> m_eventQueueMsg;OPENZWAVE_EXPORT_WARNINGS_ON
+			list<EventMsg *> m_eventQueueMsg;
 			Internal::Platform::Event* m_queueMsgEvent;				// Events for each queue, which are signalled when the queue is not empty
 			Internal::Platform::Mutex* m_eventMutex;						// Serialize access to the queues
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -366,11 +366,8 @@ namespace OpenZWave
 		private:
 			Driver* GetDriver(uint32 const _homeId); /**< Get a pointer to a Driver object from the HomeID.  Only to be used by OpenZWave. */
 			void SetDriverReady(Driver* _driver, bool success); /**< Indicate that the Driver is ready to be used, and send the notification callback. */
-
-			OPENZWAVE_EXPORT_WARNINGS_OFF
 			list<Driver*> m_pendingDrivers; /**< Drivers that are in the process of reading saved data and querying their Z-Wave network for basic information. */
 			map<uint32, Driver*> m_readyDrivers; /**< Drivers that are ready to be used by the application. */
-		OPENZWAVE_EXPORT_WARNINGS_ON
 
 		//-----------------------------------------------------------------------------
 		//	Polling Z-Wave devices
@@ -1790,10 +1787,8 @@ namespace OpenZWave
 					}
 			};
 
-			OPENZWAVE_EXPORT_WARNINGS_OFF
 			list<Watcher*> m_watchers;							// List of all the registered watchers.
 			list<list<Watcher*>::iterator*> m_watcherIterators;					// Iterators currently operating on the list of watchers
-			OPENZWAVE_EXPORT_WARNINGS_ON
 			Internal::Platform::Mutex* m_notificationMutex;
 
 			//-----------------------------------------------------------------------------

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -224,7 +224,6 @@ namespace OpenZWave
 			private:
 
 				void MultiEncap();						// Encapsulate the data inside a MultiInstance/Multicommand message
-
 				string m_logText;
 				bool m_bFinal;
 				bool m_bCallbackRequired;

--- a/cpp/src/OZWException.h
+++ b/cpp/src/OZWException.h
@@ -41,7 +41,6 @@ namespace OpenZWave
  * (such as passing incorrect ValueID's to the Manager::SetValue methods) or
  */
 
-OPENZWAVE_EXPORT_WARNINGS_OFF
 class OPENZWAVE_EXPORT OZWException : public std::runtime_error
 {
 	public:
@@ -124,7 +123,6 @@ class OPENZWAVE_EXPORT OZWException : public std::runtime_error
 	uint32 m_line;
 	std::string m_msg;
 };
-OPENZWAVE_EXPORT_WARNINGS_ON
 }
 
 #endif // _FatalErrorException_H

--- a/cpp/src/Options.h
+++ b/cpp/src/Options.h
@@ -244,9 +244,7 @@ namespace OpenZWave
 			Option* AddOption(string const& _name);							// check lock and create (or open existing) option
 			Option* Find(string const& _name);
 
-			OPENZWAVE_EXPORT_WARNINGS_OFF
 			map<string, Option*> m_options;										// Map of option names to values.
-			OPENZWAVE_EXPORT_WARNINGS_ON
 			string m_xml;											// Path to XML options file.
 			string m_commandLine;									// String containing command line options.
 			string m_SystemPath;

--- a/cpp/src/command_classes/CommandClass.h
+++ b/cpp/src/command_classes/CommandClass.h
@@ -238,9 +238,9 @@ namespace OpenZWave
 				private:
 					uint32 m_homeId;
 					uint8 m_nodeId;
-					Bitfield m_instances;OPENZWAVE_EXPORT_WARNINGS_OFF
+					Bitfield m_instances;
 					map<uint8, uint8> m_endPointMap;
-					map<uint8, string> m_instanceLabel;OPENZWAVE_EXPORT_WARNINGS_ON
+					map<uint8, string> m_instanceLabel;
 					bool m_SecureSupport; 	// Does this commandclass support secure encryption (eg, the Security CC doesn't encrypt itself, so it doesn't support encryption)
 					std::vector<RefreshValue *> m_RefreshClassValues; // what Command Class Values should we refresh ?
 					string m_commandClassLabel;

--- a/dist/openzwave.spec
+++ b/dist/openzwave.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:     openzwave
-Version:  1.6.899
+Version:  1.6.913
 Release:  1.0%{?dist}
 Summary:  Sample Executables for OpenZWave
 URL:      http://www.openzwave.net
@@ -135,7 +135,7 @@ getent group zwave >/dev/null || groupadd -f -r zwave
 
 
 %changelog
-* Wed May 08 2019 Justin Hammond <justin@dynam.ac> - 1.6.899
+* Wed May 08 2019 Justin Hammond <justin@dynam.ac> - 1.6.913
 - Update to new release of OpenZwave - 1.6
 
 * Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.0-0.20180624git1e36dcc.0


### PR DESCRIPTION
Discussion https://github.com/OpenZWave/open-zwave/pull/1835
Tested with Domoticz.
Does not affect other platforms, but cleans up clutter in
header files.