### PR TITLE
fix: Correct SetValue exception message on Schedule and Button

### DIFF
--- a/cpp/src/Manager.cpp
+++ b/cpp/src/Manager.cpp
@@ -3094,7 +3094,7 @@ bool Manager::SetValue(ValueID const& _id, string const& _value)
 				case ValueID::ValueType_Schedule:
 				case ValueID::ValueType_Button:
 				{
-					OZW_ERROR(OZWException::OZWEXCEPTION_CANNOT_CONVERT_VALUEID, "ValueID passed to GetValueFloatPrecision is not a Decimal Value");
+					OZW_ERROR(OZWException::OZWEXCEPTION_INVALID_VALUEID, "ValueID passed to SetValue cannot be set on Schedule or Button");
 					break;
 				}
 			}


### PR DESCRIPTION
Change the exception to a unique message indicating an error in the
SetValue() function, rather than GetValueFloatPrecision().

My logs contain many instances of the previous message from a Button:
```
Warning, Exception: Manager.cpp:2499 - 102 - ValueID passed to GetValueFloatPrecision is not a Decimal Value
```
I'm not sure if the error is occurring in GetValueFloatPrecision() or
SetValue(), either way this line needs to be corrected.