### PR TITLE
Align unit for Watts, Watt, W

### DIFF
--- a/config/aeotec/dsb09104.xml
+++ b/config/aeotec/dsb09104.xml
@@ -31,22 +31,22 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584509
 	Automatic report only when power is changed.
       </Help>
     </Value>
-    <Value genre="config" index="4" label="Wattage Threshold" type="short" units="watts" value="50">
+    <Value genre="config" index="4" label="Wattage Threshold" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (whole HEM).
       </Help>
     </Value>
-    <Value genre="config" index="5" label="Wattage Threshold C1" type="short" units="watts" value="50">
+    <Value genre="config" index="5" label="Wattage Threshold C1" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 1).
       </Help>
     </Value>
-    <Value genre="config" index="6" label="Wattage Threshold C2" type="short" units="watts" value="50">
+    <Value genre="config" index="6" label="Wattage Threshold C2" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 2).
       </Help>
     </Value>
-    <Value genre="config" index="7" label="Wattage Threshold C3" type="short" units="watts" value="50">
+    <Value genre="config" index="7" label="Wattage Threshold C3" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 3).
       </Help>

--- a/config/aeotec/dsb28.xml
+++ b/config/aeotec/dsb28.xml
@@ -34,22 +34,22 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584508
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="4" label="Wattage Threshold" type="short" units="watts" value="50">
+    <Value genre="config" index="4" label="Wattage Threshold" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (whole HEM).
       </Help>
     </Value>
-    <Value genre="config" index="5" label="Wattage Threshold C1" type="short" units="watts" value="50">
+    <Value genre="config" index="5" label="Wattage Threshold C1" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 1).
       </Help>
     </Value>
-    <Value genre="config" index="6" label="Wattage Threshold C2" type="short" units="watts" value="50">
+    <Value genre="config" index="6" label="Wattage Threshold C2" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 2).
       </Help>
     </Value>
-    <Value genre="config" index="7" label="Wattage Threshold C3" type="short" units="watts" value="50">
+    <Value genre="config" index="7" label="Wattage Threshold C3" type="short" units="W" value="50">
       <Help>
 	Threshold change in wattage to induce a automatic report (Clamp 3).
       </Help>

--- a/config/aeotec/dsc06106.xml
+++ b/config/aeotec/dsc06106.xml
@@ -45,7 +45,7 @@ With an unobtrusive small form factor, the Aeon Labs Smart Energy Switch will no
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="W" value="50">
       <Help>
 	The minimum change in wattage for a report to be sent.
       </Help>

--- a/config/aeotec/dsc10.xml
+++ b/config/aeotec/dsc10.xml
@@ -46,7 +46,7 @@ Aeotec DSC10 Heavy-Duty Smart Switch
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="W" value="50">
       <Help>
 	The minimum change in wattage for a report to be sent.
       </Help>

--- a/config/aeotec/dsc11.xml
+++ b/config/aeotec/dsc11.xml
@@ -23,25 +23,25 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584527
       <Item label="Disable," value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="5" label="Whole Smart Strip Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="5" label="Whole Smart Strip Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Whole Smart Strip).</Help>
     </Value>
-    <Value genre="config" index="6" label="Socket 1 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="6" label="Socket 1 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 1).</Help>
     </Value>
-    <Value genre="config" index="7" label="Socket 2 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="7" label="Socket 2 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 2).</Help>
     </Value>
-    <Value genre="config" index="8" label="Socket 3 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="8" label="Socket 3 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 3).</Help>
     </Value>
-    <Value genre="config" index="9" label="Socket 4 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="9" label="Socket 4 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 4).</Help>
     </Value>
-    <Value genre="config" index="10" label="Socket 5 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="10" label="Socket 5 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 5).</Help>
     </Value>
-    <Value genre="config" index="11" label="Socket 6 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="11" label="Socket 6 Minimum Change to send Report (Watt) " max="60000" min="0" size="2" type="short" units="W" value="25">
       <Help>Threshold change in wattage to induce an automatic report (Socket 6).</Help>
     </Value>
     <Value genre="config" index="12" label="Whole Smart Strip Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/dsc12104.xml
