### PR TITLE
Update manufacturer_specific.xml

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="132" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="134" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1026,6 +1026,7 @@
     <Product id="0001" name="RAone SmartDimmer Wall Dimmer Module" type="0001"/>
   </Manufacturer>
   <Manufacturer id="0312" name="Inovelli">
+    <Product config="inovelli/lzw30.xml" id="ff04" name="LZW30 Switch" type="ff00"/>
     <Product config="inovelli/nzw30.xml" id="1e01" name="NZW30 Smart Switch" type="1e01"/>
     <Product config="inovelli/nzw30.xml" id="1e00" name="NZW30 Smart Switch (w/Scene)" type="1e00"/>
     <Product config="inovelli/nzw30.xml" id="1e02" name="NZW30 Smart Toggle Switch (w/Scene)" type="1e02"/>


### PR DESCRIPTION
My LZW30 switch returns manufacturer id 0312 with a different id and type than the ones listed under 031E.