### PR TITLE
Fix particulate matter spelling

### DIFF
--- a/config/SensorMultiLevelCCTypes.xml
+++ b/config/SensorMultiLevelCCTypes.xml
@@ -139,7 +139,7 @@
 		<SensorScale id="0" name="Celsius">C</SensorScale>
 		<SensorScale id="1" name="Fahrenheit">F</SensorScale>
 	</SensorType>
-	<SensorType id="35" name="Particulate Mater 2.5">
+	<SensorType id="35" name="Particulate Matter 2.5">
 		<SensorScale id="0" name="Mole Per Cubic Meter">mol/m3</SensorScale>
 		<SensorScale id="1" name="Microgram Per Cubic Meter">μg/m3</SensorScale>
 	</SensorType>


### PR DESCRIPTION
Matter is spelled with 2 t's:
https://www.merriam-webster.com/dictionary/matter
https://www.merriam-webster.com/dictionary/mater