### PR TITLE
[Config Update] Kwikset Locks: New 910/914 XML (non-zwave+ versions)

### DIFF
--- a/config/kwikset/910.xml
+++ b/config/kwikset/910.xml
@@ -1,7 +1,7 @@
 <!-- 
 Kwikset smartcode 
 http://s7d5.scene7.com/is/content/BDHHI/z-wave-configuration
---><Product Revision="15" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0090:0001:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/kwikset/smartcode.png</MetaDataItem>
@@ -21,30 +21,15 @@ SmartKey: Re-key the lock in seconds</MetaDataItem>
     <MetaDataItem name="ProductSupport">http://www.kwikset.com/Customer-Support/Overview.aspx</MetaDataItem>
     <MetaDataItem name="Name">SmartCode 10 Touchpad Electronic Deadbolt</MetaDataItem>
     <ChangeLog>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/157/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/172/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/196/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/605/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="7">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/749/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="8">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/781/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="9">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/945/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="10">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1981/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="11">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2109/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="12">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2188/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="13">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2237/xml</Entry>
-      <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="14">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2369/xml</Entry>
-      <Entry author="Russell Troxel - russelltroxel@gmail.com" date="08 Jun 2020" revision="15">Fixed TriggerRefresh Index to properly update lock status via Access Control.</Entry>
+      <Entry author="firstof9 - firstof9@gmail.com" date="24 Jul 2020" revision="1">Fixed TriggerRefresh Index to properly update lock status via Alarm Type.</Entry>
     </ChangeLog>
-    <MetaDataItem id="0642" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2188/</MetaDataItem>
     <MetaDataItem name="WakeupDescription">Even though the lock is sleeping, all buttons are active and can be used to initiate any lock activity.
 For the RF side, it will wake up every 1 second to check if there are any requests from your smart home controller.</MetaDataItem>
     <MetaDataItem name="ProductManual">https://Products.Z-WaveAlliance.org/ProductManual/File?folder=&amp;filename=Manuals/2369/Install Guide GED1800 04112017.pdf</MetaDataItem>
-    <MetaDataItem id="0642" name="Identifier" type="0003">916</MetaDataItem>
     <MetaDataItem name="InclusionDescription">Initiate the process to add the lock to your system at your smart home controller.
 When prompted by your smart home system to add the lock, press button “A” on the lock interior one time. The red LED will illuminate when the lock enters Add Mode.
 Please allow time for the controller to add the lock to your system.</MetaDataItem>
     <MetaDataItem name="ExclusionDescription">Follow your smart home system’s instructions to remove the lock from the network. When prompted by the system, press button A” on the lock interior once.  The red LED will illuminate when the lock enters Remove mode. </MetaDataItem>
-    <MetaDataItem id="0642" name="FrequencyName" type="0003">U.S. / Canada / Mexico</MetaDataItem>
     <MetaDataItem name="ResetDescription">A factory reset will delete all user codes associated with the lock and will remove itself from your smart home system.
 Please only perform a factory reset when the primary controller is missing or inoperable.
 
@@ -54,12 +39,6 @@ To perform a factory reset, please perform the following:
 3. Keep holding the button for 30 seconds until the lock beeps and the status LED flashes red.
 4. Press the Program button once more.  The status LED will flash green and red several times.
 5. After a few seconds, the lock will initiate the door handing process.</MetaDataItem>
-    <MetaDataItem id="0440" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2237/</MetaDataItem>
-    <MetaDataItem id="0440" name="FrequencyName" type="0003">U.S. / Canada / Mexico</MetaDataItem>
-    <MetaDataItem id="0440" name="Identifier" type="0003">914</MetaDataItem>
-    <MetaDataItem id="0440" name="ZWProductPage" type="0006">https://products.z-wavealliance.org/products/2369/</MetaDataItem>
-    <MetaDataItem id="0440" name="Identifier" type="0006">GED1800</MetaDataItem>
-    <MetaDataItem id="0440" name="FrequencyName" type="0006">U.S. / Canada / Mexico</MetaDataItem>
   </MetaData>
   <!-- Configuration Parameters -->
   <CommandClass id="112">
@@ -377,7 +356,7 @@ To perform a factory reset, please perform the following:
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="512" Instance="1">
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>

--- a/config/kwikset/smartcode.xml
+++ b/config/kwikset/smartcode.xml
@@ -1,7 +1,7 @@
 <!-- 
 Kwikset smartcode 
 http://s7d5.scene7.com/is/content/BDHHI/z-wave-configuration
---><Product Revision="15" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="16" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0090:0001:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/kwikset/smartcode.png</MetaDataItem>
@@ -34,6 +34,7 @@ SmartKey: Re-key the lock in seconds</MetaDataItem>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="13">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2237/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="14">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2369/xml</Entry>
       <Entry author="Russell Troxel - russelltroxel@gmail.com" date="08 Jun 2020" revision="15">Fixed TriggerRefresh Index to properly update lock status via Access Control.</Entry>
+      <Entry author="firstof9 - firstof9@gmail.com" date="24 Jul 2020" revision="16">Fixed TriggerRefresh Index to properly update lock status via Alarm Type.</Entry>
     </ChangeLog>
     <MetaDataItem id="0642" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2188/</MetaDataItem>
     <MetaDataItem name="WakeupDescription">Even though the lock is sleeping, all buttons are active and can be used to initiate any lock activity.
@@ -377,7 +378,7 @@ To perform a factory reset, please perform the following:
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="512" Instance="1">
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1067,7 +1067,7 @@
   <Manufacturer id="0174" name="Kopera Development Inc"></Manufacturer>
   <Manufacturer id="023A" name="KUMHO ELECTRIC INC"></Manufacturer>
   <Manufacturer id="0090" name="Kwikset (Spectrum Brands)">
-    <Product config="kwikset/smartcode.xml" id="0001" name="Touchpad Electronic Deadbolt" type="0001"/>
+    <Product config="kwikset/910.xml" id="0001" name="Touchpad Electronic Deadbolt" type="0001"/>
     <Product config="kwikset/916.xml" id="0642" name="SmartCode 916" type="0001"/>
     <Product config="kwikset/916.xml" id="0642" name="SmartCode 916" type="0003"/>
     <Product config="kwikset/smartcode.xml" id="4006" name="SmartCode 914" type="0003"/>
@@ -1076,7 +1076,7 @@
     <Product config="kwikset/smartcode.xml" id="0339" name="SmartCode 912" type="0003"/>
     <Product config="kwikset/smartcode.xml" id="0236" name="SmartCode 910" type="0001"/>
     <Product config="kwikset/smartcode.xml" id="0238" name="SmartCode 910" type="0003"/>
-    <Product config="kwikset/smartcode.xml" id="0001" name="SmartCode 910" type="0001"/>
+    <Product config="kwikset/910.xml" id="0001" name="SmartCode 910" type="0001"/>
     <Product config="kwikset/smartcode.xml" id="0440" name="SmartCode 10" type="0006"/>
     <Product config="kwikset/smartcode.xml" id="0742" name="Obsidian" type="0003"/>
     <Product config="kwikset/914c.xml" id="0446" name="Convert 914" type="0003"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="110" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="111" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>


### PR DESCRIPTION
Replacement PR for #2304 

Unit testing shows 512/513 are the `alarm_type` and `alarm_level` reports that this lock uses instead of proper Notifications.