### PR TITLE
Fix testconfig.pl error printing

### DIFF
--- a/cpp/build/testconfig.pl
+++ b/cpp/build/testconfig.pl
@@ -417,8 +417,9 @@ sub CheckSensorMultiLevelCCTypes {
 
 
 sub PrettyPrintErrors() {
-	if (length(%errors) > 0) {
-		print "\n\nErrors: (Please Correct before Submitting to OZW)\n";
+	my $number_of_errors = keys %errors;
+	if ($number_of_errors > 0) {
+		print "\n\nErrors: ", $number_of_errors, ". (Please Correct before Submitting to OZW)\n";
 		while ((my $key, my $value) = each %errors) 
 		{
 			foreach my $detail (@{$value}) 


### PR DESCRIPTION
Use number of keys instead of size(hash)

Without this PR and no errors:

```
perl cpp/build/testconfig.pl
Checking Config Files... Please Wait


Errors: (Please Correct before Submitting to OZW)

Saving Revision Database
```

After this PR

```
Checking Config Files... Please Wait


No errors detected (You can submit your changes to OZW)

Saving Revision Database
```

If I edit config/manufacturer_specific.xml after this PR:

```
Checking Config Files... Please Wait
config/manufacturer_specific.xml - md5 does not match Database - Database Revision:54 File Revision:54


Errors: 1. (Please Correct before Submitting to OZW)
config/manufacturer_specific.xml: Revision Number Was Not Bumped - Error Code 8
```