### PR TITLE
feat: add new type/id for shenzhen neo water sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1641,6 +1641,7 @@
     <Product config="shenzen_neo/nas-pd02z.xml" id="008d" name="NAS-PD02Z Battery Powered PIR Sensor V2" type="0003"/>
     <Product config="shenzen_neo/nas-pd03z.xml" id="1031" name="NAS-PD03Z Battery Powered PIR Sensor V2" type="0200"/>
     <Product config="shenzen_neo/nas-ws02z.xml" id="0085" name="Water Leakage Detector" type="0003"/>
+    <Product config="shenzen_neo/nas-ws02z.xml" id="1025" name="Water Leakage Detector" type="0100"/>
     <Product config="shenzen_neo/nas-ws02z.xml" id="1085" name="Water Leakage Detector" type="0003"/>
     <Product config="shenzen_neo/nas-ws02z.xml" id="6085" name="Water Leakage Detector" type="0003"/>
     <Product config="shenzen_neo/nas-ws02z.xml" id="2085" name="Water Leakage Detector" type="0003"/>


### PR DESCRIPTION
I received a batch of these Shenzhen Neo water sensors via an Alibaba seller that report as a new type/id not known OZW. 

In case it's relevant, the only other difference I've noticed from a prior order of these sensors is that this batch does not send `SensorBinary` reports when triggered. 