### PR TITLE
Adds North American ID information for Aeotec ZW164-A

### DIFF
--- a/config/aeotec/zw164.xml
+++ b/config/aeotec/zw164.xml
@@ -2,13 +2,16 @@
 Aeotec ZW164 Indoor Siren 6
 -->
 
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0086:00a4:0003</MetaDataItem>
     <MetaDataItem name="ProductPic">images/aeotec/zw164.png</MetaDataItem>
     <MetaDataItem id="00a4" name="Identifier" type="0003">ZW164-C</MetaDataItem>
     <MetaDataItem id="00a4" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/3301/</MetaDataItem>
     <MetaDataItem id="00a4" name="FrequencyName" type="0003">CEPT (Europe)</MetaDataItem>
+    <MetaDataItem id="00a4" name="Identifier" type="0103">ZW164-A</MetaDataItem>
+    <MetaDataItem id="00a4" name="ZWProductPage" type="0103">https://products.z-wavealliance.org/products/3284/</MetaDataItem>
+    <MetaDataItem id="00a4" name="FrequencyName" type="0103">U.S. / Canada / Mexico</MetaDataItem>
     <MetaDataItem name="WakeupDescription"></MetaDataItem>
     <MetaDataItem name="InclusionDescription">This product supports Security 2 Command Class. While a Security S2 enabled Controller is needed in order to fully use the security feature. This product can be included and operated in any Z-Wave network with other Z-Wave certified devices from other manufacturers and/or other applications. All non-battery operated nodes within the network will act as repeaters regardless of vendor to increase reliability of the network. 1. Set your Z-Wave Controller into its 'Add Device' mode in order to add Chime into your Z-Wave system. Refer to the Controller's manual if you are unsure of how to perform this step. 2. Power on Chime via the provided power adapter; its LED will be breathing white light all the time. 3. Click Chime Action Button once, it will quickly flash white light for 30 seconds until Chime is added into the network. It will become constantly bright white light after being assigned a NodeID. 4. If your Z-Wave Controller supports S2 encryption, enter the first 5 digits of DSK into your Controller's interface if/when requested. The DSK is printed on Chime's housing. 5. If Adding fails, it will slowly flash white light 3 times and then become breathing white light; repeat steps 1 to 4. Contact us for further support if needed. 6. If Adding succeeds, it will quickly flash white light 3 times and then become off. Now, Chime is a part of your Z-Wave home control system. You can configure it and its automations via your Z-Wave system; please refer to your software's user guide for precise instructions. Note: If Action Button is clicked again during the Learn Mode, the Learn Mode will exit. At the same time, Indicator Light will extinguish immediately, and then become breathing white light.</MetaDataItem>
     <MetaDataItem name="Name">Indoor Siren 6</MetaDataItem>
@@ -18,6 +21,7 @@ Aeotec ZW164 Indoor Siren 6
     <MetaDataItem name="ProductManual">https://Products.Z-WaveAlliance.org/ProductManual/File?folder=&amp;filename=Manuals/3301/Indoor%20Siren%206%20product%20manual.pdf</MetaDataItem>
     <ChangeLog>
       <Entry author="Geert van Horrik - @GeertvanHorrik" date="28 Jul 2019" revision="1">Add metadata for aeotec indoor siren 6 #1894</Entry>
+      <Entry author="Matt Belhorn - matt.belhorn@gmail.com" date="28 Feb 2020" revision="2">Add metadata for North American model - https://products.z-wavealliance.org/products/3284</Entry>
     </ChangeLog>
   </MetaData>
 

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="81" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="82" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>
@@ -220,6 +220,7 @@
     <Product config="aeotec/zw141.xml" id="008d" name="ZW141 Nano Shutter" type="0103"/>  
     <Product config="aeotec/zw141.xml" id="008d" name="ZW141 Nano Shutter" type="0203"/>  	  
     <Product config="aeotec/zw164.xml" id="00a4" name="ZW164 Indoor Siren 6" type="0003"/>
+    <Product config="aeotec/zw164.xml" id="00a4" name="ZW164 Indoor Siren 6" type="0103"/>
     <Product config="aeotec/zw175.xml" id="00af" name="ZW175 Smart Switch 7" type="0003"/>
     <Product config="aeotec/zw187.xml" id="00bb" name="ZW187 Recessed Door Sensor 7" type="0002"/>
     <Product config="aeotec/zw187.xml" id="00bb" name="ZW187 Recessed Door Sensor 7" type="0102"/>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -364,8 +364,8 @@
                                               'md5' => '82b17ed662bd1f3d1faeabe294df9f69a72641282531946c71386c92214ec33a08d49655423d3ebe044db3b6bbe962485a108596573bd1eb7c8ba45c542c8764'
                                             },
                'config/aeotec/zw164.xml' => {
-                                              'Revision' => 1,
-                                              'md5' => '37a2261b83bfc532e64b2aafe3b14be371f2ed9987406bc84588063bc8c0fae1b695325ad5d59bc6618db116504c4a68c74c31b231cca193a9da828ba9445c00'
+                                              'Revision' => 2,
+                                              'md5' => 'ccfd9832b957c32bcdfeee2ad8802dc577e621df4d71ebfcdc3f166d67a5af5da9b789ffc53163fa2f62183ac463b29a8845fb7a8c3e7845d264bb8f7f6c2828'
                                             },
                'config/aeotec/zw175.xml' => {
                                               'Revision' => 3,
@@ -1704,8 +1704,8 @@
                                                    'md5' => '4d34aeaaea917c229bedbb737e4de1550b2d7db5f9e61566a1c0a39966b6442d381d01f93714e12aae1404797d36854274cc4063dd7424b00d27da238b17a36a'
                                                  },
                'config/manufacturer_specific.xml' => {
-                                                       'Revision' => 81,
-                                                       'md5' => '224b919432a66d0f76f7396c3374728adc4e25e638a12883639df10cd028c6b4f094d494c875f4cb658615402e02573f6a35454f20efcacbd5436ca423a053e0'
+                                                       'Revision' => 82,
+                                                       'md5' => 'd4678606995322c453c5c54ad376e12849ac4f6469f037cd1a33e8f0027d013234d2abe686cd9938c0d384dbb34ee7818fc375e959b4c3d61383f2c3b154622a'
                                                      },
                'config/mcohome/a8-9.xml' => {
                                               'Revision' => 1,


### PR DESCRIPTION
Adds identifier information for the North American frequency region version of the Aeotec Siren 6 (ZW164-A) to the existing device configuration metadata.

This information was fetched from the [Z-Wave Alliance data for the Aeotec Siren 6 ZW164-A](https://products.z-wavealliance.org/products/3284).