### PR TITLE
Update LZW31-SN Parameters for 1.47

### DIFF
--- a/config/inovelli/lzw30-sn.xml
+++ b/config/inovelli/lzw30-sn.xml
@@ -1,4 +1,4 @@
-<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="8" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/031E:0001:0002</MetaDataItem>
     <MetaDataItem name="ProductPic">images/inovelli/lzw30-sn.png</MetaDataItem>
@@ -23,6 +23,7 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     <ChangeLog>
       <Entry author="Eric Maycock - ericm@inovelli.com" date="10 Sep 2019" revision="6">Adding Metadata</Entry>
       <Entry author="Justin Hammond" date="13 Mar 2020" revision="7">Remove Static Central Scene Entries - Issue #2155</Entry>
+      <Entry author="Brett Daugherty and SirDeadlyStrike" date="23 Jul 2020" revision="8">Add Instant On/Off Parameter</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -108,6 +109,13 @@ Please Note: If this doesn't work, you can check to see if your switch is within
       Range: 0-100
       Default: 10
       </Help>
+    </Value>
+    <Value genre="config" type="list" size="1" index="51" label="Instant On" min="0" max="1" value="1">
+       <Help>
+          Enables instant on (ie: disables the 700ms button delay). Note, if you disable the delay, it will also disable scene control except for Button 1 (ie: tap up 1x or tap down 1x) and button 7 (config button). All other buttons (2-6) will be disabled.
+       </Help>
+       <Item value="0" label="Enabled (no delay)"/>
+       <Item value="1" label="Disabled (700ms delay)"/>
     </Value>
   </CommandClass>
 

--- a/config/inovelli/lzw30.xml
+++ b/config/inovelli/lzw30.xml
@@ -1,4 +1,4 @@
-<Product Revision="5" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/031E:0001:0004</MetaDataItem>
     <MetaDataItem name="ProductPic">images/inovelli/lzw30.png</MetaDataItem>
@@ -23,6 +23,7 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     </MetaDataItem>
     <ChangeLog>
       <Entry author="Eric Maycock - ericm@inovelli.com" date="10 Sep 2019" revision="5">Adding Metadata</Entry>
+      <Entry author="Brett Daugherty and SirDeadlyStrike" date="23 Jul 2020" revision="6">Add Instant On/Off Parameter</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -80,6 +81,13 @@ Please Note: If this doesn't work, you can check to see if your switch is within
       Range: 0 - 10
       Default: 0
       </Help>
+    </Value>
+    <Value genre="config" type="list" size="1" index="51" label="Instant On" min="0" max="1" value="1">
+       <Help>
+          Enables instant on (ie: disables the 700ms button delay). Note, if you disable the delay, it will also disable scene control except for Button 1 (ie: tap up 1x or tap down 1x) and button 7 (config button). All other buttons (2-6) will be disabled.
+       </Help>
+       <Item value="0" label="Enabled (no delay)"/>
+       <Item value="1" label="Disabled (700ms delay)"/>
     </Value>
   </CommandClass>
 

--- a/config/inovelli/lzw31-sn.xml
+++ b/config/inovelli/lzw31-sn.xml
@@ -230,7 +230,7 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     </Value>
     <Value genre="config" type="list" size="1" index="52" label="Smart Bulb Mode" min="0" max="1" value="0">
       <Help>
-      Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim & makes it act like an ON / OFF switch. (firmware 1.47+)
+      Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim and makes it act like an ON / OFF switch. (firmware 1.47+)
     </Help>
     <Item value="0" label="Smart Bulb Mode Disabled (Default)"/>
     <Item value="1" label="Smart Bulb Mode Enabled"/>

--- a/config/inovelli/lzw31-sn.xml
+++ b/config/inovelli/lzw31-sn.xml
@@ -22,7 +22,7 @@ Only use either of these procedures in the event that the network primary contro
 Please Note: If this doesn't work, you can check to see if your switch is within Z-Wave Range by holding down the Configuration Button for 5-10 seconds (if it's not within range, the LED Bar will indicate Red and if it is within Range, the LED Bar will indicate Green). If your switch indicates Red, please move the switch closer to the HUB. If your switch indicates Green, please try running an Exclusion to reset your switch.</MetaDataItem>
     <ChangeLog>
       <Entry author="Eric Maycock - ericm@inovelli.com" date="7 Nov 2019" revision="1">Initial Release</Entry>
-      <Entry author="Brett Daugherty" date="23 Jul 2020" revision="1">Update config for Firmware 1.47+</Entry>
+      <Entry author="Brett Daugherty and SirDeadlyStrike" date="23 Jul 2020" revision="2">Update config for Firmware 1.47+</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -221,12 +221,12 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     <Item value="1" label="3-way Toggle"/>
     <Item value="2" label="3-way Momentary"/>
     </Value>
