### PR TITLE
MultiChannel code: change wording instance -> endpoint

### DIFF
--- a/cpp/src/Group.cpp
+++ b/cpp/src/Group.cpp
@@ -203,11 +203,11 @@ void Group::WriteXML(TiXmlElement* _groupElement)
 // <Group::Contains>
 // Whether a group contains a particular node
 //-----------------------------------------------------------------------------
-bool Group::Contains(uint8 const _nodeId, uint8 const _instance)
+bool Group::Contains(uint8 const _nodeId, uint8 const _endPoint)
 {
 	for (map<InstanceAssociation, AssociationCommandVec, classcomp>::iterator it = m_associations.begin(); it != m_associations.end(); ++it)
 	{
-		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _instance))
+		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _endPoint))
 		{
 			return true;
 		}
@@ -219,7 +219,7 @@ bool Group::Contains(uint8 const _nodeId, uint8 const _instance)
 // <Group::AddAssociation>
 // Associate a node with this group
 //-----------------------------------------------------------------------------
-void Group::AddAssociation(uint8 const _nodeId, uint8 const _instance)
+void Group::AddAssociation(uint8 const _nodeId, uint8 const _endPoint)
 {
 	if (Driver* driver = Manager::Get()->GetDriver(m_homeId))
 	{
@@ -228,7 +228,7 @@ void Group::AddAssociation(uint8 const _nodeId, uint8 const _instance)
 			Internal::CC::MultiChannelAssociation* cc = static_cast<Internal::CC::MultiChannelAssociation*>(node->GetCommandClass(Internal::CC::MultiChannelAssociation::StaticGetCommandClassId()));
 			if (cc && IsMultiInstance())
 			{
-				cc->Set(m_groupIdx, _nodeId, _instance);
+				cc->Set(m_groupIdx, _nodeId, _endPoint);
 				cc->QueryGroup(m_groupIdx, 0);
 			}
 			else if (Internal::CC::Association* cc = static_cast<Internal::CC::Association*>(node->GetCommandClass(Internal::CC::Association::StaticGetCommandClassId())))
@@ -248,7 +248,7 @@ void Group::AddAssociation(uint8 const _nodeId, uint8 const _instance)
 // <Group:RemoveAssociation>
 // Remove a node from this group
 //-----------------------------------------------------------------------------
-void Group::RemoveAssociation(uint8 const _nodeId, uint8 const _instance)
+void Group::RemoveAssociation(uint8 const _nodeId, uint8 const _endPoint)
 {
 	if (Driver* driver = Manager::Get()->GetDriver(m_homeId))
 	{
@@ -257,7 +257,7 @@ void Group::RemoveAssociation(uint8 const _nodeId, uint8 const _instance)
 			Internal::CC::MultiChannelAssociation* cc = static_cast<Internal::CC::MultiChannelAssociation*>(node->GetCommandClass(Internal::CC::MultiChannelAssociation::StaticGetCommandClassId()));
 			if (cc && IsMultiInstance())
 			{
-				cc->Remove(m_groupIdx, _nodeId, _instance);
+				cc->Remove(m_groupIdx, _nodeId, _endPoint);
 				cc->QueryGroup(m_groupIdx, 0);
 			}
 			else if (Internal::CC::Association* cc = static_cast<Internal::CC::Association*>(node->GetCommandClass(Internal::CC::Association::StaticGetCommandClassId())))
@@ -432,11 +432,11 @@ uint32 Group::GetAssociations(InstanceAssociation** o_associations)
 // <Group::ClearCommands>
 // Clear all the commands for the specified node
 //-----------------------------------------------------------------------------
-bool Group::ClearCommands(uint8 const _nodeId, uint8 const _instance)
+bool Group::ClearCommands(uint8 const _nodeId, uint8 const _endPoint)
 {
 	for (map<InstanceAssociation, AssociationCommandVec, classcomp>::iterator it = m_associations.begin(); it != m_associations.end(); ++it)
 	{
-		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _instance))
+		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _endPoint))
 		{
 			it->second.clear();
 			return true;
@@ -450,11 +450,11 @@ bool Group::ClearCommands(uint8 const _nodeId, uint8 const _instance)
 // <Group::AddCommand>
 // Add a command to the list for the specified node
 //-----------------------------------------------------------------------------
-bool Group::AddCommand(uint8 const _nodeId, uint8 const _length, uint8 const* _data, uint8 const _instance)
+bool Group::AddCommand(uint8 const _nodeId, uint8 const _length, uint8 const* _data, uint8 const _endPoint)
 {
 	for (map<InstanceAssociation, AssociationCommandVec, classcomp>::iterator it = m_associations.begin(); it != m_associations.end(); ++it)
 	{
-		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _instance))
+		if ((it->first.m_nodeId == _nodeId) && (it->first.m_instance == _endPoint))
 		{
 			it->second.push_back(AssociationCommand(_length, _data));
 			return true;

--- a/cpp/src/Group.h
+++ b/cpp/src/Group.h
@@ -48,10 +48,22 @@ namespace OpenZWave
 
 	class Node;
 
+	// When dealing with MultiInstance Devices,
+	// OpenZWave uses "Instance" to identify a subdevice.
+	// The public interface maps an Instance ID to an "End Point", which in turn
+	// gets used to build Z-Wave packets.
+	// Config files and by extension ozwcache store this map per CC, for example:
+	// <Instance index="1" endpoint="1" />
+	// The Group Aka Association commands, however, expect "End Points"
+	// It would make sense to change "Instance" to "End Point" in all related code but...
+	// InstanceAssociation is exposed by the API in Manager::GetAssociations
+	// Because of its exposure, m_instance cannot be renamed to m_endPoint without
+	// breaking existing code.
+
 	typedef struct InstanceAssociation
 	{
 			uint8 m_nodeId;
-			uint8 m_instance;
+			uint8 m_instance; // "End Point" as defined in SDS13782-11B, Multi Channel Association Command Class.
 	} InstanceAssociation;
 
 	/** \brief Manages a group of devices (various nodes associated with each other).
@@ -92,7 +104,7 @@ namespace OpenZWave
 			{
 				return m_groupIdx;
 			}
-			bool Contains(uint8 const _nodeId, uint8 const _instance = 0x00);
+			bool Contains(uint8 const _nodeId, uint8 const _endPoint= 0x00);
 			bool IsMultiInstance() const
 			{
 				return m_multiInstance;
@@ -114,8 +126,8 @@ namespace OpenZWave
 				m_multiInstance = _state;
 			}
 
-			void AddAssociation(uint8 const _nodeId, uint8 const _instance = 0x00);
-			void RemoveAssociation(uint8 const _nodeId, uint8 const _instance = 0x00);
+			void AddAssociation(uint8 const _nodeId, uint8 const endPoint = 0x00);
+			void RemoveAssociation(uint8 const _nodeId, uint8 const _endPoint = 0x00);
 			void OnGroupChanged(vector<uint8> const& _associations);
 			void OnGroupChanged(vector<InstanceAssociation> const& _associations);
 
@@ -123,8 +135,8 @@ namespace OpenZWave
 			// Command methods (COMMAND_CLASS_ASSOCIATION_COMMAND_CONFIGURATION)
 			//-----------------------------------------------------------------------------
 		public:
-			bool ClearCommands(uint8 const _nodeId, uint8 const _instance = 0x00);
-			bool AddCommand(uint8 const _nodeId, uint8 const _length, uint8 const* _data, uint8 const _instance = 0x00);
+			bool ClearCommands(uint8 const _nodeId, uint8 const _endPoint = 0x00);
+			bool AddCommand(uint8 const _nodeId, uint8 const _length, uint8 const* _data, uint8 const _endPoint = 0x00);
 
 		private:
 			class AssociationCommand

--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3571,6 +3571,8 @@ uint32 Manager::GetAssociations(uint32 const _homeId, uint8 const _nodeId, uint8
 //-----------------------------------------------------------------------------
 // <Manager::GetAssociations>
 // Gets the associations for a group
+// struct InstanceAssociation is defined in Group.h and contains
+// a (NodeID, End Point) pair.
 //-----------------------------------------------------------------------------
 uint32 Manager::GetAssociations(uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, InstanceAssociation** o_associations)
 {
@@ -3627,11 +3629,11 @@ string Manager::GetGroupLabel(uint32 const _homeId, uint8 const _nodeId, uint8 c
 // <Manager::AddAssociation>
 // Adds a node to an association group
 //-----------------------------------------------------------------------------
-void Manager::AddAssociation(uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance)
+void Manager::AddAssociation(uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _endPoint)
 {
 	if (Driver* driver = GetDriver(_homeId))
 	{
-		driver->AddAssociation(_nodeId, _groupIdx, _targetNodeId, _instance);
+		driver->AddAssociation(_nodeId, _groupIdx, _targetNodeId, _endPoint);
 	}
 }
 
@@ -3639,11 +3641,11 @@ void Manager::AddAssociation(uint32 const _homeId, uint8 const _nodeId, uint8 co
 // <Manager::RemoveAssociation>
 // Removes a node from an association group
 //-----------------------------------------------------------------------------
-void Manager::RemoveAssociation(uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _instance)
+void Manager::RemoveAssociation(uint32 const _homeId, uint8 const _nodeId, uint8 const _groupIdx, uint8 const _targetNodeId, uint8 const _endPoint)
 {
 	if (Driver* driver = GetDriver(_homeId))
 	{
-		driver->RemoveAssociation(_nodeId, _groupIdx, _targetNodeId, _instance);
+		driver->RemoveAssociation(_nodeId, _groupIdx, _targetNodeId, _endPoint);
 	}
 }
 

--- a/cpp/src/Manager.h
+++ b/cpp/src/Manager.h
@@ -1673,6 +1673,9 @@ namespace OpenZWave
 			/**
 			 * \brief Gets the associations for a group.
 			 * Makes a copy of the list of associated nodes in the group, and returns it in an array of InstanceAssociation's.
+			 * struct InstanceAssociation is defined in Group.h and contains
+			 * a (NodeID, End Point) pair. See SDS13783-11B Z-Wave Transport-Encapsulation Command Class Specification
+			 * chapter 2.3.1 Terminology for the definition of "End Point" and "Multi Channel Encapsulation"
 			 * The caller is responsible for freeing the array memory with a call to delete [].
 			 * \param _homeId The Home ID of the Z-Wave controller that manages the node.
 			 * \param _nodeId The ID of the node whose associations we are interested in.

--- a/cpp/src/command_classes/MultiChannelAssociation.h
+++ b/cpp/src/command_classes/MultiChannelAssociation.h
@@ -67,8 +67,8 @@ namespace OpenZWave
 					// From CommandClass
 					virtual void ReadXML(TiXmlElement const* _ccElement) override;
 					virtual void WriteXML(TiXmlElement* _ccElement) override;
-					virtual bool RequestState(uint32 const _requestFlags, uint8 const _instance, Driver::MsgQueue const _queue) override;
-					virtual bool RequestValue(uint32 const _requestFlags, uint16 const _index, uint8 const _instance, Driver::MsgQueue const _queue) override;
+					virtual bool RequestState(uint32 const _requestFlags, uint8 const _endPoint, Driver::MsgQueue const _queue) override;
+					virtual bool RequestValue(uint32 const _requestFlags, uint16 const _index, uint8 const _endPoint, Driver::MsgQueue const _queue) override;
 					virtual uint8 const GetCommandClassId() const override
 					{
 						return StaticGetCommandClassId();
@@ -77,11 +77,11 @@ namespace OpenZWave
 					{
 						return StaticGetCommandClassName();
 					}
-					virtual bool HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance = 1) override;
+					virtual bool HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _endPoint = 1) override;
 
 					void RequestAllGroups(uint32 const _requestFlags);
-					void Set(uint8 const _group, uint8 const _nodeId, uint8 const _instance);
-					void Remove(uint8 const _group, uint8 const _nodeId, uint8 const _instance);
+					void Set(uint8 const _group, uint8 const _nodeId, uint8 const _endPoint);
+					void Remove(uint8 const _group, uint8 const _nodeId, uint8 const _endPoint);
 
 				private:
 					MultiChannelAssociation(uint32 const _homeId, uint8 const _nodeId);


### PR DESCRIPTION
Wherever posible, voriables, comments and log suggesting "instance" have been renamed to "endpoint". There is no functional change. It improves readability of the code.

Rationale:

When dealing with MultiInstance Devices, OpenZWave uses "Instance" to identify a subdevice. The public interface maps an Instance ID to an "End Point", which in turn gets used to build Z-Wave packets.
Config files and by extension ozwcache store this map per CC, for example:

<Instance index="1" endpoint="1" />

The Group aka Association commands, however, expect "End Points".
It would make sense to change "Instance" to "End Point" in *all* related code but this is not possible, there is one exception: InstanceAssociation is exposed by the API, in Manager::GetAssociations. Because of its exposure, m_instance cannot be renamed to m_endPoint without breaking existing code.