### PR TITLE
Update ZMNHDDx.xml

### DIFF
--- a/config/qubino/ZMNHDDx.xml
+++ b/config/qubino/ZMNHDDx.xml
@@ -51,7 +51,7 @@ http://qubino.com/download/990/
   <CommandClass id="112">
     <Value genre="config" index="1" instance="1" label="Input 1 switch type" max="1" min="0" size="1" type="list" value="0">
       <Help/>
-      <Item label="Mono-stable(push button)" value="0"/>
+      <Item label="Mono-stable (push button)" value="0"/>
       <Item label="Bi-stable" value="1"/>
     </Value>
     <Value genre="config" index="2" instance="1" label="Input 2 switch type" max="1" min="0" size="1" type="list" value="0">

--- a/config/qubino/ZMNHDDx.xml
+++ b/config/qubino/ZMNHDDx.xml
@@ -1,4 +1,4 @@
-<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="8" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0159:0051:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/qubino/ZMNHDDx.png</MetaDataItem>
@@ -34,6 +34,7 @@ Please use reset procedure only when the network primary controller is missing o
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="6">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2077/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="7">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2114/xml</Entry>
+      <Entry author="Chris Nesbitt-Smith - chris@cns.me.uk" date="27 Sep 2019" revision="8">Tweak config label for consistency of both buttons</Entry>
     </ChangeLog>
   </MetaData>
   <!-- 


### PR DESCRIPTION
make the label for `Input 1 switch type` match the `Input 2 contact type`
annoying whitespace difference