### PR TITLE
Ring Alarm Contact Sensor: minor fix

### DIFF
--- a/config/ring/contact-sensor-v2.xml
+++ b/config/ring/contact-sensor-v2.xml
@@ -1,11 +1,11 @@
-<Product Revision="1" xmlns="https://github.com/OpenZWave/open-zwave">
+<Product Revision="2" xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
     <MetaDataItem name="Name">Contact Sensor</MetaDataItem>
     <MetaDataItem name="Description">Ring Alarm Contact Sensor is a wireless sensor for the Ring Alarm system which provides users the ability to know when a door or window is open or closed. After installing the sensor on a door or window and setting up the sensor in the Ring app, monitor and receive notifications when the door or window opens or closes. The Ring Alarm Base Station is required to enable Contact Sensor features and functions within the Ring app. </MetaDataItem>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0346:0301:0201</MetaDataItem>
     <MetaDataItem name="ProductPic">images/ring/contact-sensor-v2.png</MetaDataItem>
     <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=product_documents/3862/Z-WaveUserManual_Contact_Sensor_700.pdf</MetaDataItem>
-    <MetaDataItem name="WakeupDescription">">The sensor will wake up every so often to send a Wake-Up Notification to allow the life line master node controller that the sensor is now available for any queued messages that the controller may have for the sensor. The time between Wake-Up Notifications can be configured with the Wake-Up Notification command class according to the following configurable values:
+    <MetaDataItem name="WakeupDescription">The sensor will wake up every so often to send a Wake-Up Notification to allow the life line master node controller that the sensor is now available for any queued messages that the controller may have for the sensor. The time between Wake-Up Notifications can be configured with the Wake-Up Notification command class according to the following configurable values:
 •	Min Value 1 hr
 •	Max Value 24 hr
 •	Default Value 12 hours (12 * 60 * 60 seconds)
@@ -26,6 +26,7 @@
     <MetaDataItem id="0301" name="Identifier" type="0201">Contact Sensor v2</MetaDataItem>
     <MetaDataItem id="0301" name="FrequencyName" type="0201">U.S. / Canada / Mexico</MetaDataItem>
     <ChangeLog>
+	<Entry author="gongtao0607@gmail.com" date="17 Jan 2021" revision="2">Minor correction</Entry>
 	<Entry author="gongtao0607@gmail.com" date="13 Jan 2021" revision="1">Initial Metadata Creation</Entry>
     </ChangeLog>
   </MetaData>
@@ -58,7 +59,7 @@
         Writing to this parameter prompts the sensor to send a wakeup notification one time after this parameter's number of seconds. After which it is reset back to 0.
       </Help>
     </Value>
-    <Value genre="config" index="6" label="Supervisory Report Timeout" max="5000" min="500" size="2" type="short" units="milliseconds" value="1500">
+    <Value genre="config" index="6" label="Supervisory Report Timeout" max="30000" min="500" size="2" type="short" units="milliseconds" value="10000">
       <Help>
         The number of milliseconds waiting for a Supervisory Report response to a Supervisory Get encapsulated command from the sensor before attempting a retry.
       </Help>

--- a/config/ring/contact-sensor-v2.xml
+++ b/config/ring/contact-sensor-v2.xml
@@ -26,8 +26,8 @@
     <MetaDataItem id="0301" name="Identifier" type="0201">Contact Sensor v2</MetaDataItem>
     <MetaDataItem id="0301" name="FrequencyName" type="0201">U.S. / Canada / Mexico</MetaDataItem>
     <ChangeLog>
-	<Entry author="gongtao0607@gmail.com" date="17 Jan 2021" revision="2">Minor correction</Entry>
 	<Entry author="gongtao0607@gmail.com" date="13 Jan 2021" revision="1">Initial Metadata Creation</Entry>
+	<Entry author="gongtao0607@gmail.com" date="17 Jan 2021" revision="2">Minor correction</Entry>
     </ChangeLog>
   </MetaData>
   <CommandClass id="112">


### PR DESCRIPTION
Config 6 is misdocumented in z-wave alliance. The true values are
read(tested) from the device.