### PR TITLE
Don't request Instances is Multichannel is "after mark"

### DIFF
--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -461,8 +461,15 @@ void Node::AdvanceQueries()
 				Internal::CC::MultiInstance* micc = static_cast<Internal::CC::MultiInstance*>(GetCommandClass(Internal::CC::MultiInstance::StaticGetCommandClassId()));
 				if (micc)
 				{
-					m_queryPending = micc->RequestInstances();
-					addQSC = m_queryPending;
+					if (micc->IsAfterMark())
+					{
+						Log::Write(LogLevel_Detail, m_nodeId, "Skipping RequestInstances() because MultiChannel CC is \"after mark\"");
+					}
+					else
+					{
+						m_queryPending = micc->RequestInstances();
+						addQSC = m_queryPending;
+					}
 				}
 
 				// when done, advance to the Static stage


### PR DESCRIPTION
IMHO if the Multichannel CC is net before, but only after the "mark" then the device is not multi channel.

Adds log:

2019-12-05 10:34:57.454 Detail, Node004, Skipping RequestInstances() because MultiChannel CC is "after mark"

Fixes "Problems with ZME_WALLC-S after Update from 1.4 to 1.6 - states missing" #2020 by not doing 17 requests that all time out...