### PR TITLE
Rename Serial Version to Firmware Version and add Communication and Chip Version

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -114,7 +114,7 @@ static char const* c_sendQueueNames[] =
 //-----------------------------------------------------------------------------
 Driver::Driver(string const& _controllerPath, ControllerInterface const& _interface) :
 		m_driverThread(new Internal::Platform::Thread("driver")), m_dns(new Internal::DNSThread(this)), m_dnsThread(new Internal::Platform::Thread("dns")), m_initMutex(new Internal::Platform::Mutex()), m_exit(false), m_init(false), m_awakeNodesQueried(false), m_allNodesQueried(false), m_notifytransactions(false), m_timer(new Internal::TimerThread(this)), m_timerThread(new Internal::Platform::Thread("timer")), m_controllerInterfaceType(_interface), m_controllerPath(_controllerPath), m_controller(
-				NULL), m_homeId(0), m_libraryVersion(""), m_libraryTypeName(""), m_libraryType(0), m_manufacturerId(0), m_productType(0), m_productId(0), m_rfregion(ZW_RFRegion::RF_REGION_UNKNOWN), m_initVersion(0), m_initCaps(0), m_controllerCaps(0), m_Controller_nodeId(0), m_nodeMutex(new Internal::Platform::Mutex()), m_controllerReplication( NULL), m_transmitOptions( TRANSMIT_OPTION_ACK | TRANSMIT_OPTION_AUTO_ROUTE | TRANSMIT_OPTION_EXPLORE), m_waitingForAck(false), m_expectedCallbackId(0), m_expectedReply(0), m_expectedCommandClassId(
+				NULL), m_homeId(0), m_libraryVersion(""), m_libraryTypeName(""), m_libraryType(0), m_manufacturerId(0), m_productType(0), m_productId(0), m_rfregion(ZW_RFRegion::RF_REGION_UNKNOWN), m_initVersion(0), m_chipType(0), m_chipVersion(0), m_initCaps(0), m_controllerCaps(0), m_Controller_nodeId(0), m_nodeMutex(new Internal::Platform::Mutex()), m_controllerReplication( NULL), m_transmitOptions( TRANSMIT_OPTION_ACK | TRANSMIT_OPTION_AUTO_ROUTE | TRANSMIT_OPTION_EXPLORE), m_waitingForAck(false), m_expectedCallbackId(0), m_expectedReply(0), m_expectedCommandClassId(
 				0), m_expectedNodeId(0), m_pollThread(new Internal::Platform::Thread("poll")), m_pollMutex(new Internal::Platform::Mutex()), m_pollInterval(0), m_bIntervalBetweenPolls(false),				// if set to true (via SetPollInterval), the pollInterval will be interspersed between each poll (so a much smaller m_pollInterval like 100, 500, or 1,000 may be appropriate)
 		m_currentControllerCommand( NULL), m_SUCNodeId(0), m_controllerResetEvent( NULL), m_sendMutex(new Internal::Platform::Mutex()), m_currentMsg( NULL), m_notificationsEvent(new Internal::Platform::Event()), m_SOFCnt(0), m_ACKWaiting(0), m_readAborts(0), m_badChecksum(0), m_readCnt(0), m_writeCnt(0), m_CANCnt(0), m_NAKCnt(0), m_ACKCnt(0), m_OOFCnt(0), m_dropped(0), m_retries(0), m_callbacks(0), m_badroutes(0), m_noack(0), m_netbusy(0), m_notidle(0), m_txverified(
 				0), m_nondelivery(0), m_routedbusy(0), m_broadcastReadCnt(0), m_broadcastWriteCnt(0), AuthKey(0), EncryptKey(0), m_nonceReportSent(0), m_nonceReportSentAttempt(0), m_queueMsgEvent(new Internal::Platform::Event()), m_eventMutex(new Internal::Platform::Mutex())
@@ -2833,6 +2833,10 @@ void Driver::HandleSerialAPIGetInitDataResponse(uint8* _data)
 
 	if (_data[4] == NUM_NODE_BITFIELD_BYTES)
 	{
+		m_chipType = _data[5+NUM_NODE_BITFIELD_BYTES];
+		Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Chip Type: %d", m_chipType);
+		m_chipVersion = _data[6+NUM_NODE_BITFIELD_BYTES];
+		Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Chip Version: %d", m_chipVersion);
 		for (i = 0; i < NUM_NODE_BITFIELD_BYTES; ++i)
 		{
 			for (int32 j = 0; j < 8; ++j)

--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -2610,7 +2610,7 @@ void Driver::HandleGetControllerCapabilitiesResponse(uint8* _data)
 void Driver::HandleGetSerialAPICapabilitiesResponse(uint8* _data)
 {
 	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), " Received reply to FUNC_ID_SERIAL_API_GET_CAPABILITIES");
-	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Serial API Version:   %d.%d", _data[2], _data[3]);
+	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Firmware Version:     %d.%d", _data[2], _data[3]);
 	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Manufacturer ID:      0x%.2x%.2x", _data[4], _data[5]);
 	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Product Type:         0x%.2x%.2x", _data[6], _data[7]);
 	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Product ID:           0x%.2x%.2x", _data[8], _data[9]);
@@ -2828,6 +2828,7 @@ void Driver::HandleSerialAPIGetInitDataResponse(uint8* _data)
 
 	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "Received reply to FUNC_ID_SERIAL_API_GET_INIT_DATA:");
 	m_initVersion = _data[2];
