### PR TITLE
Fix YRD216 alarm message index for value refresh

### DIFF
--- a/config/assa_abloy/PushButtonDeadbolt.xml
+++ b/config/assa_abloy/PushButtonDeadbolt.xml
@@ -1,4 +1,4 @@
-<Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0129:0000:0004</MetaDataItem>
     <MetaDataItem name="ProductPic">images/assa_abloy/PushButtonDeadbolt.png</MetaDataItem>
@@ -13,6 +13,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1039/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1971/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 Jun 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3239/xml</Entry>
+      <Entry author="Matt Belhorn - matt.belhorn@gmail.com" date="26 Jun 2020" revision="7">Fixed index of alarm message to trigger lock status refresh</Entry>
     </ChangeLog>
     <MetaDataItem id="0800" name="ZWProductPage" type="0004">https://products.z-wavealliance.org/products/1039/</MetaDataItem>
     <MetaDataItem id="0800" name="Identifier" type="0004">YRD110-ZW-US</MetaDataItem>
@@ -113,7 +114,8 @@ http://ozw.my-ho.st/Yale/Yale%20ZWave%20Developer%20Guide.pdf
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="0" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
+      <RefreshClassValue CommandClass="98" Index="0" Instance="1" RequestFlags="0"/>
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>


### PR DESCRIPTION
Manual lock and unlock operations for the Assa Abloy YRD216 Touch Button Deadbolt do not automatically refresh the values for the `COMMAND_CLASS_DOOR_LOCK` status values:

CommandClass 98 Instance 1 Index 0 "Locked" Boolean
and
CommandClass 98 Instance 1 Index 1 "Locked (Advanced)" list

This commit adds a value refresh trigger on the `COMMAND_CLASS_NOTIFICATION` Instance 1 Index 6 "Access Control" value which changes on manual, keypad, and wireless lock/unlock operations to update the overall lock status.

This change is similar in nature to #2260, #2256 and https://github.com/OpenZWave/qt-openzwave/issues/105.