### PR TITLE
Fix snprintf truncated value

### DIFF
--- a/cpp/src/command_classes/Configuration.cpp
+++ b/cpp/src/command_classes/Configuration.cpp
@@ -260,7 +260,7 @@ namespace OpenZWave
 					else
 					{
 						char label[16];
-						snprintf(label, 16, "Parameter #%d", parameter);
+						snprintf(label, 16, "Parameter #%hu", parameter);
 
 						// Create a new value
 						if (Node* node = GetNodeUnsafe())


### PR DESCRIPTION
Fixed compile time warning on Ubuntu 19 arm64:

```
Building src/command_classes/Configuration.cpp
/home/ubuntu/github/open-zwave/cpp/src/command_classes/Configuration.cpp: In member function ‘virtual bool OpenZWave::Internal::CC::Configuration::HandleMsg(const uint8*, uint32, uint32)’:
/home/ubuntu/github/open-zwave/cpp/src/command_classes/Configuration.cpp:263:41: error: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Werror=format-truncation=]
  263 |       snprintf(label, 16, "Parameter #%d", parameter);
      |                                         ^
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /home/ubuntu/github/open-zwave/cpp/src/command_classes/CommandClasses.h:31,
                 from /home/ubuntu/github/open-zwave/cpp/src/command_classes/Configuration.cpp:28:
/usr/include/aarch64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 13 and 17 bytes into a destination of size 16
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [/home/ubuntu/github/open-zwave/cpp/build/support.mk:192: /home/ubuntu/github/open-zwave/.lib/Configuration.o] Error 1
make[1]: Leaving directory '/home/ubuntu/github/open-zwave/cpp/build'
make: *** [Makefile:23: all] Error 2
```

Do the CI builds treat warnings as errors? Might as well since things are pretty clean.