### PR TITLE
Fix a possible infinite loop with invalid list configuration data

### DIFF
--- a/cpp/src/value_classes/ValueList.cpp
+++ b/cpp/src/value_classes/ValueList.cpp
@@ -126,9 +126,8 @@ namespace OpenZWave
 						if (itemElement->QueryIntAttribute("value", &value) != TIXML_SUCCESS)
 						{
 							Log::Write(LogLevel_Warning, "Item value %s is wrong type or does not exist in xml configuration for node %d, class 0x%02x, instance %d, index %d", labelStr, _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
-							continue;
 						}
-						if ((m_size == 1 && value > 255) || (m_size == 2 && value > 65535))
+						else if ((m_size == 1 && value > 255) || (m_size == 2 && value > 65535))
 						{
 							Log::Write(LogLevel_Warning, "Item value %s is incorrect size in xml configuration for node %d, class 0x%02x, instance %d, index %d", labelStr, _nodeId, _commandClassId, GetID().GetInstance(), GetID().GetIndex());
 						}


### PR DESCRIPTION
Before this commit, it is possible to have an infinite loop and log filling with:

"Warning, Item value  is wrong type or does not exist in xml configuration for node 9, class 0x70, instance 1, index 1"

This is because the code skipped "itemElement = itemElement->NextSiblingElement();"

IMHO only happens with corrupt or edited ozwcache file.