### PR TITLE
Updates to "OZW revision" (git describe) script on Unix

### DIFF
--- a/cpp/build/support.mk
+++ b/cpp/build/support.mk
@@ -38,14 +38,24 @@ XMLLINT := $(shell which xmllint)
 TMP     := /tmp
 #pkg-config binary for package config files
 PKGCONFIG := $(shell which pkg-config)
-#svn binary for doing a make dist export
+#git binary for doing a make dist export
 GIT		:= $(shell which git)
-# if svnversion is not installed, then set the revision to 0
+# if git is not installed, then set the revision to 0
 ifeq ($(GIT),)
+$(warning  git executable not found, setting VERSION_REV to 0)
 VERSION_REV ?= 0
 else
-GITVERSION	:= $(shell $(GIT) --git-dir $(top_srcdir)/.git describe --long --tags --dirty 2>/dev/null | sed s/^v//)
+_ := $(shell $(GIT) -C $(top_srcdir) update-index --assume-unchanged dist/openzwave.spec 2>&1)
+ifneq ($(_),)
+$(warning  git update-index returned: $(_))
+endif
+GITVERSION	:= $(shell $(GIT) -C $(top_srcdir) describe --long --tags --dirty 2>/dev/null | sed s/^v//)
+_ := $(shell $(GIT) -C $(top_srcdir) update-index --no-assume-unchanged dist/openzwave.spec 2>&1)
+ifneq ($(_),)
+$(warning  git update-index returned: $(_))
+endif
 ifeq ($(GITVERSION),)
+$(warning  git describe returned an empty result, setting GITVERSION to VERSION_MAJ.VERSION_MIN.-1 and VERSION_REV to 0)
 GITVERSION	:= $(VERSION_MAJ).$(VERSION_MIN).-1
 VERSION_REV	:= 0
 else

--- a/dist/openzwave.spec
+++ b/dist/openzwave.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:     openzwave
-Version:  1.6.969
+Version:  1.6.987
 Release:  1.0%{?dist}
 Summary:  Sample Executables for OpenZWave
 URL:      http://www.openzwave.net
@@ -135,7 +135,7 @@ getent group zwave >/dev/null || groupadd -f -r zwave
 
 
 %changelog
-* Wed May 08 2019 Justin Hammond <justin@dynam.ac> - 1.6.969
+* Wed May 08 2019 Justin Hammond <justin@dynam.ac> - 1.6.987
 - Update to new release of OpenZwave - 1.6
 
 * Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.0-0.20180624git1e36dcc.0


### PR DESCRIPTION
Potential fix for git version "dirty" flag.
Might help diagnose "revision on build server always 1.6.0".

When entering support.mk a second time, git describe returns "dirty" flag although I saw no immediate cause.

According to the docs, --git-dir should be used with --work-tree, or use the -C flag, introduced in git 1.8.5-ish.

Added debugging (Makefile warnings).

Tested on macOS Catalina and Debian 8 (Jessie), released 25–26 April 2015. Not tested on Debian 7 (Wheezy), released 4 May 2013 because Wheezy does not come with C++11 compiler by default.

Does not alter the way the version (and its parts) is determined, so still prints eg "Building OpenZWave Version 1.6-987-g555bf05e"

If git is missing, prints a warning: "open-zwave/cpp/build/support.mk:45: git executable not found, setting VERSION_REV to 0".

If git describe should fail... prints warning "support.mk:58: git describe returned an empty result, setting GITVERSION to VERSION_MAJ.VERSION_MIN.-1 and VERSION_REV to 0"