-    <Value genre="config" type="list" size="1" index="51" label="Disable Physical On/Off Delay" min="0" max="1" value="1">
-      <Help>
-      The 700ms delay that occurs after pressing the physical button to turn the switch on/off is removed. Consequently this also removes the following scenes: 2x, 3x, 4x, 5x tap. 1x tap and config button scenes still work. (firmware 1.47+) 
-    </Help>
-    <Item value="0" label="Delay Disabled"/>
-    <Item value="1" label="Delay Enabled (Default)"/>
+    <Value genre="config" type="list" size="1" index="51" label="Instant On" min="0" max="1" value="1">
+       <Help>
+          Enables instant on (ie: disables the 700ms button delay). Note, if you disable the delay, it will also disable scene control except for Button 1 (ie: tap up 1x or tap down 1x) and button 7 (config button). All other buttons (2-6) will be disabled.
+       </Help>
+       <Item value="0" label="Enabled (no delay)"/>
+       <Item value="1" label="Disabled (700ms delay)"/>
     </Value>
     <Value genre="config" type="list" size="1" index="52" label="Smart Bulb Mode" min="0" max="1" value="0">
       <Help>

--- a/config/inovelli/lzw31-sn.xml
+++ b/config/inovelli/lzw31-sn.xml
@@ -1,4 +1,4 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/031E:0001:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/inovelli/lzw31-sn.png</MetaDataItem>
@@ -22,6 +22,7 @@ Only use either of these procedures in the event that the network primary contro
 Please Note: If this doesn't work, you can check to see if your switch is within Z-Wave Range by holding down the Configuration Button for 5-10 seconds (if it's not within range, the LED Bar will indicate Red and if it is within Range, the LED Bar will indicate Green). If your switch indicates Red, please move the switch closer to the HUB. If your switch indicates Green, please try running an Exclusion to reset your switch.</MetaDataItem>
     <ChangeLog>
       <Entry author="Eric Maycock - ericm@inovelli.com" date="7 Nov 2019" revision="1">Initial Release</Entry>
+      <Entry author="Brett Daugherty" date="23 Jul 2020" revision="1">Update config for Firmware 1.47+</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -219,6 +220,20 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     <Item value="0" label="Load Only"/>
     <Item value="1" label="3-way Toggle"/>
     <Item value="2" label="3-way Momentary"/>
+    </Value>
+    <Value genre="config" type="list" size="1" index="51" label="Disable Physical On/Off Delay" min="0" max="1" value="1">
+      <Help>
+      The 700ms delay that occurs after pressing the physical button to turn the switch on/off is removed. Consequently this also removes the following scenes: 2x, 3x, 4x, 5x tap. 1x tap and config button scenes still work. (firmware 1.47+) 
+    </Help>
+    <Item value="0" label="Delay Disabled"/>
+    <Item value="1" label="Delay Enabled (Default)"/>
+    </Value>
+    <Value genre="config" type="list" size="1" index="52" label="Smart Bulb Mode" min="0" max="1" value="0">
+      <Help>
+      Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim & makes it act like an ON / OFF switch. (firmware 1.47+)
+    </Help>
+    <Item value="0" label="Smart Bulb Mode Disabled (Default)"/>
+    <Item value="1" label="Smart Bulb Mode Enabled"/>
     </Value>
   </CommandClass>
 

--- a/config/inovelli/lzw31.xml
+++ b/config/inovelli/lzw31.xml
@@ -1,4 +1,4 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/031E:0001:0003</MetaDataItem>
     <MetaDataItem name="ProductPic">images/inovelli/lzw31.png</MetaDataItem>
@@ -22,6 +22,7 @@ Only use either of these procedures in the event that the network primary contro
 Please Note: If this doesn't work, you can check to see if your switch is within Z-Wave Range by holding down the Configuration Button for 5-10 seconds (if it's not within range, the LED Bar will indicate Red and if it is within Range, the LED Bar will indicate Green). If your switch indicates Red, please move the switch closer to the HUB. If your switch indicates Green, please try running an Exclusion to reset your switch.</MetaDataItem>
     <ChangeLog>
       <Entry author="Eric Maycock - ericm@inovelli.com" date="7 Nov 2019" revision="1">Initial Release</Entry>
+	  <Entry author="Brett Daugherty and SirDeadlyStrike" date="23 Jul 2020" revision="2">Update config for Firmware 1.47+</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -191,6 +192,20 @@ Please Note: If this doesn't work, you can check to see if your switch is within
     <Item value="0" label="Load Only"/>
     <Item value="1" label="3-way Toggle"/>
     <Item value="2" label="3-way Momentary"/>
+    </Value>
+    <Value genre="config" type="list" size="1" index="51" label="Instant On" min="0" max="1" value="1">
+       <Help>
+          Enables instant on (ie: disables the 700ms button delay). Note, if you disable the delay, it will also disable scene control except for Button 1 (ie: tap up 1x or tap down 1x) and button 7 (config button). All other buttons (2-6) will be disabled.
+       </Help>
+       <Item value="0" label="Enabled (no delay)"/>
+       <Item value="1" label="Disabled (700ms delay)"/>
+    </Value>
+    <Value genre="config" type="list" size="1" index="52" label="Smart Bulb Mode" min="0" max="1" value="0">
+      <Help>
+      Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim and makes it act like an ON / OFF switch. (firmware 1.47+)
+    </Help>
+    <Item value="0" label="Smart Bulb Mode Disabled (Default)"/>
+    <Item value="1" label="Smart Bulb Mode Enabled"/>
     </Value>
   </CommandClass>
 


### PR DESCRIPTION
The newest firmware for the LZW31-SN adds 2 new parameters. Details can be found [here](https://support.inovelli.com/portal/en/kb/articles/firmware-v1-47-beta-lzw31-sn-dimmer-red-series-gen-2).

Config parameters name and description pulled from the Hubitat "driver"