### PR TITLE
Add User code parameter to RF locking and unlocking notification event

### DIFF
--- a/config/NotificationCCTypes.xml
+++ b/config/NotificationCCTypes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<NotificationTypes xmlns='https://github.com/OpenZWave/open-zwave' Revision="11">
-	<!-- Last Updated with Version 11 - 1/1/20 -->
+<NotificationTypes xmlns='https://github.com/OpenZWave/open-zwave' Revision="12">
+	<!-- Last Updated with Version 12 - 21/8/20 -->
 	<!-- Please keep Localization.xml in sync with NotificationCCTypes.xml -->
 	<!-- If you are adding new Types or Params, Please also consider updating ValueIDIndexesDefines.def -->
 	<!-- Bump Revision number, run "xmllint format" and "make xmltest" before submitting -->
@@ -184,8 +184,10 @@
 		<AlarmEvent id="2" name="Manual Unlock Operation">
 		</AlarmEvent>
 		<AlarmEvent id="3" name="Wireless Lock Operation">
+			<AlarmEventParam id="260" type="usercodereport" name="User Code" />
 		</AlarmEvent>
 		<AlarmEvent id="4" name="Wireless Unlock Operation">
+			<AlarmEventParam id="260" type="usercodereport" name="User Code" />
 		</AlarmEvent>
 		<AlarmEvent id="5" name="Keypad Lock Operation">
 			<AlarmEventParam id="260" type="usercodereport" name="User Code" />


### PR DESCRIPTION
First of all; I'm not entirely sure that this is according to Z-Wave standards. However, my Id Lock 150 Z-Wave module sends the RFID user code this way (please see ID Locks documentation [here](https://idlock.se/wp-content/uploads/2019/08/IDLock150_ZWave_UserManual_v3.02.pdf) ).
