### PR TITLE
Make set after get optional

### DIFF
--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -57,7 +57,7 @@ namespace OpenZWave
 // Constructor
 //-----------------------------------------------------------------------------
 			Value::Value(uint32 const _homeId, uint8 const _nodeId, ValueID::ValueGenre const _genre, uint8 const _commandClassId, uint8 const _instance, uint16 const _index, ValueID::ValueType const _type, string const& _label, string const& _units, bool const _readOnly, bool const _writeOnly, bool const _isSet, uint8 const _pollIntensity) :
-					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_id(_homeId, _nodeId, _genre, _commandClassId, _instance, _index, _type), m_units(_units), m_readOnly(_readOnly), m_writeOnly(_writeOnly), m_isSet(_isSet), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(_pollIntensity)
+					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_refreshAfterSet(true), m_id(_homeId, _nodeId, _genre, _commandClassId, _instance, _index, _type), m_units(_units), m_readOnly(_readOnly), m_writeOnly(_writeOnly), m_isSet(_isSet), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(_pollIntensity)
 			{
 				SetLabel(_label);
 			}
@@ -67,7 +67,7 @@ namespace OpenZWave
 // Constructor (from XML)
 //-----------------------------------------------------------------------------
 			Value::Value() :
-					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_readOnly(false), m_writeOnly(false), m_isSet(false), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(0)
+					m_min(0), m_max(0), m_refreshTime(0), m_verifyChanges(false), m_refreshAfterSet(true), m_readOnly(false), m_writeOnly(false), m_isSet(false), m_affectsLength(0), m_affects(), m_affectsAll(false), m_checkChange(false), m_pollIntensity(0)
 			{
 			}
 
@@ -189,6 +189,13 @@ namespace OpenZWave
 					m_verifyChanges = !strcmp(verifyChanges, "true");
 				}
 
+				char const* refreshAfterSet = _valueElement->Attribute( "refresh_after_set" );
+				if( refreshAfterSet )
+				{
+					m_refreshAfterSet = !strcmp(refreshAfterSet, "true");
+				}
+
+
 				if (TIXML_SUCCESS == _valueElement->QueryIntAttribute("min", &intVal))
 				{
 					m_min = intVal;
@@ -237,6 +244,7 @@ namespace OpenZWave
 				_valueElement->SetAttribute("read_only", m_readOnly ? "true" : "false");
 				_valueElement->SetAttribute("write_only", m_writeOnly ? "true" : "false");
 				_valueElement->SetAttribute("verify_changes", m_verifyChanges ? "true" : "false");
+			    _valueElement->SetAttribute("refresh_after_set", m_refreshAfterSet ? "true" : "false");
 
 				snprintf(str, sizeof(str), "%d", m_pollIntensity);
 				_valueElement->SetAttribute("poll_intensity", str);
@@ -300,7 +308,9 @@ namespace OpenZWave
 								if (!IsWriteOnly())
 								{
 									// queue a "RequestValue" message to update the value
-									cc->RequestValue(0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send);
+									if (m_refreshAfterSet) {
+										cc->RequestValue( 0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send );
+									}
 								}
 								else
 								{

--- a/cpp/src/value_classes/Value.h
+++ b/cpp/src/value_classes/Value.h
@@ -125,6 +125,15 @@ namespace OpenZWave
 						return m_verifyChanges;
 					}
 
+					void SetChangeVerified(bool _refreshAfterSet)
+					{
+						m_refreshAfterSet = _refreshAfterSet;
+					}
+					bool GetRefreshAfterSet()
+					{
+						return m_refreshAfterSet;
+					}
+
 					virtual string const GetAsString() const
 					{
 						return "";
@@ -173,6 +182,7 @@ namespace OpenZWave
 
 					time_t m_refreshTime;			// time_t identifying when this value was last refreshed
 					bool m_verifyChanges;		// if true, apparent changes are verified; otherwise, they're not
+					bool m_refreshAfterSet;		// if true, all value sets are followed by a get to refresh the value manually
 					ValueID m_id;
 
 				private:


### PR DESCRIPTION
Resolves #1980 

Patch adds additional parameter to every Z-wave value in config xml: `refresh_after_set`. By default it is turned on (no changed behavior by default), but user can turn it off manually for devices that do not need constant verification.

Smart lighting in my Z-wave network consists solely of recent Aeotec and Fibaro devices that all send SwitchMultiLevel report on their own whenever you update them. By disabling redundant get commands, my network's responsiveness has increased significantly, especially when changing multiple lights at once or when changing color on bulbs.