### PR TITLE
Fix TriggerRefreshValue for Schlage BE468 locks

### DIFF
--- a/config/schlage/BE468.xml
+++ b/config/schlage/BE468.xml
@@ -65,7 +65,7 @@
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-		<TriggerRefreshValue Genre="user" Index="0" Instance="1">
+		<TriggerRefreshValue Genre="user" Index="6" Instance="1">
 			<RefreshClassValue CommandClass="98" RequestFlags="0" Index="1" Instance="1" />
 		</TriggerRefreshValue>
 	</CommandClass>

--- a/config/schlage/BE468.xml
+++ b/config/schlage/BE468.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="2">
 	<CommandClass id="112">
 		<Value type="list" genre="config" index="3" label="Beeper" min="0" max="255" size="1" value="255">
 			<Help>


### PR DESCRIPTION
Index should be 6 instead of 0. This was previously fixed for the BE469 locks but not the BE468.