### PR TITLE
Call CheckCompletedNodeQueries in MoveMessagesToWakeUpQueue

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -1432,6 +1432,8 @@ bool Driver::MoveMessagesToWakeUpQueue(uint8 const _targetNodeId, bool const _mo
 
 					m_sendMutex->Unlock();
 
+					CheckCompletedNodeQueries();
+
 					// Move completed successfully
 					return true;
 				}


### PR DESCRIPTION
If a network consists of sleeping nodes (and they sleep) none of the notifications Type_AwakeNodesQueried Type_AllNodesQueriedSomeDead Type_AllNodesQueried is send because all messages are moved to the wake up queue.

Reported by Gilles Printemps, https://groups.google.com/d/msg/openzwave/THGYQ1jqKF4/cZPF5FEDBQAJ

It is a bit of a corner case, and I could not think of an easier way to handle this, I am open to suggestions.