### PR TITLE
BE469ZP User index="6" update

### DIFF
--- a/config/schlage/BE469ZP.xml
+++ b/config/schlage/BE469ZP.xml
@@ -1,4 +1,4 @@
-<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/003B:0469:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/schlage/BE469ZP.png</MetaDataItem>

--- a/config/schlage/BE469ZP.xml
+++ b/config/schlage/BE469ZP.xml
@@ -1,4 +1,4 @@
-<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/003B:0469:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/schlage/BE469ZP.png</MetaDataItem>
@@ -195,7 +195,7 @@ NOTE: Please use this procedure only when the network primary controller is miss
 		Lock Status is Changed, but instead send a Alarm Message -
 		So we trigger a Refresh of the DoorLock Command Class when
 		we recieve a Alarm Message Instead -->
-    <TriggerRefreshValue Genre="user" Index="0" Instance="1">
+    <TriggerRefreshValue Genre="user" Index="6" Instance="1">
       <RefreshClassValue CommandClass="98" Index="1" Instance="1" RequestFlags="0"/>
     </TriggerRefreshValue>
   </CommandClass>

--- a/config/schlage/BE469ZP.xml
+++ b/config/schlage/BE469ZP.xml
@@ -1,4 +1,4 @@
-<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/003B:0469:0001</MetaDataItem>
     <MetaDataItem name="ProductPic">images/schlage/BE469ZP.png</MetaDataItem>

--- a/config/schlage/BE469ZP.xml
+++ b/config/schlage/BE469ZP.xml
@@ -49,6 +49,7 @@ NOTE: Please use this procedure only when the network primary controller is miss
 </MetaDataItem>
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 Jun 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3130/xml</Entry>
+      <Entry author="Jaburges" date="03 Nov 2020" revision="3">Update TriggerRefreshValue index. </Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">


### PR DESCRIPTION
Based on this https://github.com/OpenZWave/Zwave2Mqtt/issues/742

and the BE469 lock that was updated. 
Solving error 
```
OpenZWave Info, Node101, Got a AlarmCmd_Report Message....
OpenZWave Info, Node101, Received Notification report (>v1): Type: Access Control (6) Event: Keypad Unlock Operation (6) Status: true, Param Length: 1
OpenZWave Warning, Node101, Couldn't Find ValueID_Index_Alarm::Type_ParamUserCodeid
OpenZWave Warning, Node101, Couldn't Find a ValueList for Notification Type 6 (1)
```