### PR TITLE
Console log unix: change dark blue to light blue, add more colors.

### DIFF
--- a/cpp/src/platform/unix/LogImpl.cpp
+++ b/cpp/src/platform/unix/LogImpl.cpp
@@ -90,31 +90,36 @@ namespace OpenZWave
 
 				switch (_level)
 				{
+					case LogLevel_Internal:
+					case LogLevel_StreamDetail:
+						code = 97;
+						break;   // 97=bright white
 					case LogLevel_Debug:
-						code = 34;
-						break;   // 34=blue
+						code = 36;
+						break;   // 36=cyan
 					case LogLevel_Detail:
-						code = 34;
-						break;	 // 34=blue
+						code = 94;
+						break;	 // 94=bright blue
 					case LogLevel_Info:
 						code = 39;
 						break;   // 39=white
 					case LogLevel_Alert:
-						code = 33;
-						break;   // 33=orange
+						code = 93;
+						break;   // 93=bright yellow
 					case LogLevel_Warning:
 						code = 33;
-						break;   // 31=red
+						break;   // 33=yellow
 					case LogLevel_Error:
 						code = 31;
-						break;
+						break;   // 31=red
 					case LogLevel_Fatal:
 						code = 95;
-						break;
+						break;	 // 95=bright magenta
 					case LogLevel_Always:
 						code = 32;
-						break;   // 95=magenta
-					default:
+						break;   // 32=green
+					case LogLevel_Invalid:
+					case LogLevel_None:
 						code = 39;
 						break;   // 39=white (reset to default)
 				}


### PR DESCRIPTION
The dark blue that was assigned to "Detail" is hard to read on a black background.

Fixes a small, but to me quite annoying readability problem.

Feel free to ignore or suggest another color scheme ;)