### PR TITLE
Check if packet is actually device data before checking security

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1775,7 +1775,7 @@ void Driver::ProcessMsg(uint8* _data, uint8 _length)
 	bool wasencrypted = false;
 	//uint8 nodeId = GetNodeNumber( m_currentMsg );
 
-	if ((REQUEST == _data[0]) && (Internal::CC::Security::StaticGetCommandClassId() == _data[5]))
+	if ((REQUEST == _data[0]) && FUNC_ID_APPLICATION_COMMAND_HANDLER == _data[1] && (Internal::CC::Security::StaticGetCommandClassId() == _data[5]))
 	{
 		/* if this message is a NONCE Report - Then just Trigger the Encrypted Send */
 		if (Internal::CC::SecurityCmd_NonceReport == _data[6])


### PR DESCRIPTION
Before this PR, ProcessMsg only checks _data[5] (and type is request) to determine if the serial packet is a security CC and should be subject to nonce handling and encryption.

I would say that is only valid if the serial packet is of type "application command handler".

I am not sure if this would make a huge difference in practice...