### PR TITLE
Fix "make test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ ozw_config
 .idea/
 .idea/*
 ozw_config
-
+gtest-main
 cpp/src/command_classes/\.DS_Store

--- a/cpp/test/Makefile
+++ b/cpp/test/Makefile
@@ -9,9 +9,16 @@
 .SUFFIXES:	.d .cpp .o .a
 .PHONY:	default clean
 
+# 2019-10 added this test because there are path issues, hings go wrong when you try to run
+# "make" in the cpp/test subdirectory. One of the offending statements is "top_builddir ?= $(CURDIR)"
+# Needs some work to get a proper fix.
 
-DEBUG_CFLAGS    := -Wall -ggdb -DDEBUG $(CPPFLAGS)
-RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -O3 $(CPPFLAGS)
+ifeq ($(top_builddir),)
+ $(error Variable top_builddir is undefined, please run "make" from root of OpenzWave repository only.)
+endif
+
+DEBUG_CFLAGS    := -std=c++11 -Wall -ggdb -DDEBUG $(CPPFLAGS)
+RELEASE_CFLAGS  := -std=c++11 -Wall -Wno-unknown-pragmas -O3 $(CPPFLAGS)
 
 DEBUG_LDFLAGS	:= -g
 
@@ -21,7 +28,13 @@ top_srcdir := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../)
 LIBDIR  	?= $(top_builddir)
 
 INCLUDES	:= -I $(top_srcdir)/cpp/test/ -I $(top_srcdir)/cpp/test/include/ -I $(top_srcdir)/cpp/src -I $(top_srcdir)/cpp/tinyxml/ -I $(top_srcdir)/cpp/hidapi/hidapi/
-LIBS = $(wildcard $(LIBDIR)/*.a )
+OZW_LIB = $(wildcard $(LIBDIR)/*.a )
+LIBS = $(OZW_LIB)
+
+ifneq ($(UNAME),FreeBSD)
+LIBS += -lresolv
+endif
+
 #LIBSDIR = $(abspath $(dir $(firstword $(LIBS))))
 SOURCES  := $(top_srcdir)/cpp/test/src/ $(top_srcdir)/cpp/test/
 gtestsrc := $(notdir $(wildcard $(top_srcdir)/cpp/test/src/*.cc))
@@ -69,7 +82,7 @@ $(OBJDIR)/%.o : %.cc
 	@$(CXX) $(CFLAGS) $(TARCH) $(INCLUDES) -o $@ $<
 
 $(top_builddir)/gtest-main:	$(patsubst %.cc,$(OBJDIR)/%.o,$(gtestsrc)) \
-	$(patsubst %.cpp,$(OBJDIR)/%.o,$(testsrc))
+	$(patsubst %.cpp,$(OBJDIR)/%.o,$(testsrc)) $(OZW_LIB)
 	@echo "Linking $@"
 	@$(LD) $(LDFLAGS) $(TARCH) -o $@ $+ $(LIBS) -pthread
 

--- a/cpp/test/ValueID_test.cpp
+++ b/cpp/test/ValueID_test.cpp
@@ -28,9 +28,21 @@
 #include "gtest/gtest.h"
 
 #include "value_classes/ValueID.h"
+
 using namespace OpenZWave;
 
-TEST(ValueID, Constructor) {
+extern uint16_t ozw_vers_major;
+extern uint16_t ozw_vers_minor;
+extern uint16_t ozw_vers_revision;
+
+TEST(OpenZWave, Version)
+{
+	EXPECT_EQ(ozw_vers_major, 1);
+	EXPECT_EQ(ozw_vers_minor, 6);
+	EXPECT_GE(ozw_vers_revision, 900);
+}
+TEST(ValueID, Constructor)
+{
 	ValueID *vid = new ValueID(0xFFFF, 0x1, ValueID::ValueGenre_Basic, 0xCC, 0x02, 0x04, ValueID::ValueType_BitSet);
 	EXPECT_EQ(vid->GetCommandClassId(), 0xCC);
 	EXPECT_EQ(vid->GetGenre(), ValueID::ValueGenre_Basic);
@@ -42,7 +54,8 @@ TEST(ValueID, Constructor) {
 	EXPECT_EQ(vid->GetId(), 0x400000133002A);
 	delete vid;
 }
-TEST(ValueID, KeyConstructor) {
+TEST(ValueID, KeyConstructor)
+{
 	ValueID *vid = new ValueID(0xFFFF, (uint64)0x400000133002A);
 	EXPECT_EQ(vid->GetCommandClassId(), 0xCC);
 	EXPECT_EQ(vid->GetGenre(), ValueID::ValueGenre_Basic);
@@ -53,18 +66,12 @@ TEST(ValueID, KeyConstructor) {
 	EXPECT_EQ(vid->GetType(), ValueID::ValueType_BitSet);
 	delete vid;
 }
-TEST(ValueID, Comparision) {
-	ValueID *vid1 = new ValueID(0xFFFF, (uint64)0x400000133002A);
-	ValueID *vid2 = new ValueID(0xFFFF, 0x1, ValueID::ValueGenre_Basic, 0xCC, 0x02, 0x04, ValueID::ValueType_BitSet);
-	ValueID *vid3 = new ValueID(0xFFFF, (uint64)0x01);
-//	EXPECT_TRUE(vid1 == vid2);
-//	EXPECT_TRUE(vid1 != vid3);
-//	EXPECT_FALSE(vid1 == vid3);
-	delete vid1;
-	delete vid2;
-	delete vid3;
+TEST(ValueID, Comparision)
+{
+	EXPECT_EQ(
+		ValueID(0xFFFF, (uint64)0x400000133002A),
+		ValueID(0xFFFF, 0x1, ValueID::ValueGenre_Basic, 0xCC, 0x02, 0x04, ValueID::ValueType_BitSet));
+	EXPECT_NE(
+		ValueID(0xFFFF, (uint64)0x01),
+		ValueID(0xFFFF, 0x1, ValueID::ValueGenre_Basic, 0xCC, 0x02, 0x04, ValueID::ValueType_BitSet));
 }
-
-
-
-


### PR DESCRIPTION
Edit Makefile to clarify "make test" must be run in root of repository.
Add c++11 flag en link resolv library.
Re-enable equality test in cpp/test/ValueID_test.cpp.