### PR TITLE
Update Cooper RF9540-N device

### DIFF
--- a/config/cooper/RF9540-N.xml
+++ b/config/cooper/RF9540-N.xml
@@ -1,4 +1,4 @@
-<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="4" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/001A:0101:4449</MetaDataItem>
     <MetaDataItem name="ProductPic">images/cooper/RF9540-N.png</MetaDataItem>
@@ -9,6 +9,7 @@
     <MetaDataItem name="Description">Aspire RF All load smart dimmer master</MetaDataItem>
     <ChangeLog>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="03 May 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/797/xml</Entry>
+      <Entry author="Tao Gong - gongtao0607@gmail.com" date="02 Nov 2020" revision="4">Remove group 255 as 0 associations is reported from the device</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters -->
@@ -73,9 +74,8 @@
   </CommandClass>
   <!-- Association Groups -->
   <CommandClass id="133">
-    <Associations num_groups="2">
+    <Associations num_groups="1">
       <Group index="1" label="Group #1" max_associations="5"/>
-      <Group index="255" label="Group #255" max_associations="1"/>
     </Associations>
   </CommandClass>
 </Product>


### PR DESCRIPTION
Opposite to the spec, group 255 allows 0 associations is reported
from the device. Issue discussed here:
https://community.home-assistant.io/t/stuck-on-associations/136980/6