### PR TITLE
parameter 12 has wrong default in description

### DIFF
--- a/config/fibaro/fgsd002.xml
+++ b/config/fibaro/fgsd002.xml
@@ -1,4 +1,4 @@
-<Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/010F:1002:0C02</MetaDataItem>
     <MetaDataItem name="ProductPic">images/fibaro/fgsd002.png</MetaDataItem>
@@ -33,7 +33,8 @@ https://www.youtube.com/watch?v=50QGfkdUtns
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="08 May 2019" revision="5">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1273/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2837/xml</Entry>
-    </ChangeLog>
+      <Entry author="J van Berlo - jvberlo@hotmail.com" date="22 Mar 2020" revision="7">Updated Text for parameter 12</Entry>
+  </ChangeLog>
     <MetaDataItem id="1003" name="ZWProductPage" type="0C02">https://products.z-wavealliance.org/products/2837/</MetaDataItem>
     <MetaDataItem id="1003" name="Identifier" type="0C02">FGSD-002</MetaDataItem>
     <MetaDataItem id="1003" name="FrequencyName" type="0C02">CEPT (Europe)</MetaDataItem>

--- a/config/fibaro/fgsd002.xml
+++ b/config/fibaro/fgsd002.xml
@@ -82,10 +82,10 @@ https://www.youtube.com/watch?v=50QGfkdUtns
       <Item label="BASIC OFF enabled" value="2"/>
     </Value>
     <Value genre="config" index="11" instance="1" label="BASIC ON frame value" max="255" min="0" type="byte" value="255">
-      <Help>BASIC ON frame is sent in case of smoke presence detection and FIRE ALARM triggering. Available settings: (1 - 99) or 255. Default setting: 255</Help>
+      <Help>BASIC ON frame is sent in case of smoke presence detection and FIRE ALARM triggering. Available settings: 0,(1 - 99) or 255. Default setting: 255</Help>
     </Value>
     <Value genre="config" index="12" instance="1" label="BASIC OFF frame value" max="255" min="0" type="byte" value="0">
-      <Help>BASIC OFF frame is sent in case of FIRE ALARM cancellation. Available settings: (1 - 99) or 255. Default setting: 255</Help>
+      <Help>BASIC OFF frame is sent in case of FIRE ALARM cancellation. Available settings: 0,(1 - 99) or 255. Default setting: 0</Help>
     </Value>
     <Value genre="config" index="13" instance="1" label="Alarm broadcast" max="4" min="0" size="1" type="list" value="0">
       <Help>A value other than 0 means that alarms are being sent in broadcast mode, i.e. to all devices within a Fibaro Smoke Sensor's range.</Help>


### PR DESCRIPTION
according the fibaro website the default for parameter 12 is 0 and not 255. This is now corrected