### PR TITLE
Qubino ZMNHHDx Mini Dimmer: fix value type of config parameter 65

### DIFF
--- a/config/qubino/ZMNHHDx.xml
+++ b/config/qubino/ZMNHHDx.xml
@@ -1,4 +1,4 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
     <!--
   Qubino: ZMNHHDx Mini Dimmer Z-Wave+
   https://products.z-wavealliance.org/products/3381
@@ -63,10 +63,10 @@
             <Help>2 - 99 = 2% - 99%, step is 1%. Maximum dimming values is set by entered value.
                 Default value 99 (Maximum dimming value is 99%).</Help>
         </Value>
-        <Value genre="config" index="65" instance="1" label="Dimming time (soft on/off)" max="255" min="1" type="short" value="100">
-            <Help>Set value means time of moving the Dimmer between min. and max. dimming values by short press of push button I1 or controlled through.
-                1- 255 = 10mseconds - 2550mseconds (2,55s), step is 10mseconds.
-                Default value 100 (Dimming time between min. and max. dimming values is 1s).</Help>
+        <Value genre="config" index="65" instance="1" label="Dimming time (soft on/off)" max="127" min="1" type="byte" value="1">
+            <Help>Set value means time of moving the Dimmer between min. and max. dimming values by short press of push button I1 or controlled through the controller.
+                1 - 127 = 1 second - 127 seconds.
+                Default value 1 (Dimming time between min. and max. dimming values is 1s).</Help>
         </Value>
         <Value genre="config" index="66" instance="1" label="Dimming time when key hold" max="255" min="1" type="short" value="3">
             <Help>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -2024,8 +2024,8 @@
                                                 'md5' => 'de18029a1539e10dd15fc85ede084182e1cfcbc78325602ca6e5b428884f6db6ce1bebdbea331a8ca0f4ba133828c09f13ce6c1f8486871a5ca9c17258358ba1'
                                               },
                'config/qubino/ZMNHHDx.xml' => {
-                                                'Revision' => 1,
-                                                'md5' => 'd47f8f39a5bdd5d5f5881708761769ccd517dae796e7580f77f8441715a957ed29de74221bff41746b306b461f243dbeaa6ec9d09451b8ba0d97eb2696b465a5'
+                                                'Revision' => 2,
+                                                'md5' => '190639b81177c88bd4a340e96d83578085f35ede860d7bc613bc879e4baff907c951d498696a52d84659936714855efae2a62e183d279957e3a8bda14d949a26'
                                               },
                'config/qubino/ZMNHIA2.xml' => {
                                                 'Revision' => 2,


### PR DESCRIPTION
Adjustments according to the [manual][1] on parameter 65:

* The type is "1 byte dec" corresponding with "byte" in OZW, but this was
  "short", so the device ignored the setting.
* The maximum value is 127, not 255.
* The default value is 1, not 100.
* The description about the valid value range appears untrue (1-255) as
  well as a 10-ms step per value.

Relevant Qubino support interaction in ticket [#4847][2] point 1.

[1]: https://qubino.com/wp-content/uploads/2019/09/Qubino_Mini-Dimmer-PLUS-extended-manual_eng_3.4_09092019.pdf
[2]: https://support.qubino.com/public/tickets/cc6122dca894548e0b935144554a874e3da214108f079fbe34cc51b429ae3891