+	Log::Write(LogLevel_Info, GetNodeNumber(m_currentMsg), "    Communication Interface Version: %d", m_initVersion);
 	m_initCaps = _data[3];
 
 	if (_data[4] == NUM_NODE_BITFIELD_BYTES)

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -344,8 +344,10 @@ namespace OpenZWave
 			uint8 m_serialapiMask;							// FUNC_ID_SERIAL_API_SETUP Commands Supported
 			ZW_RFRegion m_rfregion;
 
-			uint8 m_initVersion;								// Version of the Serial API used by the controller.
-			uint8 m_initCaps;									// Set of flags indicating the serial API capabilities (See IsSlave, HasTimerSupport, IsPrimaryController and IsStaticUpdateController above).
+			uint8 m_initVersion;							// Version of the Serial API used by the controller.
+			uint8 m_chipType;								// See INS12350-17 - Serial API Host Appl. Prg. Guide.pdf.pdf FUNC_ID_SERIAL_API_GET_INIT_DATA
+			uint8 m_chipVersion;
+			uint8 m_initCaps;								// Set of flags indicating the serial API capabilities (See IsSlave, HasTimerSupport, IsPrimaryController and IsStaticUpdateController above).
 			uint8 m_controllerCaps;							// Set of flags indicating the controller's capabilities (See IsInclusionController above).
 			bool m_hasExtendedTxStatus;						// True if the controller accepted SERIAL_API_SETUP_CMD_TX_STATUS_REPORT
 			uint8 m_Controller_nodeId;						// Z-Wave Controller's own node ID.


### PR DESCRIPTION
1 - Motivation for the rename logging of "Serial API Version" to "Firmware Version":

a) "Serial API Version" is confusing, the serial IP does indeed have a "version" but that is not this one.

b) The spec calls it an "application version"... And that is what end-users commonly know as "firmware version"

INS12350-17 Serial API Host Appl. Prg. Guide
7.3 Capabilities Command
FUNC_ID_SERIAL_API_GET_CAPABILITIES

ZW->HOST: RES | 0x07 | SERIAL_APPL_VERSION | SERIAL_APPL_REVISION | SERIALAPI_MANUFACTURER_ID1 | SERIALAPI_MANUFACTURER_ID2 | SERIALAPI_MANUFACTURER_PRODUCT_TYPE1 | SERIALAPI_MANUFACTURER_PRODUCT_TYPE2 | SERIALAPI_MANUFACTURER_PRODUCT_ID1 | SERIALAPI_MANUFACTURER_PRODUCT_ID2 | FUNCID_SUPPORTED_BITMASK[ ]

SERIAL_APPL_VERSION is the Serial API application Version number.
SERIAL_APPL_REVISION is the Serial API application Revision number.

Notice it is not "Serial API Version number" but "Serial API *application* Version number"

That's why I would log it as "Firmware Version"

The result on 3 of my dongles:

- A somewhat older Z-Wave.me UZB1 prints 5.6 which is correct (though sometimes printed as 5.06 because the dot is not a decimal separator)
- A recent UZB7 prints 7.0 which I did not check but sounds reasonable enough
- A Reference Implementation of a controller prints 6.8 which matches its definition

2 - Motivation for printing "Communication Version"

As discussed in issue https://github.com/OpenZWave/open-zwave/issues/2129 the "Serial Version" is a number between 1 and 8 and can inform us of the capabilities of the controller (documented in INS12350)

For example... My 3 dongles...

- Z-Wave.me UZB1 prints

```
Info, contrlr, Received reply to FUNC_ID_SERIAL_API_GET_INIT_DATA:
Info, contrlr,     Communication Interface Version: 6
```

This means that with this firmware, my controller supports "Extended Status Information" but does not do "Smartwtart

-  UZB7 prints "8" so supports S2 and "Smart Start"
- My reference controller also prints "8" which matches the capabilities of the SDK it was based on...

ATM I do not have a series 300 controller to test with.

BTW this does not answer the question "is this a ZW-Plus" controller but I think this information is useful regardless.
