### PR TITLE
make MAX_TRIES configurable

### DIFF
--- a/config/options.xml
+++ b/config/options.xml
@@ -35,6 +35,9 @@
   This is unlikely to fix any timeout issues you may have -->
   <!-- <Option name="RetryTimeout" value="40000" /> -->
 
+  <!-- How many times do we try to send a message before giving up. -->
+  <!-- <Option name="MaxTries" value="1" /> -->
+
   <!-- If you are using any Security Devices, you MUST set a network Key -->
   <!-- <Option name="NetworkKey" value="0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10" /> -->
 

--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -35,6 +35,7 @@
 #include "command_classes/MultiInstance.h"
 #include "command_classes/Security.h"
 #include "aes/aescpp.h"
+#include "Options.h"
 
 namespace OpenZWave
 {
@@ -67,6 +68,12 @@ namespace OpenZWave
 			m_buffer[1] = 0;					// Length of the following data, filled in during Finalize.
 			m_buffer[2] = _msgType;
 			m_buffer[3] = _function;
+
+			int maxTries = MAX_TRIES;
+			if (Options::Get()->GetOptionAsInt("MaxTries", &maxTries)) 
+			{
+				m_maxSendAttempts = maxTries;
+			}
 		}
 
 //-----------------------------------------------------------------------------

--- a/cpp/src/Options.cpp
+++ b/cpp/src/Options.cpp
@@ -122,6 +122,7 @@ Options* Options::Create(string const& _configPath, string const& _userPath, str
 		s_instance->AddOptionString("NetworkKey", string(""), false);
 		s_instance->AddOptionBool("RefreshAllUserCodes", false); 					// if true, during startup, we refresh all the UserCodes the device reports it supports. If False, we stop after we get the first "Available" slot (Some devices have 250+ usercode slots! - That makes our Session Stage Very Long )
 		s_instance->AddOptionInt("RetryTimeout", RETRY_TIMEOUT);				// How long do we wait to timeout messages sent
+		s_instance->AddOptionInt("MaxTries", MAX_TRIES);				// How many time do we retry a message before giving up
 		s_instance->AddOptionBool("EnableSIS", true);						// Automatically become a SUC if there is no SUC on the network.
 		s_instance->AddOptionBool("AssumeAwake", true);						// Assume Devices that Support the Wakeup CC are awake when we first query them....
 		s_instance->AddOptionBool("NotifyOnDriverUnload", false);						// Should we send the Node/Value Notifications on Driver Unloading - Read comments in Driver::~Driver() method about possible race conditions


### PR DESCRIPTION
I've been experiencing issues with my Z-wave network: Every once in a while, a message will randomly timeout, most often when sending multiple messages at a time (https://groups.google.com/g/openzwave/c/Jcw-wn2i4FI).

I've not been able to find root cause of the issue, so as a workaround, I have shortened the timeout. This solved the "network freezing for 10 seconds" issue, but the problem is that dropped message could live my system in inconsistent state. So I've also decided to enable retries. 

Unfortunately, there has been no config option for retries until now. Option has only been hardcoded. This PR fixes this.