### PR TITLE
Updates for Zooz Zen27 and ZSE29

### DIFF
--- a/config/zooz/zen27.xml
+++ b/config/zooz/zen27.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="4" xmlns="https://github.com/OpenZWave/open-zwave">
 	<MetaData>
 		<MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/027a:a002:a000</MetaDataItem>
 		<MetaDataItem name="ProductPic">images/zooz/zen27.png</MetaDataItem>
@@ -60,6 +60,7 @@ tap-tap-tap-and-hold: factory reset
 		<ChangeLog>
 			<Entry author="David Alden - dave@alden.name" date="23 Oct 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3148/xml - this requires v2.0 (or newer) firmware</Entry>
 			<Entry author="Brad Parker - https://github.com/bepsoccer" date="13 April 2020" revision="3">Updated for firmware version 2.08</Entry>
+			<Entry author="Brad Parker - https://github.com/bepsoccer" date="28 May 2020" revision="4">Updated for param 9 min value</Entry>
 		</ChangeLog>
 	</MetaData>
 

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -52,6 +52,16 @@ NOTE: All previously recorded activity and custom settings will be erased from t
 
   <!-- Configuration Parameters -->
   <CommandClass id="112">
+    <Value type="byte" genre="config" index="1" label="Basic Set Report Value Sent to Associated Devices" size="1" min="0" max="99" value="99">
+      <Help> Set the value of basic set report sent to the light associated with the sensor in Group 2 (so the light turns on to the selected brightness level). 99 is the equivalent of full brightness in Z-Wave terms.
+      default: 99
+      </Help>
+    </Value>
+    <Value type="list" genre="config" index="2" label="Enable / Disable Motion Reports" size="1" min="0" max="1" value="1">
+      <Help>Enable or disable motion reports completely. If motion sensor is disabled, the device will not report motion at all to your hub.</Help>
+      <Item label="Disabled" value="0"/>
+      <Item label="Enabled (default)" value="1"/>
+    </Value> 
     <Value type="byte" genre="config" index="3" label="Motion Sensativity" size="1" min="1" max="10" value="10">
       <Help>Adjust motion sensitivity where 10 is the most sensative setting.
       default: 10

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -49,7 +49,32 @@ NOTE: All previously recorded activity and custom settings will be erased from t
       <Entry author="Brad Parker - https://github.com/bepsoccer" date="27 May 2020" revision="3">Updated for firmware version 2.0</Entry>
     </ChangeLog>
   </MetaData>
-  <!-- Zooz ZSE29 Outdoor Motion Sensor -->
+
+  <!-- Configuration Parameters -->
+  <CommandClass id="112">
+    <Value type="byte" genre="config" index="3" label="Motion Sensativity" size="1" min="1" max="10" value="10">
+      <Help>Adjust motion sensitivity where 10 is the most sensative setting.
+      default: 10
+      </Help>
+    </Value>
+    <Value type="short" genre="config" index="4" label="Lux Level Trigger" size="2" min="0" max="900" value="0">
+      <Help>Set lux level trigger with 10 being the lowest reported value.  The sensor will report motion to the hub and associated devices only if lux level is below the set value.
+      0 - set manually by lux knob; (default)
+      1 - ignore lux and always report motion;
+      </Help>
+    </Value>
+    <Value type="short" genre="config" index="5" label="Motion Re-trigger Time" size="2" min="0" max="720" value="0" units="seconds">
+      <Help>Set motion re-trigger time for the delay before the sensor reports no motion to the hub and associated devices after detecting the last motion activity.
+      0 - set manually by timer knob; (default)
+      5-720 (seconds) - set customer re-trigger time;
+      </Help>
+    </Value>
+    <Value type="short" genre="config" index="6" label="Lux Reporting Frequency" size="2" min="1" max="1440" value="30" units="minutes">
+      <Help>Set lux reporting frequency to decide how often the snesor will measure and send brightness level data to the hub and associated devices.
+      default: 30 (minutes)
+      </Help>
+    </Value>
+  </CommandClass>
 
     <!-- Association Groups -->
   <CommandClass id="133">

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -1,4 +1,4 @@
-<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/027A:0005:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/zooz/zse29.png</MetaDataItem>
@@ -46,6 +46,7 @@ NOTE: All previously recorded activity and custom settings will be erased from t
     <MetaDataItem id="0005" name="Identifier" type="0001">ZSE29</MetaDataItem>
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 Jun 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3081/xml</Entry>
+      <Entry author="Brad Parker - https://github.com/bepsoccer" date="27 May 2020" revision="3">Updated for firmware version 2.0</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Zooz ZSE29 Outdoor Motion Sensor -->


### PR DESCRIPTION
- Zen27 update to reflect the min value of 0 for parameter 9
- ZSE29 config parameters added and are valid for firmware 2.0