### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/cpp/src/command_classes/Configuration.cpp
+++ b/cpp/src/command_classes/Configuration.cpp
@@ -66,7 +66,7 @@ namespace OpenZWave
 			};
 
 			uint32 Configuration::getField(const uint8 *data, CC_Param_Size size, uint8 &pos) {
-				uint32 value;
+				uint32 value = 0;
 				switch (size) {
 					case CC_Param_Size::CC_Param_Size_Byte:
 						value = data[pos++];
@@ -79,6 +79,9 @@ namespace OpenZWave
 						break;
 					case CC_Param_Size::CC_Param_Size_Unassigned:
 						value = 0;
+						break;
+					default:
+						Log::Write(LogLevel_Error, "Unhandled CC_Param_Size %u", size);
 						break;
 				}
 				return value;


### PR DESCRIPTION
Fix maybe-uninitialized warning:

```
#5 80.71 Building src/command_classes/Configuration.cpp
#5 82.11 /src/open-zwave/cpp/src/command_classes/Configuration.cpp: In member function 'uint32 OpenZWave::Internal::CC::Configuration::getField(const uint8*, OpenZWave::Internal::CC::Configuration::CC_Param_Size, uint8&)':
#5 82.11 /src/open-zwave/cpp/src/command_classes/Configuration.cpp:84:12: error: 'value' may be used uninitialized in this function [-Werror=maybe-uninitialized]
#5 82.11    84 |     return value;
#5 82.11       |            ^~~~~
#5 82.88 cc1plus: all warnings being treated as errors
#5 82.90 make[1]: *** [/src/open-zwave/cpp/build/support.mk:192: /src/open-zwave/.lib/Configuration.o] Error 1
#5 82.90 make[1]: Leaving directory '/src/open-zwave/cpp/build'
#5 82.90 make: *** [Makefile:23: all] Error 2

```