### PR TITLE
Make flock(m_hSerialController... actually do something

### DIFF
--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -188,9 +188,10 @@ namespace OpenZWave
 					goto SerialOpenFailure;
 				}
 
-				if (flock(m_hSerialController, LOCK_EX | LOCK_NB) == -1)
+				if (flock(m_hSerialController, LOCK_EX | LOCK_NB) != 0)
 				{
 					Log::Write(LogLevel_Error, "ERROR: Cannot get exclusive lock for serial port %s. Error code %d", device.c_str(), errno);
+					goto SerialOpenFailure;
 				}
 
 				int bits;


### PR DESCRIPTION
I noticed... I could run many instances of MinOZW on the same port, on my Mac, or MinOZW and "picocom" on the same port...

This will make OZW retry as if it failed to open the port.

Prints this if it cannot get an exclusive lock:

ERROR: Cannot get exclusive lock for serial port /dev/cu.usbmodem14101. Error code 35