### PR TITLE
Adding COMMAND_CLASS_BASIC blocks to GE/Honeywell/Jasco switches that support double tap and default double tap association auto=true

### DIFF
--- a/config/ge/12724-dimmer.xml
+++ b/config/ge/12724-dimmer.xml
@@ -1,4 +1,4 @@
-<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="10" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="11" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3031:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/12724-dimmer.png</MetaDataItem>
@@ -20,6 +20,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="8">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2506/xml</Entry>
       <Entry author="Shaun Feakes" date="04 Sep 2019" revision="9">Update for 3032</Entry>
       <Entry author="Justin Hammond" date="26 June 2020" revision="10">Add Verifed Change Flag</Entry>
+      <Entry author="Brian France" date="19 Nov 2020" revision="11">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
     </ChangeLog>
     <MetaDataItem id="3033" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/1201/</MetaDataItem>
     <MetaDataItem id="3033" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>

--- a/config/ge/12724-dimmer.xml
+++ b/config/ge/12724-dimmer.xml
@@ -1,4 +1,4 @@
-<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="12" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="11" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3031:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/12724-dimmer.png</MetaDataItem>
@@ -20,8 +20,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="8">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2506/xml</Entry>
       <Entry author="Shaun Feakes" date="04 Sep 2019" revision="9">Update for 3032</Entry>
       <Entry author="Justin Hammond" date="26 June 2020" revision="10">Add Verifed Change Flag</Entry>
-      <Entry author="Justin Hammond" date="26 June 2020" revision="11">Add Verifed Change Flag</Entry>
-      <Entry author="Brian France" date="23 Nov 2020" revision="12">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="11">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
     <MetaDataItem id="3033" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/1201/</MetaDataItem>
     <MetaDataItem id="3033" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>

--- a/config/ge/12724-dimmer.xml
+++ b/config/ge/12724-dimmer.xml
@@ -77,4 +77,11 @@ Note: This should only be used in the event your network’s primary controller 
       <VerifyChanged index="0">true</VerifyChanged>
     </Compatibility>
   </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>
 </Product>

--- a/config/ge/12724-dimmer.xml
+++ b/config/ge/12724-dimmer.xml
@@ -1,4 +1,4 @@
-<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="11" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="10" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3031:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/12724-dimmer.png</MetaDataItem>
@@ -20,7 +20,6 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="8">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2506/xml</Entry>
       <Entry author="Shaun Feakes" date="04 Sep 2019" revision="9">Update for 3032</Entry>
       <Entry author="Justin Hammond" date="26 June 2020" revision="10">Add Verifed Change Flag</Entry>
-      <Entry author="Brian France" date="19 Nov 2020" revision="11">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
     </ChangeLog>
     <MetaDataItem id="3033" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/1201/</MetaDataItem>
     <MetaDataItem id="3033" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>
@@ -76,13 +75,6 @@ Note: This should only be used in the event your network’s primary controller 
   <CommandClass id="38">
     <Compatibility>
       <VerifyChanged index="0">true</VerifyChanged>
-    </Compatibility>
-  </CommandClass>
-  <!-- COMMAND_CLASS_BASIC -->
-  <CommandClass id="32">
-    <Compatibility>
-      <IgnoreMapping>true</IgnoreMapping>
-      <SetAsReport>true</SetAsReport>
     </Compatibility>
   </CommandClass>
 </Product>

--- a/config/ge/12724-dimmer.xml
+++ b/config/ge/12724-dimmer.xml
@@ -1,4 +1,4 @@
-<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="10" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- GE(Jasco) 12724 3-Way Dimmer Switch --><Product Revision="12" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3031:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/12724-dimmer.png</MetaDataItem>
@@ -20,6 +20,8 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="8">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2506/xml</Entry>
       <Entry author="Shaun Feakes" date="04 Sep 2019" revision="9">Update for 3032</Entry>
       <Entry author="Justin Hammond" date="26 June 2020" revision="10">Add Verifed Change Flag</Entry>
+      <Entry author="Justin Hammond" date="26 June 2020" revision="11">Add Verifed Change Flag</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="12">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
     <MetaDataItem id="3033" name="ZWProductPage" type="4944">https://products.z-wavealliance.org/products/1201/</MetaDataItem>
     <MetaDataItem id="3033" name="FrequencyName" type="4944">U.S. / Canada / Mexico</MetaDataItem>
@@ -75,6 +77,21 @@ Note: This should only be used in the event your network’s primary controller 
   <CommandClass id="38">
     <Compatibility>
       <VerifyChanged index="0">true</VerifyChanged>
+    </Compatibility>
+  </CommandClass>
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="3">
+      <Group index="1" label="Lifeline" max_associations="5"/>
+      <Group index="2" label="Basic - Local Load" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true" />
+    </Associations>
+  </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
     </Compatibility>
   </CommandClass>
 </Product>

