### PR TITLE
Update 03009496.xml

### DIFF
--- a/config/technisat/03009496.xml
+++ b/config/technisat/03009496.xml
@@ -39,13 +39,13 @@
       <Item label="disable central scene" value="0" />
       <Item label="enable central scene" value="1" />
     </Value>
-    <Value type="int" genre="config" instance="1" index="2" label="Parameter 2" value="3" min="0" max="8640">
+    <Value type="short" genre="config" instance="1" index="2" label="Parameter 2" value="3" min="0" max="8640">
       <Help>
         3 to 8640 - Interval of current wattage meter reports in 10 seconds increments.
         0 - Disable unsolicited meter reports of current wattage.
       </Help>
     </Value>
-    <Value type="int" genre="config" instance="1" index="3" label="Parameter 3" value="60" min="0" max="30240">
+    <Value type="short" genre="config" instance="1" index="3" label="Parameter 3" value="60" min="0" max="30240">
       <Help>
         Interval of active energy meter reports in minutes.
          - 10 to 30240 - Interval of active energy meter unsolicited reports in minutes (10 minutes - 3 weeks)


### PR DESCRIPTION
Value type should be "short" for "Parameter 2" and "Parameter 3" as parameter size is 2 bytes.
Could also apply for 
open-zwave/config/technisat/03009497.xml
and
open-zwave/config/technisat/03009499.xml
Unfortunately for those two other devices I cannot check as I do not own these devices.