### PR TITLE
Fix YRD446 alarm message index for refresh

### DIFF
--- a/config/assa_abloy/TouchDeadbolt.xml
+++ b/config/assa_abloy/TouchDeadbolt.xml
@@ -1,4 +1,4 @@
-<Product Revision="12" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="13" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0129:0000:0002</MetaDataItem>
     <MetaDataItem name="ProductPic">images/assa_abloy/TouchDeadbolt.png</MetaDataItem>
@@ -20,6 +20,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="10">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2403/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 Jun 2019" revision="11">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3211/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 Jun 2019" revision="12">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3251/xml</Entry>
+	  <Entry author="Brett Daugherty" date="17 Jun 2020" revision="13">Fixed index of alarm message to trigger lock status refresh</Entry>
     </ChangeLog>
     <MetaDataItem id="0800" name="ZWProductPage" type="0002">https://products.z-wavealliance.org/products/1040/</MetaDataItem>
     <MetaDataItem id="0800" name="FrequencyName" type="0002">U.S. / Canada / Mexico</MetaDataItem>
@@ -134,7 +135,7 @@ http://products.z-wavealliance.org/products/1973/configs
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="0" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>


### PR DESCRIPTION
See https://github.com/OpenZWave/qt-openzwave/issues/105, and https://github.com/OpenZWave/open-zwave/pull/2256

Proper refresh lock status when lock is manually operated. 