--- a/config/ge/14291-switch.xml
+++ b/config/ge/14291-switch.xml
@@ -1,4 +1,4 @@
-<!-- Configuration Parameters - per https://products.z-wavealliance.org/products/1879 --><Product Revision="5" xmlns="https://github.com/OpenZWave/open-zwave">
+<!-- Configuration Parameters - per https://products.z-wavealliance.org/products/1879 --><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3036:4952</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/14291-switch.png</MetaDataItem>
@@ -19,6 +19,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="08 May 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1438/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1879/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2501/xml</Entry>
+      <Entry author="Brian France" date="19 Nov 2020" revision="6">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">

--- a/config/ge/14291-switch.xml
+++ b/config/ge/14291-switch.xml
@@ -40,7 +40,7 @@
     <Associations num_groups="3">
       <Group index="1" label="Lifeline" max_associations="5"/>
       <Group index="2" label="Basic - Local Load" max_associations="5"/>
-      <Group index="3" label="Basic - Double Tap" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true" />
     </Associations>
   </CommandClass>
   <!-- COMMAND_CLASS_BASIC -->

--- a/config/ge/14291-switch.xml
+++ b/config/ge/14291-switch.xml
@@ -19,7 +19,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="08 May 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1438/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1879/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2501/xml</Entry>
-      <Entry author="Brian France" date="19 Nov 2020" revision="6">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="6">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, default double tap association auto=true</Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">

--- a/config/ge/14291-switch.xml
+++ b/config/ge/14291-switch.xml
@@ -42,4 +42,11 @@
       <Group index="3" label="Basic - Double Tap" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>
 </Product>

--- a/config/ge/14292-toggle-switch.xml
+++ b/config/ge/14292-toggle-switch.xml
@@ -39,4 +39,11 @@
       <Group index="3" label="Basic - Double Tap" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>
 </Product>

--- a/config/ge/14292-toggle-switch.xml
+++ b/config/ge/14292-toggle-switch.xml
@@ -37,7 +37,7 @@
     <Associations num_groups="3">
       <Group index="1" label="Lifeline" max_associations="5"/>
       <Group index="2" label="Basic - Local Load" max_associations="5"/>
-      <Group index="3" label="Basic - Double Tap" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true" />
     </Associations>
   </CommandClass>
   <!-- COMMAND_CLASS_BASIC -->

--- a/config/ge/14292-toggle-switch.xml
+++ b/config/ge/14292-toggle-switch.xml
@@ -18,7 +18,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1856/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="3">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2055/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2502/xml</Entry>
-      <Entry author="Brian France" date="19 Nov 2020" revision="5">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="5">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, default double tap association auto=true</Entry>
     </ChangeLog>
     <MetaDataItem id="3038" name="ZWProductPage" type="4952">https://products.z-wavealliance.org/products/2055/</MetaDataItem>
     <MetaDataItem id="3038" name="FrequencyName" type="4952">U.S. / Canada / Mexico</MetaDataItem>

--- a/config/ge/14292-toggle-switch.xml
+++ b/config/ge/14292-toggle-switch.xml
@@ -1,4 +1,4 @@
-<Product Revision="4" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="5" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3037:4952</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/14292-toggle-switch.png</MetaDataItem>
@@ -18,6 +18,7 @@
       <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="2">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1856/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="3">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2055/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2502/xml</Entry>
+      <Entry author="Brian France" date="19 Nov 2020" revision="5">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
     </ChangeLog>
     <MetaDataItem id="3038" name="ZWProductPage" type="4952">https://products.z-wavealliance.org/products/2055/</MetaDataItem>
     <MetaDataItem id="3038" name="FrequencyName" type="4952">U.S. / Canada / Mexico</MetaDataItem>

--- a/config/ge/14294-dimmer.xml
+++ b/config/ge/14294-dimmer.xml
@@ -94,4 +94,11 @@ and release the top or bottom of the wireless smart dimmer
       <Group index="3" label="Basic - Double Tap" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>
 </Product>

--- a/config/ge/14294-dimmer.xml
+++ b/config/ge/14294-dimmer.xml
@@ -33,7 +33,7 @@ and release the top or bottom of the wireless smart dimmer
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2168/xml</Entry>
       <Entry author="Justin Hammond" date="26 Jun 2020" revision="6">Add Verified Change Flag </Entry>
       <Entry author="Keith Pine" date="14 Sep 2020" revision="7">Fixed metadata, added undocumented configuration parameters</Entry>
-      <Entry author="Brian France" date="19 Nov 2020" revision="8">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="8">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, default double tap association auto=true</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration -->

--- a/config/ge/14294-dimmer.xml
+++ b/config/ge/14294-dimmer.xml
@@ -1,5 +1,5 @@
 <!-- GE(Jasco) 14294 Z-Wave Plus Dimmer Switch -->
-<Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="8" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3038:4944</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/14294-dimmer.png</MetaDataItem>
@@ -33,6 +33,7 @@ and release the top or bottom of the wireless smart dimmer
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2168/xml</Entry>
       <Entry author="Justin Hammond" date="26 Jun 2020" revision="6">Add Verified Change Flag </Entry>
       <Entry author="Keith Pine" date="14 Sep 2020" revision="7">Fixed metadata, added undocumented configuration parameters</Entry>
