### PR TITLE
Add support For Ge 12720

### DIFF
--- a/config/ge/12720.xml
+++ b/config/ge/12720.xml
@@ -1,0 +1,22 @@
+<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+  <MetaData>
+    <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3130:6363</MetaDataItem>
+    <MetaDataItem name="ProductPic">images/ge/14284.png</MetaDataItem>
+    <MetaDataItem id="3130" name="ZWProductPage" type="6363">https://products.z-wavealliance.org/products/1194/</MetaDataItem>
+    <MetaDataItem name="ResetDescription">1. If plugged in, unplug the Switch from the receptacle. 
+2. Press and hold the top button for at least 3 seconds while you plug the switch into a receptacle. </MetaDataItem>
+    <MetaDataItem id="3130" name="Identifier" type="6363">12720/ZW4201</MetaDataItem>
+    <MetaDataItem name="ProductManual">http://z-wave-assets.s3-us-west-2.amazonaws.com/docs/138/B0013V8K3O_GE_Jasco_Z-Wave_Plug-in_Outdoor_Smart_Switch_12720_Manual.pdf</MetaDataItem>
+    <MetaDataItem name="Description">Transform any home into a smart home with the GE Z-Wave Outdoor Smart Switch. The lighting control enables wireless control of on/off functions for outdoor applications, and is compatible with incandescent, LED, Xenon, Halogen, fluorescent and compact fluorescent bulbs. The weather-resistant housing with a protective outlet cover safeguards the outlet from dirt and debris when not in use. The discreet black color blends in with any outdoor environment. Perfect for decorative or seasonal lighting, fountains and other outdoor plug-in appliances. Take control of your home lighting with GE Z-Wave Smart Lighting Controls! </MetaDataItem>
+    <MetaDataItem name="ExclusionDescription">1. Follow the instructions for your Z-Wave certified controller to exclude a device from the Z-Wave network. 
+2. Once the controller is ready to Exclude your device, press and release the manual/program button on the smart switch to exclude it from the network. </MetaDataItem>
+    <MetaDataItem name="Name">Plug-in Outdoor Smart Switch</MetaDataItem>
+    <MetaDataItem id="3032" name="FrequencyName" type="6363">U.S. / Canada / Mexico</MetaDataItem>
+    <MetaDataItem name="InclusionDescription">1. Follow the instructions for you Z-Wave certified controller to include the smart switch to the Z-Wave network. 
+2. Once the controller is ready to include your outdoor smart switch, press and release the manual/program button on the smart switch to include it in the network.
+3. Once your controller has confirmed that the smart switch has been included, refresh the Z-Wave network to optimize performance. </MetaDataItem>
+    <ChangeLog>
+      <Entry author="mike240se" date="26 June 2020" revision="1">Initial Metadata added - https://products.z-wavealliance.org/products/1194/xml</Entry>
+    </ChangeLog>
+  </MetaData>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -794,6 +794,7 @@
     <Product config="ge/45604.xml" id="3030" name="45603 Plugin Appliance Module" type="5250"/>
     <Product id="3130" name="45604 Outdoor Module" type="5250"/>
     <Product id="3031" name="12720 Outdoor Smart Switch" type="4f50"/>
+    <Product config="ge/12720.xml" id="3130" name="12720 Outdoor Smart Switch" type="6363"/>
     <Product config="ge/14284.xml" id="3032" name="14284 Outdoor Smart Switch" type="4f50"/>
     <Product config="ge/14285.xml" id="3032" name="14285 Outdoor Smart Switch" type="4f44"/>
     <Product config="ge/receptacle.xml" id="3530" name="45605 Duplex Receptacle" type="5252"/>


### PR DESCRIPTION
This is the older non-plus revision of the ZW4201 GE/Jasco Outdoor Plugin Smart Switch.  The product images are exactly the same, the casing of the product was the same for both revisions.

The manual is not available on Zwave alliance DB, I added another one I found though.