### PR TITLE
SwitchBinary CC to include payload length before assuming V2 message content

### DIFF
--- a/cpp/src/command_classes/Basic.cpp
+++ b/cpp/src/command_classes/Basic.cpp
@@ -148,7 +148,7 @@ namespace OpenZWave
 					if (!m_com.GetFlagBool(COMPAT_FLAG_BASIC_IGNOREREMAPPING) && m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING) != 0)
 					{
 						/* update our Mapped Class with the Target Values */
-						if (GetVersion() >= 2 && _length == 4)
+						if (GetVersion() >= 2 && _length >= 4)
 							UpdateMappedClass(_instance, m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING), _data[2]);
 						else
 							UpdateMappedClass(_instance, m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING), _data[1]);
@@ -158,7 +158,7 @@ namespace OpenZWave
 						if (Internal::VC::ValueByte* value = static_cast<Internal::VC::ValueByte*>(GetValue(_instance, ValueID_Index_Basic::Set)))
 						{
 							/* Set the Target Value, if it is present */
-							if (_length == 4)
+							if (_length >= 4)
 								value->SetTargetValue(_data[2], _data[3]);
 							value->OnValueRefreshed(_data[1]);
 							value->Release();
@@ -167,7 +167,7 @@ namespace OpenZWave
 						{
 							Log::Write(LogLevel_Warning, GetNodeId(), "No Valid Mapping for Basic Command Class and No ValueID Exported. Error?");
 						}
-						if (_length == 4)
+						if (_length >= 4)
 						{
 							if (Internal::VC::ValueByte* target = static_cast<Internal::VC::ValueByte*>(GetValue(_instance, ValueID_Index_Basic::Target)))
 							{
@@ -192,7 +192,7 @@ namespace OpenZWave
 						if (!m_com.GetFlagBool(COMPAT_FLAG_BASIC_IGNOREREMAPPING) && m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING) != 0)
 						{
 							/* update our Mapped Class with the Target Values */
-							if (GetVersion() >= 2 && _length == 4)
+							if (GetVersion() >= 2 && _length >= 4)
 								UpdateMappedClass(_instance, m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING), _data[2]);
 							else
 								UpdateMappedClass(_instance, m_com.GetFlagByte(COMPAT_FLAG_BASIC_MAPPING), _data[1]);
@@ -209,7 +209,7 @@ namespace OpenZWave
 								Log::Write(LogLevel_Warning, GetNodeId(), "No Valid Mapping for Basic Command Class and No ValueID Exported. Error?");
 							}
 							
-							if (_length == 4)
+							if (_length >= 4)
 							{
 								if (Internal::VC::ValueByte* target = static_cast<Internal::VC::ValueByte*>(GetValue(_instance, ValueID_Index_Basic::Target)))
 								{

--- a/cpp/src/command_classes/SwitchBinary.cpp
+++ b/cpp/src/command_classes/SwitchBinary.cpp
@@ -107,7 +107,7 @@ namespace OpenZWave
 					// data[1] => Switch state
 					if (Internal::VC::ValueBool* value = static_cast<Internal::VC::ValueBool*>(GetValue(_instance, ValueID_Index_SwitchBinary::Level)))
 					{
-						if (GetVersion() >= 2)
+						if (GetVersion() >= 2 && _length == 4)
 							value->SetTargetValue(_data[2] != 0, _data[3]);
 						value->OnValueRefreshed(_data[1] != 0);
 						value->Release();

--- a/cpp/src/command_classes/SwitchBinary.cpp
+++ b/cpp/src/command_classes/SwitchBinary.cpp
@@ -107,7 +107,7 @@ namespace OpenZWave
 					// data[1] => Switch state
 					if (Internal::VC::ValueBool* value = static_cast<Internal::VC::ValueBool*>(GetValue(_instance, ValueID_Index_SwitchBinary::Level)))
 					{
-						if (GetVersion() >= 2 && _length == 4)
+						if (GetVersion() >= 2 && _length >= 4)
 							value->SetTargetValue(_data[2] != 0, _data[3]);
 						value->OnValueRefreshed(_data[1] != 0);
 						value->Release();


### PR DESCRIPTION
Leviton DZ15S and maybe other switches that support Version 2, don't send a V2 report, but still send what appears to be a V1 report without the Target vale.  This checks the payload length as well as version. (the pattern currently used in Basic CC).
