### PR TITLE
Making GetValue code more consistent, Releasing values

### DIFF
--- a/cpp/src/command_classes/ClimateControlSchedule.cpp
+++ b/cpp/src/command_classes/ClimateControlSchedule.cpp
@@ -317,6 +317,8 @@ namespace OpenZWave
 							if (Internal::VC::ValueByte* setback = static_cast<Internal::VC::ValueByte*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideSetback)))
 							{
 								Msg* msg = new Msg("ClimateControlScheduleCmd_OverrideSet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
+								// nullptr check after "new" is kind of placebo, but it makes for consistent code
+								// discussion: https://github.com/OpenZWave/open-zwave/pull/1985
 								if (msg != nullptr)
 								{
 									msg->SetInstance(this, instance);
@@ -331,8 +333,20 @@ namespace OpenZWave
 								}
 								setback->Release();
 							}
+							else
+							{
+								Log::Write(LogLevel_Warning, GetNodeId(), "ClimateControlSchedule::SetValue couldn't Find ValueID_Index_ClimateControlSchedule::OverrideSetback");
+							}
+						}
+						else
+						{
+							Log::Write(LogLevel_Warning, GetNodeId(), "ClimateControlSchedule::SetValue state->GetItem() returned nullptr");
 						}
 						state->Release();
+					}
+					else
+					{
+						Log::Write(LogLevel_Warning, GetNodeId(), "ClimateControlSchedule::SetValue couldn't Find ValueID_Index_ClimateControlSchedule::OverrideState");
 					}
 				}
 

--- a/cpp/src/command_classes/ClimateControlSchedule.cpp
+++ b/cpp/src/command_classes/ClimateControlSchedule.cpp
@@ -316,7 +316,6 @@ namespace OpenZWave
 						{
 							if (Internal::VC::ValueByte* setback = static_cast<Internal::VC::ValueByte*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideSetback)))
 							{
-								Internal::VC::ValueList::Item const* item = state->GetItem();
 								Msg* msg = new Msg("ClimateControlScheduleCmd_OverrideSet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
 								if (msg != nullptr)
 								{

--- a/cpp/src/command_classes/ClimateControlSchedule.cpp
+++ b/cpp/src/command_classes/ClimateControlSchedule.cpp
@@ -310,27 +310,30 @@ namespace OpenZWave
 				else
 				{
 					// Set an override
-					Internal::VC::ValueList* state = static_cast<Internal::VC::ValueList*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideState));
-					Internal::VC::ValueByte* setback = static_cast<Internal::VC::ValueByte*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideSetback));
-
-					if (state && setback)
+					if (Internal::VC::ValueList* state = static_cast<Internal::VC::ValueList*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideState)))
 					{
-						Internal::VC::ValueList::Item const *item = state->GetItem();
-						if (item == NULL)
+						if (Internal::VC::ValueList::Item const* item = state->GetItem())
 						{
-							return false;
+							if (Internal::VC::ValueByte* setback = static_cast<Internal::VC::ValueByte*>(GetValue(instance, ValueID_Index_ClimateControlSchedule::OverrideSetback)))
+							{
+								Internal::VC::ValueList::Item const* item = state->GetItem();
+								Msg* msg = new Msg("ClimateControlScheduleCmd_OverrideSet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
+								if (msg != nullptr)
+								{
+									msg->SetInstance(this, instance);
+									msg->Append(GetNodeId());
+									msg->Append(4);
+									msg->Append(GetCommandClassId());
+									msg->Append(ClimateControlScheduleCmd_OverrideSet);
+									msg->Append((uint8)item->m_value);
+									msg->Append(setback->GetValue());
+									msg->Append(GetDriver()->GetTransmitOptions());
+									GetDriver()->SendMsg(msg, Driver::MsgQueue_Send);
+								}
+								setback->Release();
+							}
 						}
-
-						Msg* msg = new Msg("ClimateControlScheduleCmd_OverrideSet", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true, true, FUNC_ID_APPLICATION_COMMAND_HANDLER, GetCommandClassId());
-						msg->SetInstance(this, instance);
-						msg->Append(GetNodeId());
-						msg->Append(4);
-						msg->Append(GetCommandClassId());
-						msg->Append(ClimateControlScheduleCmd_OverrideSet);
-						msg->Append((uint8) item->m_value);
-						msg->Append(setback->GetValue());
-						msg->Append(GetDriver()->GetTransmitOptions());
-						GetDriver()->SendMsg(msg, Driver::MsgQueue_Send);
+						state->Release();
 					}
 				}
 


### PR DESCRIPTION
I noticed throughout application that 95% of the time GetValue is retreived/used via a 'if statement like:

```
			if (Internal::VC::ValueSchedule* value = static_cast<Internal::VC::ValueSchedule*>(driver->GetValue(_id)))
			{
				res = value->.....

```

This is not done on some locations, and could also aid checking against nullptr's
This patch also 'releases' the values
