### PR TITLE
Add VerifyChange to Homeseer HS-WD100+ to resolve out-of-sync state

### DIFF
--- a/config/homeseer/hs-wd100plus.xml
+++ b/config/homeseer/hs-wd100plus.xml
@@ -1,4 +1,4 @@
-<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="8" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/000C:3034:4447</MetaDataItem>
     <MetaDataItem name="ProductPic">images/homeseer/hs-wd100plus.png</MetaDataItem>
@@ -35,6 +35,7 @@ To manually reset, tap the ON button twice quickly and then tap the OFF button t
       <Entry author="Jean-Francois Auger- Nechry@gmail.com" date="25 May 2019" revision="5">Apply PR #1546 from kaburke</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2563/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="7">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2874/xml</Entry>
+      <Entry author="Jeremy M. Johnson" date="23 June 2020" revision="8">Added compatibility parameters to ensure correct dimming level is reported</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Compatibility Parameters -->

--- a/config/homeseer/hs-wd100plus.xml
+++ b/config/homeseer/hs-wd100plus.xml
@@ -37,6 +37,12 @@ To manually reset, tap the ON button twice quickly and then tap the OFF button t
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="7">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2874/xml</Entry>
     </ChangeLog>
   </MetaData>
+  <!-- Compatibility Parameters -->
+  <CommandClass id="38">
+    <Compatibility>
+      <VerifyChanged index="0">true</VerifyChanged>
+    </Compatibility>
+  </CommandClass>
   <!-- Configuration Parameters -->
   <CommandClass id="112">
     <Value genre="config" index="4" label="Invert switch" max="1" min="0" size="1" type="list" value="0">

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1396,8 +1396,8 @@
                                                        'md5' => '528e313dab27daf86c92e7ecfbf311077842bdff72f662c308d0554a308691b9a9c5830bc08dab5a4860991053c6a73b05d5c21f1cf115a8c70c873adeb27a5d'
                                                      },
                'config/homeseer/hs-wd100plus.xml' => {
-                                                       'Revision' => 7,
-                                                       'md5' => '58dc37e456d17f71693c819806d931e2e71fa36811e384bb225e9fac00539a80aa0df1093c5b48a0b8c58de2bfd6d1e0bf3f20ff9e8aca331d6530962fad0240'
+                                                       'Revision' => 8,
+                                                       'md5' => 'dd1aeca42ff3c3465442a45a0da960632ea52301b5514cceec9e4d58b47a8fc18e7ddbfb1fe06b191ba10f32cb91d6671e125bde7ce8e99e5603703124b29f0b'
                                                      },
                'config/homeseer/hs-wd200plus.xml' => {
                                                        'Revision' => 2,


### PR DESCRIPTION
OZW is not reporting the final dimming value of the HS-WD100+.  This change adds the `VerifyChanged` compatibility setting to resolve the issue.  Tested against HS-WD100+ firmware 5.19.