### PR TITLE
Update configuration parameter descriptions for Aeotec ZW175

### DIFF
--- a/config/aeotec/zw175.xml
+++ b/config/aeotec/zw175.xml
@@ -1,4 +1,4 @@
-<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
     <MetaData>
         <MetaDataItem name="Name">ZW175 Smart Switch 7</MetaDataItem>
         <MetaDataItem name="Description">
@@ -36,6 +36,7 @@
         <ChangeLog>
             <Entry author="Jean-Francois Auger - nechry@gmail.com" date="01 July 2019" revision="1">Add ZW175 Smart Switch 7</Entry>
             <Entry author="Jean-Francois Auger - nechry@gmail.com" date="03 July 2019" revision="2">Change refresh on node info frame</Entry>
+            <Entry author="Gert van Dijk - gertvdijk@gmail.com" date="09 January 2020" revision="3">Fix description on configuration parameters 101 and 111 (power reporting)</Entry>
         </ChangeLog>
     </MetaData>
     <!-- ZW175 Smart Switch 7 -->
@@ -146,10 +147,10 @@
         <Value genre="config" index="101" label="Configure which meter reading will be periodically report via Lifeline" type="int" units="" value="15">
             <Help>
                 Defines the type of report sent for reporting group 1.
-                1 is meter report for voltage.
-                2 is meter report for current.
-                4 is meter report for watts.
-                8 is meter report for kilowatts.
+                1 is meter report for kilowatts.
+                2 is meter report for watts.
+                4 is meter report for voltage.
+                8 is meter report for current.
                 Value 1 (msb) Reserved
                 Value 2 Reserved
                 Value 3 Reserved
@@ -163,7 +164,7 @@
         <Value genre="config" index="111" label="Configure the sending frequency of Meter Report" max="2592000" min="0" type="int" units="seconds" value="600">
             <Help>
                 0 => Disable.
-                600..2592000 => 600-2592000s. (10minute-30day)
+                30..2592000 => 30-2592000s. (30seconds-30day)
             </Help>
         </Value>
         <Value genre="config" index="255" label="Reset To Factory Defaults" size="4" type="list" value="1" write_only="true">

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -368,8 +368,8 @@
                                               'md5' => '37a2261b83bfc532e64b2aafe3b14be371f2ed9987406bc84588063bc8c0fae1b695325ad5d59bc6618db116504c4a68c74c31b231cca193a9da828ba9445c00'
                                             },
                'config/aeotec/zw175.xml' => {
-                                              'Revision' => '2',
-                                              'md5' => '0c55631d8012d5c723cac19568a743397fa6dcfcdba9b30e9bd062eceec9c5eafd21690fc0fbca9b15f04c570add037f0f67c4053355fd6db994f631fbb0a04c'
+                                              'Revision' => 3,
+                                              'md5' => '1ea7de2ad02c49d24bb0c5d86ddf91cb09d37e3d9b3f64d9802f33f6d5626cd8cf33a18c1d0775f5622f075979415c461a846630ad40212d41998e8a4a970b8d'
                                             },
                'config/aeotec/zw187.xml' => {
                                               'Revision' => '1',


### PR DESCRIPTION
```
I own a few of these devices (with firmware 1.02) and found the
configuration applied did not match the description in Open-Zwave.

- Parameter 101 controls the periodic power reporting. The description
  before this change was all wrong. The Aeotec manual updated November 2019
  [1] appears to be wrong about bits 2 & 3 (values 4 and 8); they seem
  reversed in practice.
- Parameter 111 controls the interval for the periodic power reporting. The
  Aeotec manual updated November 2019 [1] mentions that the minimal
  interval is 30 seconds, not 600. The factory default is 600, though.

[1]: https://aeotec.freshdesk.com/support/solutions/articles/6000219911-smart-switch-7-user-guide-
     (version "Modified on: Wed, 13 Nov, 2019 at 10:45 PM")
```