### PR TITLE
[Config] Add LED config for Honeywell 39358 Fan Control

### DIFF
--- a/config/honeywell/39358-ZW4002.xml
+++ b/config/honeywell/39358-ZW4002.xml
@@ -1,4 +1,5 @@
-<!-- Honeywell(Jasco) 39358 / ZW4002 In-Wall Fan Control --><Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- Honeywell(Jasco) 39358 / ZW4002 In-Wall Fan Control -->
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0039:3131:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/honeywell/39358-ZW4002.png</MetaDataItem>
@@ -27,6 +28,7 @@ and release the top or bottom of the wireless smart dimmer
     <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=MarketCertificationFiles/2725/39358-HQSG-v1-para.pdf</MetaDataItem>
     <ChangeLog>
       <Entry author="Nathan Holben - nathan@holben.me" date="09 May 2020" revision="1">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2725/xml</Entry>
+      <Entry author="Bill Bagdon - bill@bagdon.io" date="14 Nov 2020" revision="2">Add LED config</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters - per https://products.z-wavealliance.org/products/2725 -->
@@ -35,6 +37,12 @@ and release the top or bottom of the wireless smart dimmer
       <Help>Change the top of the switch to OFF and the bottom of the switch to ON, if the switch was installed upside down.</Help>
       <Item label="No" value="0"/>
       <Item label="Yes" value="1"/>
+    </Value>
+    <Value genre="config" index="3" label="LED Light" max="2" min="0" size="1" type="list" value="0">
+      <Help>Sets when the LED on the switch is lit.</Help>
+      <Item label="LED on when fan on" value="0"/>
+      <Item label="LED on when fan off" value="1"/>
+      <Item label="LED always off" value="2"/>
     </Value>
   </CommandClass>
   <!-- Association Groups -->


### PR DESCRIPTION
The Honeywell 39358 is manufactured by Jasco and is similar to the GE Fan Control also manufactured by Jasco [config/ge/12724-dimmer.xml](../blob/master/config/ge/12724-dimmer.xml).

The control set for the LEDs is the same between the two devices and I have tested this out on 2 that I own.