### PR TITLE
Add basic command class to Aeotec switches and dimmers

### DIFF
--- a/config/aeotec/zw111.xml
+++ b/config/aeotec/zw111.xml
@@ -2,7 +2,7 @@
 Aeotec ZW111 Nano Dimmer, base on Engineering Spec 3/6/2018 V2.02
 Product Type ID: EU=0x00, US=0x01, AU=0x02 CN=0x1D
 https://aeotec.freshdesk.com/helpdesk/attachments/6048080397
---><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0086:006F:0103</MetaDataItem>
     <MetaDataItem name="ProductPic">images/aeotec/zw111.png</MetaDataItem>
@@ -21,6 +21,7 @@ The Nano Dimmer is also a security Z-Wave plus device and supports Over The Air 
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2095/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2135/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2149/xml</Entry>
+      <Entry author="Matej Drobnič - matejdro@gmail.com" date="27 Dec 2020" revision="7">Enable Basic command class</Entry>
     </ChangeLog>
     <MetaDataItem id="006F" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/2135/</MetaDataItem>
     <MetaDataItem id="006F" name="Identifier" type="0003">ZW111-C</MetaDataItem>
@@ -361,4 +362,10 @@ The Nano Dimmer is also a security Z-Wave plus device and supports Over The Air 
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>	
 </Product>

--- a/config/aeotec/zw111.xml
+++ b/config/aeotec/zw111.xml
@@ -362,7 +362,8 @@ The Nano Dimmer is also a security Z-Wave plus device and supports Over The Air 
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
-  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+  <!-- Basic command class --> 
+  <CommandClass id="32">
     <Compatibility>
       <IgnoreMapping>true</IgnoreMapping>
       <SetAsReport>true</SetAsReport>

--- a/config/aeotec/zw116.xml
+++ b/config/aeotec/zw116.xml
@@ -1,7 +1,7 @@
 <!--
 Aeotec ZW116 Nano Switch, base on Engineering Spec 03/19/2018 V2.0
 Product Type ID: EU=0x00, US=0x01, AU=0x02 CN=0x1D 
---><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="7" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0086:0074:0103</MetaDataItem>
     <MetaDataItem name="ProductPic">images/aeotec/zw116.png</MetaDataItem>
@@ -20,6 +20,7 @@ The Nano Switch is also a security Z-Wave device and supports Over The Air (OTA)
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2208/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2288/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="6">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2289/xml</Entry>
+      <Entry author="Matej Drobnič - matejdro@gmail.com" date="27 Dec 2020" revision="7">Enable Basic command class</Entry>
     </ChangeLog>
     <MetaDataItem id="0074" name="ZWProductPage" type="0203">https://products.z-wavealliance.org/products/2288/</MetaDataItem>
     <MetaDataItem id="0074" name="Identifier" type="0203">ZW116-B</MetaDataItem>
@@ -325,4 +326,10 @@ The Nano Switch is also a security Z-Wave device and supports Over The Air (OTA)
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+          <Compatibility>
+                  <IgnoreMapping>true</IgnoreMapping>
+                  <SetAsReport>true</SetAsReport>
+          </Compatibility>
+    </CommandClass>	
 </Product>

--- a/config/aeotec/zw116.xml
+++ b/config/aeotec/zw116.xml
@@ -326,7 +326,8 @@ The Nano Switch is also a security Z-Wave device and supports Over The Air (OTA)
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
-  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+  <!-- Basic command class --> 
+  <CommandClass id="32">
           <Compatibility>
                   <IgnoreMapping>true</IgnoreMapping>
                   <SetAsReport>true</SetAsReport>

--- a/config/aeotec/zw132.xml
+++ b/config/aeotec/zw132.xml
@@ -356,7 +356,8 @@ The Dual Nano Switch is also a security Z-Wave device and supports Over The Air 
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
-  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+  <!-- Basic command class --> 
+  <CommandClass id="32">
     <Compatibility>
       <IgnoreMapping>true</IgnoreMapping>
       <SetAsReport>true</SetAsReport>

--- a/config/aeotec/zw132.xml
+++ b/config/aeotec/zw132.xml
@@ -1,7 +1,7 @@
 <!--
 Aeotec ZW132 Dual Nano Switch, base on Engineering Spec 03/19/2018 V2.0
 Product Type ID: EU=0x00, US=0x01, AU=0x02 CN=0x1D 
---><Product Revision="5" xmlns="https://github.com/OpenZWave/open-zwave">
+--><Product Revision="6" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0086:0084:0103</MetaDataItem>
     <MetaDataItem name="ProductPic">images/aeotec/zw132.png</MetaDataItem>
@@ -20,6 +20,7 @@ The Dual Nano Switch is also a security Z-Wave device and supports Over The Air 
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2136/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="4">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2150/xml</Entry>
       <Entry author="Justin Hammond - Justin@dynam.ac" date="02 Jun 2019" revision="5">Updated Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/2151/xml</Entry>
+      <Entry author="Matej Drobnič - matejdro@gmail.com" date="27 Dec 2020" revision="6">Enable Basic command class</Entry>
     </ChangeLog>
     <MetaDataItem id="0084" name="ZWProductPage" type="0203">https://products.z-wavealliance.org/products/2150/</MetaDataItem>
     <MetaDataItem id="0084" name="Identifier" type="0203">ZW132-B</MetaDataItem>
@@ -355,4 +356,10 @@ The Dual Nano Switch is also a security Z-Wave device and supports Over The Air 
       <Group index="4" label="Control Key2" max_associations="5"/>
     </Associations>
   </CommandClass>
+  <CommandClass id="32" name="COMMAND_CLASS_BASIC">
+    <Compatibility>
+      <IgnoreMapping>true</IgnoreMapping>
+      <SetAsReport>true</SetAsReport>
+    </Compatibility>
+  </CommandClass>	
 </Product>


### PR DESCRIPTION
As discussed on https://github.com/OpenZWave/qt-openzwave/issues/60, only way to use get Basic events going forward is to add couple of flags to the devices that support this.

These three devices all support basic command independently from controlling the load (e.g. pressing the physical switch can trigger basic set independently of controlling the actual load connected to those switches) and thus I think it is useful for OZW to also report basic status independently from actual load status.