### PR TITLE
Update Kwikset 914c for proper alarm message index

### DIFF
--- a/config/kwikset/914c.xml
+++ b/config/kwikset/914c.xml
@@ -13,6 +13,7 @@ Works with existing select single cylinder deadbolts</MetaDataItem>
     <MetaDataItem name="Name">Convert Electronic Deadbolt</MetaDataItem>
     <ChangeLog>
       <Entry author="Jeff Sanicola - jeff.sanicola@outlook.com" date="20 Dec 2019" revision="1">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2268/xml</Entry>
+      <Entry author="Steve Sell - stevesell@hotmail.com" date="14 Jun 2020" revision="2">Updated the index for the alarm message that triggers status refresh</Entry>
     </ChangeLog>
     <MetaDataItem name="WakeupDescription">The electronic conversion kit remains asleep until an action occurs on the latch or a request is received from the RF side.
 For the RF side, it will wake up every 1 second to check if there are any requests from your smart home controller.</MetaDataItem>

--- a/config/kwikset/914c.xml
+++ b/config/kwikset/914c.xml
@@ -13,7 +13,7 @@ Works with existing select single cylinder deadbolts</MetaDataItem>
     <MetaDataItem name="Name">Convert Electronic Deadbolt</MetaDataItem>
     <ChangeLog>
       <Entry author="Jeff Sanicola - jeff.sanicola@outlook.com" date="20 Dec 2019" revision="1">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2268/xml</Entry>
-      <Entry author="Steve Sell - stevesell@hotmail.com" date="14 Jun 2020" revision="2">Updated the index for the alarm message that triggers status refresh</Entry>
+      <Entry author="Steve28" date="14 Jun 2020" revision="2">Updated the index for the alarm message that triggers status refresh</Entry>
     </ChangeLog>
     <MetaDataItem name="WakeupDescription">The electronic conversion kit remains asleep until an action occurs on the latch or a request is received from the RF side.
 For the RF side, it will wake up every 1 second to check if there are any requests from your smart home controller.</MetaDataItem>

--- a/config/kwikset/914c.xml
+++ b/config/kwikset/914c.xml
@@ -1,4 +1,4 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0090:0446:0003</MetaDataItem>
     <MetaDataItem name="ProductPic">images/kwikset/914c.png</MetaDataItem>
@@ -67,7 +67,7 @@ To perform a factory reset, please perform the following:
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="0" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1612,8 +1612,8 @@
                                               'md5' => '6c73035dfad876c339cd6433337ec8b822da99ec5e4cee641f7c0bea712b18118e58243764df11200aa7745e1ef4fbe38b77f3df17b8a81ec7bc1350d379d57b'
                                             },
                'config/kwikset/914c.xml' => {
-                                              'Revision' => 1,
-                                              'md5' => '8a03cf4ab3f166b2daf23317797a5e6f6871ea14a996ac09ad4d8d769f1f1fcb1884368a879c689fd16248b94fb225f67eda780b9d9390852ae73fdd778341ca'
+                                              'Revision' => 2,
+                                              'md5' => 'e38238ddceb3913be69545c4af4e563b8e33f9e559d7aed75cd64fdffceeaa5bcec7d00fe4b932b18807febb2ea15b7f33f69c1fb4cd60daee1dd17ed63e03db'
                                             },
                'config/kwikset/smartcode.xml' => {
                                                    'Revision' => 14,


### PR DESCRIPTION
The 914c does not push the lock status when the lock is manually manipulated, but it does send an alarm message.  There was a trigger set in the original XML file to force a refresh when that alarm message was received.  In Rev 1 of the file, it had an incorrect index.

This pull request updates the index value to the proper one.