### PR TITLE
Update GE 14294 device XML

### DIFF
--- a/config/ge/14294-dimmer.xml
+++ b/config/ge/14294-dimmer.xml
@@ -1,11 +1,11 @@
-<!-- GE(Jasco) 14294 Z-Wave Plus Dimmer Switch --><!-- Configuration Parameters - per
-             http://products.z-wavealliance.org/products/1442 --><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- GE(Jasco) 14294 Z-Wave Plus Dimmer Switch -->
+<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3038:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/14294-dimmer.png</MetaDataItem>
     <MetaDataItem id="3038" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/2105/</MetaDataItem>
     <MetaDataItem name="Name">In-Wall Smart 1000W Dimmer </MetaDataItem>
-    <MetaDataItem name="ProductManual">https://Products.Z-WaveAlliance.org/ProductManual/File?folder=&amp;filename=Manuals/2168/Binder1.pdf</MetaDataItem>
+    <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=MarketCertificationFiles/2105/Binder1.pdf</MetaDataItem>
     <MetaDataItem id="3038" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>
     <MetaDataItem name="ResetDescription">Quickly press ON (Top) button three (3) times then immediately
 press the OFF (Bottom) button three (3) times. The LED will flash
@@ -32,11 +32,10 @@ and release the top or bottom of the wireless smart dimmer
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2105/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2168/xml</Entry>
       <Entry author="Justin Hammond" date="26 Jun 2020" revision="6">Add Verified Change Flag </Entry>
+      <Entry author="Keith Pine" date="14 Sep 2020" revision="7">Fixed metadata, added undocumented configuration parameters</Entry>
     </ChangeLog>
-    <MetaDataItem id="3039" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/2168/</MetaDataItem>
-    <MetaDataItem id="3039" name="Identifier" type="4944">14299/ZW3006</MetaDataItem>
-    <MetaDataItem id="3039" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>
   </MetaData>
+  <!-- Configuration -->
   <CommandClass id="112">
     <Value genre="config" index="3" label="LED Light" max="2" min="0" size="1" type="list" value="0">
       <Help>Sets when the LED on the switch is lit.</Help>
@@ -48,6 +47,11 @@ and release the top or bottom of the wireless smart dimmer
       <Help>Change the top of the switch to OFF and the bottom of the switch to ON, if the switch was installed upside down.</Help>
       <Item label="No" value="0"/>
       <Item label="Yes" value="1"/>
+    </Value>
+    <Value genre="config" index="6" label="Dim up/down rate" max="1" min="0" size="1" type="list" value="0">
+      <Help>Adjust the speed at which the light ramps to a specific value other than 0 and FF.</Help>
+      <Item label="Quickly" value="0"/>
+      <Item label="Slowly" value="1"/>
     </Value>
     <!-- Both the number of steps (or levels) that the dimmer will change and the timing of the steps can be modified to suit personal preferences. The timing of the steps can be adjusted in 10 millisecond intervals. As an example, the default setting for parameter 8 is 3. This means that the lighting level will change every 30 milliseconds when the Dim Command is received. A value of 255 would mean that the level would change every 2.55 seconds. Combined, the two parameters allow dim rate adjustments from 10 milliseconds to 4.2 minutes to go from maximum-to-minimum or minimum-to-maximum brightness levels. -->
     <Value genre="config" index="7" label="Z-Wave Command Dim Step" max="99" min="1" type="byte" units="" value="1">
@@ -67,6 +71,14 @@ and release the top or bottom of the wireless smart dimmer
     </Value>
     <Value genre="config" index="12" label="ALL ON/ALL OFF Dim Rate" max="255" min="1" type="short" units="x 10 milliseconds" value="3">
       <Help>This value indicates in 10 millisecond resolution, how often the dim level will change. For example, if you set this parameter to 1, then every 10ms the dim level will change. If you set it to 255, then every 2.55 seconds the dim level will change.</Help>
+    </Value>
+    <Value genre="config" index="16" label="Switch Mode" max="1" min="0" size="1" type="list" value="0">
+      <Help>Turn your dimmer into an On/Off switch with switch mode.</Help>
+      <Item label="Disable" value="0"/>
+      <Item label="Enable" value="1"/>
+    </Value>
+    <Value genre="config" index="20" label="Minimum Dim Threshold" max="99" min="1" type="byte" units="" value="1">
+      <Help>Set the minimum dimmer threshold when manually or remotely controlled.</Help>
     </Value>
   </CommandClass>
   <CommandClass id="38">

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1176,8 +1176,8 @@
                                                         'md5' => '499251768ad6b8c824d1a20f49270d9ecb1bf8681067654ffe6a795aa3a5b8ac314e3a75047fade9bfaa31dd57879b16556fe5c4e04ea82db570f99c0171e177'
                                                       },
                'config/ge/14294-dimmer.xml' => {
-                                                 'Revision' => 6,
-                                                 'md5' => '3566a439c13669b14c25fa7ed20b60648877360616def87c30855143d5119228339f437ded87c44734558e1170cba5326a842df5b5c100e9202c199fad7d8c54'
+                                                 'Revision' => 7,
+                                                 'md5' => '4a6aaff166c92187dfe9dc674fe8417c6b149e5a3b1414c5efe5d88965378613dfd92fced66ca4a92484d582772a3009feece8e204c5135bef683b8956ed1585'
                                                },
                'config/ge/14295-dimmer-toggle.xml' => {
                                                         'Revision' => 2,


### PR DESCRIPTION
Remove duplicate metadata that was from a different product.

Add some undocumented configuration parameters. These are documented in newer revisions and work fine in this version. They should work with firmware version >= 5.26.

Interesting [discussion ](https://community.getvera.com/t/ge-14294-operation/197000/3) at the Vera community about these  undocumented parameters.

Thanks to KeithL in the HA community for [bringing this up](https://community.home-assistant.io/t/ozw-beta-can-t-set-parameter-not-in-device-xml/226588)!