+++ b/config/aeotec/dsc12104.xml
@@ -29,7 +29,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584526
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value type="short" index="91" genre="config" label="Wattage threshold" units="watts" min="0" max="32000" value="50">
+    <Value type="short" index="91" genre="config" label="Wattage threshold" units="W" min="0" max="32000" value="50">
       <Help>
 	The minimum change in wattage for a report to be sent.
       </Help>

--- a/config/aeotec/dsc13104.xml
+++ b/config/aeotec/dsc13104.xml
@@ -25,7 +25,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584519
     <Value type="bool" index="90" genre="config" label="Enables/disables parameter 91/92" units="" value="0">
       <Help>Enable/disable Wattage threshold and percent.</Help>
     </Value>
-    <Value type="short" index="91" genre="config" label="Minimum Change to send Report (Watt)" units="watts" min="0" max="32000" size="2" value="25">
+    <Value type="short" index="91" genre="config" label="Minimum Change to send Report (Watt)" units="W" min="0" max="32000" size="2" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value type="byte" index="92" genre="config" label="Minimum Change to send Report (%)" units="%" min="0" max="100" value="5">

--- a/config/aeotec/dsc18103.xml
+++ b/config/aeotec/dsc18103.xml
@@ -47,7 +47,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584524
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="W" value="50">
       <Help>
 	The minimum change in wattage for a report to be sent.
       </Help>

--- a/config/aeotec/dsc19103.xml
+++ b/config/aeotec/dsc19103.xml
@@ -55,7 +55,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584517
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="W" value="50">
       <Help>
 	The minimum change in wattage for a report to be sent.
       </Help>

--- a/config/aeotec/dsc24.xml
+++ b/config/aeotec/dsc24.xml
@@ -53,7 +53,7 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584528
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw075.xml
+++ b/config/aeotec/zw075.xml
@@ -64,7 +64,7 @@ Also a tool that can be programmed, scheduled, controlled and communicated with 
     <Value genre="config" index="90" label="Enables/disables parameter 91/92" type="bool" units="" value="0">
       <Help>Enable/disable Wattage threshold and percent.</Help>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw078.xml
+++ b/config/aeotec/zw078.xml
@@ -60,7 +60,7 @@ By taking advantage of the Z-Wave mesh network, commands can be routed to their 
     <Value genre="config" index="90" label="Enable Wattage Reports" type="bool" units="" value="1">
       <Help>Enable/disable Wattage threshold and percent.</Help>
     </Value>
-    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="91" label="Wattage threshold" max="32000" min="0" type="short" units="W" value="50">
       <Help>The minimum change in wattage for a report to be sent.</Help>
     </Value>
     <Value genre="config" index="92" label="Wattage threshold percent" max="99" min="0" type="byte" units="%" value="10">

--- a/config/aeotec/zw095.xml
+++ b/config/aeotec/zw095.xml
@@ -42,22 +42,22 @@ Products that are Z-Wave certified can be used and communicate with other Z-Wave
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="4" label="Wattage Threshold Whole HEM" max="60000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="4" label="Wattage Threshold Whole HEM" max="60000" min="0" type="short" units="W" value="50">
       <Help>
 				Threshold change in wattage to induce a automatic report (whole HEM).
 			</Help>
     </Value>
-    <Value genre="config" index="5" label="Wattage Threshold C1" max="60000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="5" label="Wattage Threshold C1" max="60000" min="0" type="short" units="W" value="50">
       <Help>
 				Threshold change in wattage to induce a automatic report (Clamp 1).
 			</Help>
     </Value>
-    <Value genre="config" index="6" label="Wattage Threshold C2" max="60000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="6" label="Wattage Threshold C2" max="60000" min="0" type="short" units="W" value="50">
       <Help>
 				Threshold change in wattage to induce a automatic report (Clamp 2).
 			</Help>
     </Value>
-    <Value genre="config" index="7" label="Wattage Threshold C3" max="60000" min="0" type="short" units="watts" value="50">
+    <Value genre="config" index="7" label="Wattage Threshold C3" max="60000" min="0" type="short" units="W" value="50">
       <Help>
 				Threshold change in wattage to induce a automatic report (Clamp 3).
 			</Help>

