### PR TITLE
Zooz ZEN21v3 corrections

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ManufacturerSpecificData Revision="95" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="97" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ManufacturerSpecificData Revision="94" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="95" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1889,7 +1889,7 @@
     <Product id="0002" name="ZST10 S2 Z-Wave Plus USB Stick" type="0401"/>
     <Product config="zooz/zen26.xml" id="a001" name="ZEN26 S2 On Off Wall Switch" type="a000"/>
     <Product config="zooz/zen27.xml" id="a002" name="ZEN27 S2 Dimmer Wall Switch" type="a000"/>
-    <Product config="zooz/zen21.xml" id="1e1c" name="ZEN21 Switch V2.0" type="b111"/>
+    <Product config="zooz/zen21v3.xml" id="1e1c" name="ZEN21 Switch V3.0" type="b111"/>
     <Product config="zooz/zse19.xml" id="0003" name="ZSE19 S2 Multisiren" type="000c"/>
     <Product config="zooz/zen20v2.xml" id="a004" name="ZEN20 V2.0 Power Strip" type="a000"/>
     <Product config="zooz/zse29.xml" id="0005" name="ZSE29 Outdoor Motion Sensor" type="0001"/>
@@ -1905,7 +1905,6 @@
     <Product config="zooz/zen23.xml" id="1e1c" name="ZEN23 Toggle Switch" type="1111"/>
     <Product config="zooz/zen24.xml" id="1f1c" name="ZEN24 Dimmer Switch" type="0111"/>
     <Product config="inovelli/nzw97.xml" id="6100" name="NZW97 Inovelli Dual Outdoor Z-Wave Plug" type="6100"/>
-    <Product config="zooz/zen21.xml" id="1e1c" name="ZEN21 Switch V2.0" type="b111"/>
   </Manufacturer>
   <Manufacturer id="0315" name="zwaveproducts.com">
     <Product type="4447" id="3031" name="PA-100" config="zwp/PA-100.xml"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1889,7 +1889,7 @@
     <Product id="0002" name="ZST10 S2 Z-Wave Plus USB Stick" type="0401"/>
     <Product config="zooz/zen26.xml" id="a001" name="ZEN26 S2 On Off Wall Switch" type="a000"/>
     <Product config="zooz/zen27.xml" id="a002" name="ZEN27 S2 Dimmer Wall Switch" type="a000"/>
-    <Product config="zooz/zen21v3.xml" id="1e1c" name="ZEN21 Switch V3.0" type="b111"/>
+    <Product config="zooz/zen21v3.xml" id="1e1c" name="ZEN21 Switch V3" type="b111"/>
     <Product config="zooz/zse19.xml" id="0003" name="ZSE19 S2 Multisiren" type="000c"/>
     <Product config="zooz/zen20v2.xml" id="a004" name="ZEN20 V2.0 Power Strip" type="a000"/>
     <Product config="zooz/zse29.xml" id="0005" name="ZSE29 Outdoor Motion Sensor" type="0001"/>

--- a/config/zooz/zen21v3.xml
+++ b/config/zooz/zen21v3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="3">
 	<MetaData>
 		<MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/027a:1e1c:b111</MetaDataItem>
 		<MetaDataItem name="ProductPic">images/zooz/zen21.png</MetaDataItem>
@@ -63,6 +63,7 @@ tap-tap-tap-and-hold: factory reset
 	</MetaDataItem>
 		<ChangeLog>
 			<Entry author="Brad Parker - https://github.com/bepsoccer" date="13 April 2020" revision="2">Updated for firmware version 3.04</Entry>
+			<Entry author="Matthew Grimes" date="12 June 2020" revision="3">Rename XML for correct hardware version</Entry>
 		</ChangeLog>
 	</MetaData>
 	<!-- Configuration Parameters -->


### PR DESCRIPTION
Config XML for v3 hardware incorrectly labeled v2, manufacturer specific entry was never pointed to config XML after created. Everything was pointing to the original v1/v2 XML.