### PR TITLE
Update for revised Zooz ZEN23 config

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ManufacturerSpecificData Revision="100" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="101" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>
@@ -1906,7 +1906,7 @@
     <Product config="zooz/zen20v2.xml" id="a004" name="ZEN20 V2.0 Power Strip" type="a000"/>
     <Product config="zooz/zen21v3.xml" id="1e1c" name="ZEN21 Switch V3" type="b111"/>
     <Product config="zooz/zen22v2.xml" id="1f1c" name="ZEN22 Dimmer V2" type="b112"/>
-    <Product config="zooz/zen23.xml" id="251c" name="ZEN23 Toggle Switch V2" type="b111"/>
+    <Product config="zooz/zen23v3.xml" id="251c" name="ZEN23 Toggle Switch" type="b111"/>
     <Product config="zooz/zen24v2.xml" id="261c" name="ZEN24 Dimmer Switch V2" type="b112"/>
     <Product config="zooz/zen25.xml" id="a003" name="ZEN25 S2 Double Plug with USB Port" type="a000"/>
     <Product config="zooz/zen26.xml" id="a001" name="ZEN26 S2 On Off Wall Switch" type="a000"/>


### PR DESCRIPTION
Use the ZEN23v3 config by default for advanced config settings. Vendor used same node identity codes as old hardware that can't be updated; changing to new config since this is what is still being sold today. As far as I can see having new config options on old hardware doesn't cause any problems, they are just ignored / don't do anything.