### PR TITLE
Add ZEN24 Dimmer Switch v3

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -2270,6 +2270,7 @@
 		<Product type="b111" id="1e1c" name="ZEN21 Switch V2.0" config="zooz/zen21v2.xml" />
 		<Product type="000c" id="0003" name="ZSE19 S2 Multisiren" config="zooz/zse19.xml" />
 		<Product type="a000" id="a004" name="ZEN20 V2.0 Power Strip" config="zooz/zen20v2.xml" />
+		<Product type="b112" id="261c" name="ZEN24 Dimmer Switch V3" config="zooz/zen24v3.xml" />
 	</Manufacturer>
 	<Manufacturer id="015d" name="Zooz (Willis Electric)">
 		<Product type="0651" id="f51c" name="ZEN20 Power Strip" config="zooz/zen20.xml" />


### PR DESCRIPTION
Please see: https://github.com/OpenZWave/open-zwave/pull/2238
Zooz ZEN24 v3 hardware offers advance settings not available in original hardware. Created zen24v3 XML for these config settings.