--- a/config/aeotec/zw096.xml
+++ b/config/aeotec/zw096.xml
@@ -82,7 +82,7 @@ The Plug is also a security Z-wave device and supports Over The Air (OTA) featur
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw099.xml
+++ b/config/aeotec/zw099.xml
@@ -89,7 +89,7 @@ The Smart Dimmer 6 is also a security Z-Wave device and supports Over The Air (O
 	Enable/disable Wattage threshold and percent.
       </Help>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="32000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw111.xml
+++ b/config/aeotec/zw111.xml
@@ -178,7 +178,7 @@ The Nano Dimmer is also a security Z-Wave plus device and supports Over The Air 
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw116.xml
+++ b/config/aeotec/zw116.xml
@@ -174,7 +174,7 @@ The Nano Switch is also a security Z-Wave device and supports Over The Air (OTA)
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw132.xml
+++ b/config/aeotec/zw132.xml
@@ -174,7 +174,7 @@ The Dual Nano Switch is also a security Z-Wave device and supports Over The Air 
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/aeotec/zw175.xml
+++ b/config/aeotec/zw175.xml
@@ -126,7 +126,7 @@
                 Value4: Disable Minute. Valid value are 0-59 and 255. Value 255 means use last valid setting.
             </Help>
         </Value>
-        <Value genre="config" index="91" label="Threshold Power for inducing automatic report" max="2300" min="0" size="2" type="short" units="watts" value="0">
+        <Value genre="config" index="91" label="Threshold Power for inducing automatic report" max="2300" min="0" size="2" type="short" units="W" value="0">
             <Help>
                 0 => Disable.
                 1-2300 => 1-2300W.

--- a/config/aeotec/zwa006.xml
+++ b/config/aeotec/zwa006.xml
@@ -70,7 +70,7 @@ The Aeotec Smart Boost Time Switch supports consumption meter function. When the
 				When user press the boost button one time, the boost time will increase 30 (the value can be changed) minutes.
             </Help>
     </Value>
-    <Value genre="config" index="7" label="LED threshold setting" max="3000" min="0" type="short" units="watt" value="100">
+    <Value genre="config" index="7" label="LED threshold setting" max="3000" min="0" type="short" units="W" value="100">
       <Help>
                 This parameter is used to configure the power led threshold, unit W.
 				When the load &lt;= 100W, the power led will indicate yellow.
@@ -85,7 +85,7 @@ The Aeotec Smart Boost Time Switch supports consumption meter function. When the
 				1 ~ 10000 - enable report.
             </Help>
     </Value>
-    <Value genre="config" index="21" label="Watt threshold setting" max="2500" min="0" type="short" units="watt" value="100">
+    <Value genre="config" index="21" label="Watt threshold setting" max="2500" min="0" type="short" units="W" value="100">
       <Help>
                 Threshold settings for Watt automatic report, unit W. When Watt above the threshold, it will send a meter report command to gateway.
 				0 - disable report.

--- a/config/everspring/an181.xml
+++ b/config/everspring/an181.xml
@@ -55,7 +55,7 @@ The Metering Plug is designed to control the on/off status of lighting and appli
     <Value genre="config" index="5" label="Energy Auto report" max="32767" min="0" size="2" type="short" units="minutes" value="60">
       <Help>Set the interval for kWh auto report (0 = disabled)</Help>
     </Value>
-    <Value genre="config" index="6" label="Value of Wattage surpassed" max="2500" min="0" size="2" type="short" units="watts" value="0">
+    <Value genre="config" index="6" label="Value of Wattage surpassed" max="2500" min="0" size="2" type="short" units="W" value="0">
       <Help>Auto report is sent when load surpasses the set value of wattage (0 = disabled)</Help>
     </Value>
     <Value genre="config" index="7" label="Change of Wattage surpassed" max="100" min="0" size="1" type="byte" units="%" value="0">

--- a/config/fibaro/fgd212.xml
+++ b/config/fibaro/fgd212.xml
@@ -245,7 +245,7 @@ Default setting: 15</Help>
     <Value genre="config" index="38" instance="1" label="Brightness level correction for flickering loads" max="255" min="0" type="short" value="255">
       <Help>Correction reduces spontaneous flickering of some capacitive load (e.g. dimmable lEDs) at certain brightness levels in 2-wire installation. In countries using ripple-control, correction may cause changes in brightness. In this case it is necessary to disable correction or adjust time of correction for flickering loads. Available settings: 0 - automatic correction disabled 1-254 - duration of correction in seconds 255 - automatic correction always enabled Default setting: 255</Help>
     </Value>
-    <Value genre="config" index="39" instance="1" label="Power limit - OVERLOAD" max="350" min="1" type="short" units="Watt" value="250">
+    <Value genre="config" index="39" instance="1" label="Power limit - OVERLOAD" max="350" min="1" type="short" units="W" value="250">
       <Help>Reaching the defined value will result in turning off the load. Additional apparent power limit of 350VA is active by default. Available settings: 0 - functionality disabled; 1-350 - 1W-350W; Default setting: 250</Help>
     </Value>
     <Value genre="config" index="40" instance="1" label="Response to General Purpose Alarm" size="1" type="list" value="3">
@@ -333,7 +333,7 @@ Default setting: 10 (0,1 kWh)</Help>
       <Item label="approximation based on the calibration data" value="1"/>
       <Item label="approximation based on the control angle" value="2"/>
     </Value>
-    <Value genre="config" index="59" instance="1" label="Approximated power at the maximum brightness level" max="500" min="0" type="short" units="Watt" value="0">
+    <Value genre="config" index="59" instance="1" label="Approximated power at the maximum brightness level" max="500" min="0" type="short" units="W" value="0">
       <Help>This parameter determines the approximate value of the power that will be reported by the device at its maximum brightness level. This parameter works only when parameter 58 has a value other than 0. Available settings: 0-500 (0-500W) - power consumed by the load at the maximum brightness level. Default setting: 0</Help>
     </Value>
   </CommandClass>

--- a/config/fibaro/fgr223.xml
+++ b/config/fibaro/fgr223.xml
@@ -268,7 +268,7 @@ Main features of FIBARO Roller Shutter 3:
                 Default setting: 10 (1s).
             </Help>
     </Value>
-    <Value genre="config" index="155" instance="1" label="Motor operation detection" max="255" min="0" size="2" type="short" units="watt" value="10">
+    <Value genre="config" index="155" instance="1" label="Motor operation detection" max="255" min="0" size="2" type="short" units="W" value="10">
       <Help>
                 Power threshold to be interpreted as reaching a limit switch.
                 0: reaching a limit switch will not be detected

--- a/config/fibaro/fgwr111.xml
+++ b/config/fibaro/fgwr111.xml
@@ -356,7 +356,7 @@
       </Help>
     </Value>
 
-    <Value genre="config" index="155" label="Motor operation detection" max="255" min="0" size="2" type="short" units="watt" value="10">
+    <Value genre="config" index="155" label="Motor operation detection" max="255" min="0" size="2" type="short" units="W" value="10">
       <Help>
         Power threshold interpreted as reaching a limit switch.
 

--- a/config/hank/hkzw-so03.xml
+++ b/config/hank/hkzw-so03.xml
@@ -55,7 +55,7 @@ Smart Plug is also a security Z-Wave device and supports the Over The Air (OTA) 
       <Item label="Display power consumption always" value="0"/>
       <Item label="Display power consumption at state change" value="1"/>
     </Value>
-    <Value genre="config" index="151" instance="1" label="Power Report Value Threshold" max="65535" min="0" size="2" type="short" units="Watts" value="50">
+    <Value genre="config" index="151" instance="1" label="Power Report Value Threshold" max="65535" min="0" size="2" type="short" units="W" value="50">
       <Help>Minimum change in watts to report</Help>
     </Value>
     <Value genre="config" index="152" instance="1" label="Power Report Percentage Threshold" max="255" min="0" size="1" type="byte" units="%" value="10">

--- a/config/oomi/ft111.xml
+++ b/config/oomi/ft111.xml
@@ -87,7 +87,7 @@ The In-Wall Dimmer is also a security Z-Wave plus device and supports Over The A
       <Item label="Disable" value="0"/>
       <Item label="Enable" value="1"/>
     </Value>
-    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="watts" value="25">
+    <Value genre="config" index="91" label="Minimum Change to send Report (Watt)" max="6000" min="0" size="2" type="short" units="W" value="25">
       <Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
     </Value>
     <Value genre="config" index="92" label="Minimum Change to send Report (%)" max="100" min="0" type="byte" units="%" value="5">

--- a/config/popp/009105.xml
+++ b/config/popp/009105.xml
@@ -39,7 +39,7 @@
 			<Item label="Yes (default)" value="1" />
 		</Value>
 		
-		<Value type="short" genre="config" instance="1" index="20" label="Energy consumption" size="2" units="Watts" min="0" max="3500" value="0">
+		<Value type="short" genre="config" instance="1" index="20" label="Energy consumption" size="2" units="W" min="0" max="3500" value="0">
 			<Help>
 			Specify the consumption of the load in Watts, for the calculation of power.
 			0 -> Disabled (default)

--- a/config/popp/700397.xml
+++ b/config/popp/700397.xml
@@ -90,7 +90,7 @@ All metering values an be requested from the central controller and will be repo
                 0 - 255 -> * 0,01 A
             </Help>
     </Value>
-    <Value genre="config" index="25" instance="1" label="Power Reporting Threshold" max="255" min="0" size="1" type="byte" units="Watts" value="50">
+    <Value genre="config" index="25" instance="1" label="Power Reporting Threshold" max="255" min="0" size="1" type="byte" units="W" value="50">
       <Help>
                 Report the power when the power  has changed by more then X Watt. 
                 When disabled the device will report every 10 minutes regardless of power consumption change.
@@ -99,7 +99,7 @@ All metering values an be requested from the central controller and will be repo
                 1 - 255 -> Watts
             </Help>
     </Value>
-    <Value genre="config" index="26" instance="1" label="Soft Circuit Breaker Threshold" max="3600" min="0" size="2" type="short" units="Watts" value="3600">
+    <Value genre="config" index="26" instance="1" label="Soft Circuit Breaker Threshold" max="3600" min="0" size="2" type="short" units="W" value="3600">
       <Help>
                 When the power draw exceeds the value set in this parameter for a time set in parameter 28 the soft circuit breaker will disconnect the load.
                 0 -> Disabled

--- a/config/qubino/ZMNHHDx.xml
+++ b/config/qubino/ZMNHHDx.xml
@@ -94,7 +94,7 @@
             </Help>
         </Value>
 
-        <Value genre="config" index="70" instance="1" label="Overload safety switch" units="watt" max="255" min="1" type="short" value="200">
+        <Value genre="config" index="70" instance="1" label="Overload safety switch" units="W" max="255" min="1" type="short" value="200">
             <Help>
                 The function allows for turning off the controlled device in case of exceeding the defined power for more than 5s.
                 Controlled device can be turned back on by input I1 or sending a control frame.

--- a/config/qubino/ZMNHYDx.xml
+++ b/config/qubino/ZMNHYDx.xml
@@ -102,14 +102,14 @@ By resetting the device, all custom parameters previously set on the device will
                 Default value 300 (power report in Watts is send each 300s).
             </Help>
     </Value>
-    <Value genre="config" index="50" instance="1" label="Down value" max="4000" min="0" size="2" type="short" units="Watts" value="30">
+    <Value genre="config" index="50" instance="1" label="Down value" max="4000" min="0" size="2" type="short" units="W" value="30">
       <Help>
                 Lower power threshold used in param 52.
                 Can not be higher than param 51
                 0-4000 (0.0 to 4000.0W, 0 disables)
             </Help>
     </Value>
-    <Value genre="config" index="51" instance="1" label="Up value" max="4000" min="0" size="2" type="short" units="Watts" value="50">
+    <Value genre="config" index="51" instance="1" label="Up value" max="4000" min="0" size="2" type="short" units="W" value="50">
       <Help>
                 Upper power threshold used in param 52.
                 Can not be higher than param 50
@@ -128,7 +128,7 @@ By resetting the device, all custom parameters previously set on the device will
       <Item label="1 and 4 combined" value="5"/>
       <Item label="2 and 3 combined" value="6"/>
     </Value>
-    <Value genre="config" index="70" instance="1" label="Overload safety switch" max="4000" min="0" size="2" type="short" units="Watts" value="0">
+    <Value genre="config" index="70" instance="1" label="Overload safety switch" max="4000" min="0" size="2" type="short" units="W" value="0">
       <Help>
                 The function allows for turning off the controlled device in case of exceeding the defined power for more than 3.1s.
                 Controlled device can be turned back on by S-button or sending a control frame. By default this function is inactive.

--- a/config/telldus/tzwp102.xml
+++ b/config/telldus/tzwp102.xml
@@ -62,7 +62,7 @@ Smart Plug is also a security Z-Wave device and supports the Over The Air (OTA) 
       <Item label="The LED follows the load status" value="0"/>
       <Item label="When operating plug, the LED is lit for 5 seconds" value="1"/>
     </Value>
-    <Value genre="config" index="16" label="Send report on change of power consumption (W)" max="2500" min="0" size="2" type="short" units="Watts" value="50">
+    <Value genre="config" index="16" label="Send report on change of power consumption (W)" max="2500" min="0" size="2" type="short" units="W" value="50">
       <Help>
                 This parameter will send a power report automatically if the power value changes of x W (Watts) compared to the last report. Default 50.
             </Help>

--- a/config/vision/zl7261.xml
+++ b/config/vision/zl7261.xml
@@ -8,7 +8,7 @@
             <Help>Choose how often you want to send automatic reports, in seconds.
                 Defaults to 60 seconds.</Help>
         </Value>
-        <Value type="int" genre="config" index="2" label="Wattage Threshold" min="5" max="3600" value="50" units="watts">
+        <Value type="int" genre="config" index="2" label="Wattage Threshold" min="5" max="3600" value="50" units="W">
             <Help>Minimum change in wattage to induce an automatic report.
                 Defaults to 50 watts.</Help>
         </Value>

--- a/config/wenzhou/tz69.xml
+++ b/config/wenzhou/tz69.xml
@@ -52,7 +52,7 @@ Use the "Reset" procedure only in the event that the network primary controller 
     <Value genre="config" index="5" instance="1" label="Threshold of Kwh for Load Caution" max="10000" min="1" type="short" units="Kwh" value="10000">
       <Help></Help>
     </Value>
-    <Value genre="config" index="6" instance="1" label="Threshold of Watt for Load Caution" max="3000" min="10" type="short" units="Watt" value="3000">
+    <Value genre="config" index="6" instance="1" label="Threshold of Watt for Load Caution" max="3000" min="10" type="short" units="W" value="3000">
       <Help></Help>
     </Value>
   </CommandClass>

--- a/config/wenzhou/tz79.xml
+++ b/config/wenzhou/tz79.xml
@@ -21,7 +21,7 @@
         <Value type="short" genre="config" instance="1" index="4" label="kWh meter report period" min="1" max="32767" units="10 min" value="6">
             <Help>If the setting is configured for 1 hour (value=6), the TZ79 will report its accumulated power consumption (kWh) every 1 hour.</Help>
         </Value>
-        <Value type="short" genre="config" instance="1" index="5" label="Threshold of Watt for Load Caution" min="10" max="3000" units="Watt" value="3000">
+        <Value type="short" genre="config" instance="1" index="5" label="Threshold of Watt for Load Caution" min="10" max="3000" units="W" value="3000">
             <Help></Help>
         </Value>
         <Value type="short" genre="config" instance="1" index="6" label="Threshold of Kwh for Load Caution" min="0" max="10000" units="Kwh" value="0">

--- a/config/widom/UME304C_S.xml
+++ b/config/widom/UME304C_S.xml
@@ -70,7 +70,7 @@ Main Feature:
       <Item label="Consumed" value="1"/>
       <Item label="Produced" value="2"/>
     </Value>
-    <Value genre="config" index="35" label="UP Power Level" max="11250" min="0" size="2" type="short" units="Watts" value="11250">
+    <Value genre="config" index="35" label="UP Power Level" max="11250" min="0" size="2" type="short" units="W" value="11250">
       <Help>C VERSION. Sets the level of instantaneous power in Watts beyond which time of permanence above this level is calculated. For S VERSION. Sets to 3000 the default and max level of instantaneous power in Watts beyond which time of permanence above this level is calculated.</Help>
     </Value>
     <Value genre="config" index="36" label="UP Power Time" max="10800" min="0" size="2" type="short" units="seconds" value="10">
@@ -86,7 +86,7 @@ Main Feature:
     <Value genre="config" index="38" label="UP Power Associated" max="99" min="-1" size="1" type="byte" value="0">
       <Help>Defines the status of associated devices in the presence of a UP Power event. From: 1 to 99 for dimming purpose. .0 (OFF) and -1(ON) for switching ON/OFF</Help>
     </Value>
-    <Value genre="config" index="39" label="DOWN Power Level" max="11250" min="0" size="2" type="short" units="Watts" value="0">
+    <Value genre="config" index="39" label="DOWN Power Level" max="11250" min="0" size="2" type="short" units="W" value="0">
       <Help>Sets the level of instantaneous power in Watts beyond which time of permanence below this level is calculated.</Help>
     </Value>
     <Value genre="config" index="40" label="DOWN Power Time" max="10800" min="0" size="2" type="short" units="seconds" value="10">

--- a/config/zooz/zen06.xml
+++ b/config/zooz/zen06.xml
@@ -88,7 +88,7 @@ NOTE: All previously recorded activity and custom settings will be erased from t
       <Item label="Display power consumption always" value="0"/>
       <Item label="Display power consumption at state change" value="1"/>
     </Value>
-    <Value genre="config" index="151" instance="1" label="Power Report Value Threshold" max="65535" min="0" size="2" type="short" units="Watts" value="50">
+    <Value genre="config" index="151" instance="1" label="Power Report Value Threshold" max="65535" min="0" size="2" type="short" units="W" value="50">
       <Help>Minimum change in watts to report</Help>
     </Value>
     <Value genre="config" index="152" instance="1" label="Power Report Percentage Threshold" max="255" min="0" size="1" type="byte" units="%" value="10">

--- a/config/zooz/zen15.xml
+++ b/config/zooz/zen15.xml
@@ -95,7 +95,7 @@ Press and HOLD the Z-Wave button for at least 3 seconds
       <Item label="Display whenever the device is plugged in (Default)" value="0"/>
       <Item label="Display power consumption for 5 seconds" value="1"/>
     </Value>
-    <Value genre="config" index="151" label="Power Report Value Threshold" max="65535" min="1" size="2" type="short" units="watts" value="0">
+    <Value genre="config" index="151" label="Power Report Value Threshold" max="65535" min="1" size="2" type="short" units="W" value="0">
       <Help>Number of Watts the appliance needs to go over for the change to be reported</Help>
     </Value>
     <Value genre="config" index="152" label="Power Report Percentage Threshold" max="255" min="1" size="4" type="int" units="%" value="10">

--- a/config/zooz/zen20v2.xml
+++ b/config/zooz/zen20v2.xml
@@ -49,7 +49,7 @@ NOTE: All previously recorded activity and custom settings EXCEPT for the kWh re
       <Item label="ON after power restored" value="1"/>
       <Item label="OFF after power restored" value="2"/>
     </Value>
-    <Value genre="config" index="2" label="Power Wattage Report Value Threshold" max="65535" min="0" size="4" type="int" units="watts" value="65535">
+    <Value genre="config" index="2" label="Power Wattage Report Value Threshold" max="65535" min="0" size="4" type="int" units="W" value="65535">
       <Help>0 = power meter disabled; 1-65535 = value in watts for report threshold</Help>
     </Value>
     <Value genre="config" index="3" label="Power Wattage Report Frequency" max="2678400" min="0" size="4" type="int" units="seconds" value="2678400">
@@ -58,7 +58,7 @@ NOTE: All previously recorded activity and custom settings EXCEPT for the kWh re
     <Value genre="config" index="4" label="Energy (kWh) Report Frequency" max="2678400" min="0" size="4" type="int" units="seconds" value="2678400">
       <Help>0 = disabled; 30-2678400 = time in seconds to send energy report</Help>
     </Value>
-    <Value genre="config" index="5" label="Overload Protection" max="1800" min="0" size="2" type="short" units="watts" value="1800">
+    <Value genre="config" index="5" label="Overload Protection" max="1800" min="0" size="2" type="short" units="W" value="1800">
       <Help>0 = disabled; 1-1800 = value in watts for overload protection</Help>
     </Value>
     <Value genre="config" index="6" label="Enable/Disable Auto Turn-Off Timer for CH1" max="1" min="0" size="1" type="list" units="" value="0">

--- a/config/zooz/zen25.xml
+++ b/config/zooz/zen25.xml
@@ -12,7 +12,7 @@ https://products.z-wavealliance.org/products/3192
       <Item value="1" label="ON"/>
       <Item value="2" label="OFF"/>
     </Value>
-    <Value type="int" genre="config" index="2" label="Power Wattage Report Value Threshold" units="Watts" size="4" min="0" max="65535" value="5">
+    <Value type="int" genre="config" index="2" label="Power Wattage Report Value Threshold" units="W" size="4" min="0" max="65535" value="5">
       <Help>Minimum change in watts to report</Help>
     </Value>
     <Value type="int" genre="config" index="3" label="Power Wattage Report Frequency" units="seconds" size="4" min="30" max="2678400" value="30">

--- a/config/zwave.me/ZME_05461.xml
+++ b/config/zwave.me/ZME_05461.xml
@@ -90,10 +90,10 @@
             <Item label="Switch On, Off only (send Basic Set)" value="1"/>
             <Item label="Send Scenes" value="3"/>
         </Value>
-        <Value type="int" index="20" genre="config" label="Energy consumption for first channel" units="watts" min="0" max="708" value="0">
+        <Value type="int" index="20" genre="config" label="Energy consumption for first channel" units="W" min="0" max="708" value="0">
             <Help>Specify the consumption of the load in watts, for the calculation of power consumption. Max load 1800 W. Disabled if zero.</Help>
         </Value>
-        <Value type="int" index="40" genre="config" label="Energy consumption for second channel" units="watts" min="0" max="708" value="0">
+        <Value type="int" index="40" genre="config" label="Energy consumption for second channel" units="W" min="0" max="708" value="0">
             <Help>Specify the consumption of the load in watts, for the calculation of power consumption. Max load 1800 W. Disabled if zero.</Help>
         </Value>
     </CommandClass>

--- a/config/zwave.me/ZME_064381.xml
+++ b/config/zwave.me/ZME_064381.xml
@@ -28,7 +28,7 @@
             <Item label="No, turn off" value="0"/>
             <Item label="Yes" value="1"/>
         </Value>
-        <Value type="short" genre="config" instance="1" index="20" label="Energy consumption" size="2" units="watt" min="0" max="3500" value="0">
+        <Value type="short" genre="config" instance="1" index="20" label="Energy consumption" size="2" units="W" min="0" max="3500" value="0">
             <Help>Specify the consumption of the load in watts, for the calculation of power consumption. Maximum load 1800 W. Unit: Watts, Min: 0, Max: 3500, Default: 0</Help>
         </Value>
         <Value type="list" genre="config" instance="1" index="21" label="Off color" size="1" value="0">


### PR DESCRIPTION
There is mixture of namings for "Watt".
This PR aligns into just "W".

This is especially noticable in for example home-assistant where unit_id_measurement is added to the device, and its metrics will go into different buckets like "watts", "watt" and "w".

Unclear to me the scope and what this affects tho.

https://github.com/home-assistant/core/pull/35585/