+      <Entry author="Brian France" date="19 Nov 2020" revision="8">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration -->

--- a/config/ge/14294-dimmer.xml
+++ b/config/ge/14294-dimmer.xml
@@ -92,7 +92,7 @@ and release the top or bottom of the wireless smart dimmer
     <Associations num_groups="3">
       <Group index="1" label="Lifeline" max_associations="5"/>
       <Group index="2" label="Basic - Load" max_associations="5"/>
-      <Group index="3" label="Basic - Double Tap" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true" />
     </Associations>
   </CommandClass>
   <!-- COMMAND_CLASS_BASIC -->

--- a/config/ge/46201-switch.xml
+++ b/config/ge/46201-switch.xml
@@ -17,7 +17,7 @@
 3. Once your controller has confirmed that the device has been included, refresh the Z-Wave network to optimize performance.</MetaDataItem>
     <ChangeLog>
       <Entry author="Caleb Mingle - caleb@mingle.cm" date="07 Sept 2019" revision="1">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3317/xml</Entry>
-      <Entry author="Brian France" date="23 Nov 2020" revision="3">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="2">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">

--- a/config/ge/46201-switch.xml
+++ b/config/ge/46201-switch.xml
@@ -1,4 +1,4 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0063:3135:4952</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ge/46201-switch.png</MetaDataItem>
@@ -17,6 +17,7 @@
 3. Once your controller has confirmed that the device has been included, refresh the Z-Wave network to optimize performance.</MetaDataItem>
     <ChangeLog>
       <Entry author="Caleb Mingle - caleb@mingle.cm" date="07 Sept 2019" revision="1">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3317/xml</Entry>
+      <Entry author="Brian France" date="23 Nov 2020" revision="3">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">
@@ -38,7 +39,14 @@
     <Associations num_groups="3">
       <Group index="1" label="Lifeline" max_associations="5"/>
       <Group index="2" label="Basic - Local Load" max_associations="5"/>
-      <Group index="3" label="Basic - Double Tap" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true"/>
     </Associations>
+  </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+  <CommandClass id="32">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
   </CommandClass>
 </Product>

--- a/config/honeywell/39348-zw4008.xml
+++ b/config/honeywell/39348-zw4008.xml
@@ -1,5 +1,5 @@
 <!-- Honeywell(Jasco) 39348 / ZW4008 In-Wall Smart Switch-->
-<Product Revision="1" 
+<Product Revision="2" 
   xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <!--<MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/</MetaDataItem>-->

--- a/config/honeywell/39348-zw4008.xml
+++ b/config/honeywell/39348-zw4008.xml
@@ -20,7 +20,7 @@ Note: This should only be used in the event your network’s primary controller 
     <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=MarketCertificationFiles/3599/39348%20Binder.pdf</MetaDataItem>
     <ChangeLog>
       <Entry author="Jeff Sanicola - jeff.sanicola@outlook.com" date="01 Jan 2020" revision="1">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/Products/3599/xml</Entry>
-      <Entry author="Brian France" date="11 Dec 2020" revision="11">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
+      <Entry author="Brian France" date="11 Dec 2020" revision="2">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters - per https://products.z-wavealliance.org/products/3599 -->

--- a/config/honeywell/39348-zw4008.xml
+++ b/config/honeywell/39348-zw4008.xml
@@ -20,6 +20,7 @@ Note: This should only be used in the event your network’s primary controller 
     <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=MarketCertificationFiles/3599/39348%20Binder.pdf</MetaDataItem>
     <ChangeLog>
       <Entry author="Jeff Sanicola - jeff.sanicola@outlook.com" date="01 Jan 2020" revision="1">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/Products/3599/xml</Entry>
+      <Entry author="Brian France" date="11 Dec 2020" revision="11">Added COMMAND_CLASS_BASIC block to set Value type instead of Node Event for Basic Set, Added COMMAND_CLASS_ASSOCIATION block for double tap with double tap defauled to auto</Entry>
     </ChangeLog>
   </MetaData>
   <!-- Configuration Parameters - per https://products.z-wavealliance.org/products/3599 -->
@@ -43,7 +44,14 @@ Note: This should only be used in the event your network’s primary controller 
     <Associations num_groups="3">
       <Group index="1" label="Lifeline" max_associations="5"/>
       <Group index="2" label="Basic - Load" max_associations="5"/>
-      <Group index="3" label="Basic - Double Tap" max_associations="5"/>
+      <Group index="3" label="Basic - Double Tap" max_associations="5" auto="true"/>
     </Associations>
   </CommandClass>
+  <!-- COMMAND_CLASS_BASIC -->
+   <CommandClass id="32">
+     <Compatibility>
+       <IgnoreMapping>true</IgnoreMapping>
+       <SetAsReport>true</SetAsReport>
+     </Compatibility>
+   </CommandClass>
 </Product>


### PR DESCRIPTION
This will cause Basic Set, usually treated as a Node Event, to be converted to a Value type.

Thread talking about about the fix:

https://github.com/OpenZWave/qt-openzwave/issues/60#issuecomment-664781107
