### PR TITLE
Fix SensorBinary V1 decoding

### DIFF
--- a/cpp/src/command_classes/SensorBinary.cpp
+++ b/cpp/src/command_classes/SensorBinary.cpp
@@ -152,7 +152,7 @@ namespace OpenZWave
 			{
 				if (SensorBinaryCmd_Report == (SensorBinaryCmd) _data[0])
 				{
-					if (_length > 2)
+					if (_length > 3)
 					{
 						uint8 index = m_sensorsMap[_data[2]];
 


### PR DESCRIPTION
I noticed bogus Binary Sensor numbers in the log, for example:

Node002, Received SensorBinary report: Sensor:199 State=On

Based on serial frame:

Received: 0x01, 0x0b, 0x00, 0x04, 0x00, 0x02, 0x03, 0x30, 0x03, 0xff, 0xc7, 0x00, 0xfa

Length of the CC is 0x03, payload is 0x30, 0x03, 0xff, so OZW mistakenly takes next byte as "Sensor Type"

The length test was off by one.

After this patch:

Node002, Received SensorBinary report: State=On

V2 reports still work:

Received: 0x01, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x04, 0x30, 0x03, 0xff, 0x0c, 0x37

Node002, Received SensorBinary report: Sensor:12 State=On

This probably did not cause apparent issues because the bogus sensor type isn't likely to be in the "SensorMap"