### PR TITLE
Add support for different MCO Home MH9 and extend config options

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1176,6 +1176,7 @@
     <Product config="mcohome/mh8fceu.xml" id="3102" name="MH8-FC4-EU Thermostat" type="0802"/>
     <Product config="mcohome/mh9co2.xml" id="0201" name="MH9-CO2-WD CO2 Monitor" type="0905"/>
     <Product config="mcohome/mh9co2.xml" id="3102" name="MH9-CO2-WD CO2 Monitor" type="0901"/>
+    <Product config="mcohome/mh9co2.xml" id="5102" name="MH9-CO2-WD CO2 Monitor" type="0902"/>
     <Product config="mcohome/a8-9.xml" id="1352" name="A8-9 Multi-sensor" type="a800"/>
     <Product config="mcohome/a8-9.xml" id="1352" name="A8-9 Multi-sensor" type="a803"/>
     <Product config="mcohome/mh7h.xml" id="5102" name="MH7H Water/Electrical Heating Thermostat" type="0701"/>

--- a/config/mcohome/mh9co2.xml
+++ b/config/mcohome/mh9co2.xml
@@ -6,6 +6,18 @@
         <Value type="short" genre="config" instance="1" index="1" label="CO2 Notification threshold" size="2" min="1" max="1200" units="ppm" value="1000">
             <Help>CO2 Notification threshold 1 to 2000ppm</Help>
         </Value>
+        <Value genre="config" index="2" instance="1" label="CO2 reporting threshold" max="100" min="0" size="1" type="byte" units="" value="10">
+            <Help>0 report disabled, base on 5ppm unit, 10 by default, 10*5ppm=50ppm</Help>
+        </Value>
+        <Value genre="config" index="3" instance="1" label="Temperature reporting threshold" max="100" min="0" size="1" type="byte" units="" value="1">
+            <Help>0 report disabled, base on 0.5C unit, 1 by default, 1*0.5C=0.5C</Help>
+        </Value>
+        <Value genre="config" index="4" instance="1" label="Humidity reporting threshold" max="50" min="0" size="1" type="byte" units="" value="2">
+            <Help>0 report disabled, base on 1% unit, 2 by default, 2*1C=2C</Help>
+        </Value>
+        <Value genre="config" index="255" instance="1" label="Factory setting" max="255" min="0" size="1" type="byte" units="" value="0">
+            <Help>Restore the factory setting - write only, set to 85 to reset</Help>
+        </Value>        
     </CommandClass>
     <!-- Association Groups -->
     <CommandClass id="133">


### PR DESCRIPTION
Add support for MCO Home MH9 multisensor with different type and id than currently in de DB and improve config file to include all config options.