### PR TITLE
Add MFS entry for Silicon Labs USB3 Z-Wave USB stick

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ManufacturerSpecificData Revision="86" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="87" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>
@@ -1820,6 +1820,7 @@
   <Manufacturer id="037D" name="Xiamen AcTEC Electronics"></Manufacturer>
   <Manufacturer id="0000" name="Z-Wave (Sigma Designs)">
     <Product id="0001" name="UZB Z-Wave USB Adapter" type="0001"/>
+    <Product id="0008" name="UZB3 Z-Wave USB Adapter" type="0003"/>
   </Manufacturer>
   <Manufacturer id="031D" name="Z-Wave Alliance"></Manufacturer>
   <Manufacturer id="004F" name="Z-Wave Technologia"></Manufacturer>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1712,8 +1712,8 @@
                                                    'md5' => '4d34aeaaea917c229bedbb737e4de1550b2d7db5f9e61566a1c0a39966b6442d381d01f93714e12aae1404797d36854274cc4063dd7424b00d27da238b17a36a'
                                                  },
                'config/manufacturer_specific.xml' => {
-                                                       'Revision' => 86,
-                                                       'md5' => '4d22a019e498044696e57d6cdbd562e2cf28ed3250b1e2d697ebfe2959c1d345b340c798e918215717658dd611d373ff13382a8cca6e2add12baad9f42bb839f'
+                                                       'Revision' => 87,
+                                                       'md5' => '1f0c8f3b5fa306167fa94ae91471f43f6472a8c370e17754d473ad63f545246ccd17c287833c6b16dd5a56378389acd1d346c9348d1af9a4bd2c0cf59f65f06e'
                                                      },
                'config/mcohome/a8-9.xml' => {
                                               'Revision' => 1,
@@ -2704,16 +2704,16 @@
                                             'md5' => '047323e2ed1a3e5340c052d40737fbdb2d2790e225e002f7d58fa3ad32f592da3e2a8cc0f3dd6cc6f06f7b6b505378482be7125db0a335e56abfd478c1cb398b'
                                           },
                'config/zooz/zen21v2.xml' => {
-                                              'Revision' => 1,
-                                              'md5' => '3891b1d08aac36a6c37ac96fc3015947bd5119305c066600a3a16231f7c171dbc3893dbb1cf654d9fec1f2c01fd62e3d6cc635f2afd186e21f87ac8fe1529293'
+                                              'Revision' => 2,
+                                              'md5' => '004dd989826be59c166af2103c5363c53be87aada839dc7b54c5396c8b9e75f00c4103a975f759fbd05aa24160844ec5f6c3960df2a56f40b40691c1db0c8420'
                                             },
                'config/zooz/zen22.xml' => {
                                             'Revision' => 2,
                                             'md5' => '5516b28dbfb21fa8057cf83e04100d7e27a74d6bffa5c8203924fbd139ffee8536552307cab4c29dc92f4d762c99e357eb5f86641bae733fb226d67fab9b09a5'
                                           },
                'config/zooz/zen22v2.xml' => {
-                                              'Revision' => 2,
-                                              'md5' => 'd10939f4a17ad1f5de7bf463da453c29320ad97c8abcb8cf8caaf8e6ea424600013db19a559853d7f526bb8eeeda21ea5dda8cebef538ac7a499375da56c91f4'
+                                              'Revision' => 3,
+                                              'md5' => 'ea4ce1d9800d69e6e04c4ea5317a891575ee49f751f66754f0371bf9894b19504b90b3c8e80c509a8f458d4e989111b21facc9d0cd6740dcddca1e01dc678039'
                                             },
                'config/zooz/zen23.xml' => {
                                             'Revision' => 1,
@@ -2728,16 +2728,16 @@
                                             'md5' => 'a1518c737c0eb0b63610dca95ebece7df7be426b8b435fb309314f110c77ddb90146d0b03888d2ac03959b2bfd6d181edb7b71cc59c798aeb7f5fa341c4f0d4d'
                                           },
                'config/zooz/zen26.xml' => {
-                                            'Revision' => 3,
-                                            'md5' => 'a29881e72eda6f6f3e7f649efa58c8ee1ac1728985c37885a7fd987d9685bcb7d50306a6a72b42f3fad06935fa56f4cc3a50bbd13852d5d56ded7468897f2584'
+                                            'Revision' => 4,
+                                            'md5' => 'c416e8c6296c859c66c9b5817d2a0f4e2d805830019c215e95b4cc160bc95d040f974ee074c96a2c1318c790a91b152665372d2bdb1dcdeef86eef935f741c17'
                                           },
                'config/zooz/zen27.xml' => {
-                                            'Revision' => 2,
-                                            'md5' => '5ab98630896730c87473681c02bb78e6774818f447d47abbc4da4b2c2560ed23b5e2b1ace378c942eb65ad8cb9794ebe038fc2bb68e62c3f6e1ece9df2fb05ef'
+                                            'Revision' => 3,
+                                            'md5' => '643a5055528a07e8c489b9c281bbaf1eb107b763428c69a3769410a7387e2a61677c33e7b471eec0ce9bc8799ddf62808bea54ce92c6f83a431d851dc6b426f4'
                                           },
                'config/zooz/zen30.xml' => {
-                                            'Revision' => 2,
-                                            'md5' => '1560513ab406fcea1460dcec1a3ac1a5e693bb893b289692180261fe12336cb079408e2607c9fd63a04e1b1b4cc381059d3bd0f26a8d804c4d1399901a025401'
+                                            'Revision' => 3,
+                                            'md5' => '97c43b277e9ebdad3e538426470242ddf856e571495ffefe0b64cf6d89c1d654412bfa59a12a89ec0970637ea8cc473d6693802bda28f2190176a007cb9b0f10'
                                           },
                'config/zooz/zen31.xml' => {
                                             'Revision' => 2,


### PR DESCRIPTION
Add an entry in the MFS for the Silicon Labs (was Sigma) UZB3 Z-Wave USB stick.

`make xmltest` updated file testconfigversions.cfg for some device files I did not touch. I presume they were not updated from another PR.