### PR TITLE
Support new Dome Mouser id version 0104

### DIFF
--- a/config/dome/0104.xml
+++ b/config/dome/0104.xml
@@ -1,0 +1,95 @@
+<Product Revision="3" xmlns="https://github.com/OpenZWave/open-zwave">
+  <MetaData>
+    <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/021F:0086:0003</MetaDataItem>
+    <MetaDataItem name="ProductPic">images/dome/0086.png</MetaDataItem>
+    <MetaDataItem id="0104" name="ZWProductPage" type="0003">https://products.z-wavealliance.org/products/1847/</MetaDataItem>
+    <MetaDataItem name="Description">The Dome™ Home Automation DMMZ1 Mouser is a powerful rodent electric trap with Z-Wave technology built-in. It kills mice, rats and other rodents quickly, cleanly and humanely with a powerful jolt of electricity. Simply set bait, turn on and place in desired location. When connected to Z-Wave Certified Hub, once the trap is full, it sends out a notification to your smarthome system. You can easily dispose of Mouser’s contents without ever having to touch them. Use the top handle and tip to dispose of caught rodents. Specially designed removable and washable bait tray will allow you to easily replace the bait and set it back up. It operates on 4 AA batteries (not included) and is optimised to last over 50 uses. Mouser features extra-long Z-Wave wireless range (up to 150 ft) and  Dome™ DMMZ1 Mouser comes with a 1-year limited warranty. Measurements in inches: 8.75 x 4.5 x 5. Dome™ Home Automation Z-Wave devices give your family peace of mind and security you can count on. With Dome™, you’re always connected and always covered.
+•	Humanely kills mice, rats and other rodents with a powerful electric shock and sends an alert to your smarthome system when the trap needs to be emptied
+•	Easy to use: set bait, turn on and place in desired location 
+Touch free: hold handle and tip to dispose of contents, then set it again
+•	Up to 150-foot Z-Wave range. Operating Temperature: 32°F - 112°F. Powered by 4 AA batteries (not included) enabling it to be triggered over 50 times  
+•	Z-Wave Plus Certified. Works as a stand alone electronic mouse trap  but requires a Z-Wave Certified Hub for notification functionality
+•	Tested to work with SmartThings, Vera, Staples Connect, HomeSeer, Nexia, Piper, URC, Harmony. Not supported by Wink, DSC, ADT Pulse, 2Gig, Napco, Interlogix, Honeywell (Dome is not associated with listed brands)
+</MetaDataItem>
+    <MetaDataItem name="InclusionDescription">Follow the instructions for your Z-Wave Certified controller to enter inclusion mode.  When prompted by the controller:
+1. Bring the Mouser to within 10’ of your Z-Wave controller for the inclusion process.  After successful pairing, the device can be brought to the desired location.
+2. Remove top cover by sliding it back and lifting up.
+3. Insert batteries.
+4. Press the CONNECT BUTTON quickly 3 times in a row.
+5. The LED INDICATOR will flash five times indicating inclusion
+</MetaDataItem>
+    <MetaDataItem name="ResetDescription">If needed, the Mouser can be reset locally by following these steps.  Only do this when your Z-Wave controller is disconnected or otherwise unreachable.  Beware that resetting your device will disconnect it from the system:
+1. Remove the TOP COVER and confirm that your Mouser is powered up.
+2. Press and hold the CONNECT BUTTON for at least 10 seconds then release.  A flashing LED INDICATOR indicates a successful factory reset. 
+3. The Mouser’s memory will be erased to factory settings.  
+</MetaDataItem>
+    <MetaDataItem id="0104" name="Identifier" type="0003">DMMZ1</MetaDataItem>
+    <MetaDataItem name="WakeupDescription">If needed, the Mouser can be reset locally by following these steps.  Only do this when your Z-Wave controller is disconnected or otherwise unreachable.  Beware that resetting your device will disconnect it from the system:
+1. Remove the TOP COVER and confirm that your Mouser is powered up.
+2. Press and hold the CONNECT BUTTON for at least 10 seconds then release.  A flashing LED INDICATOR indicates a successful factory reset. 
+3. The Mouser’s memory will be erased to factory settings.  </MetaDataItem>
+    <MetaDataItem id="0104" name="FrequencyName" type="0003">U.S. / Canada / Mexico</MetaDataItem>
+    <MetaDataItem name="ExclusionDescription">Follow the instructions for your Z-Wave Certified controller to enter exclusion mode.
+When prompted by the controller:
+1. Remove top cover by sliding it back and lifting up.
+2. Press the CONNECT BUTTON quickly 3 times in a row.
+The LED INDICATOR will flash five times indicating exclusion/disconnection.</MetaDataItem>
+    <MetaDataItem name="ProductManual">https://Products.Z-WaveAlliance.org/ProductManual/File?folder=&amp;filename=Manuals/1847/Mouser API Manual.pdf</MetaDataItem>
+    <MetaDataItem name="Name">Dome Mouser</MetaDataItem>
+    <ChangeLog>
+      <Entry author="Justin Hammond - Justin@dynam.ac" date="24 May 2019" revision="3">Initial Metadata Import from Z-Wave Alliance Database - https://products.z-wavealliance.org/products/1847/xml</Entry>
+    </ChangeLog>
+  </MetaData>
+  <!--
+  Dome Mouser
+  https://products.z-wavealliance.org/products/1847
+  -->
+  <!-- Configuration Parameters -->
+  <CommandClass id="112">
+    <Value genre="config" index="1" label="Basic Set Level" max="255" min="0" size="1" type="byte" value="255">
+      <Help>
+        This parameter defines the value sent by the BASIC_SET command to Association Group 2.
+        0 Turn Off Device.
+        1 to 99 Set Device to Value.
+        255 Turn On Device.
+      </Help>
+    </Value>
+    <Value genre="config" index="2" label="Set Firing Mode" max="2" min="1" size="1" type="list" value="2">
+      <Help>
+        This parameter sets firing mode of the Mouser.
+        Two firing modes are available: in the first (Continuous Fire,) electricity is passed continuously for the entire duration,
+        and in the second (Burst Fire,) electricity is passed continuously only for the first minute and it is pulsed at approximately 400 beats per minute for the remainder of the time.
+      </Help>
+      <Item label="Continuous Fire" value="1"/>
+      <Item label="Burst Fire" value="2"/>
+    </Value>
+    <Value genre="config" index="3" label="High Voltage Duration Time" max="360" min="100" size="2" type="short" units="Seconds" value="100">
+      <Help>
+        This parameter defines how long the Mouser will fire continuously before it starts to burst-fire
+      </Help>
+    </Value>
+    <Value genre="config" index="4" label="LED Alarm" max="1" min="0" size="1" type="list" value="1">
+      <Help>
+        This parameter enables or disables the indicator LED alarm when the trap is tripped.
+      </Help>
+      <Item label="Disable" value="0"/>
+      <Item label="Enable" value="1"/>
+    </Value>
+    <Value genre="config" index="5" label="LED Alarm Duration" max="255" min="1" size="1" type="byte" units="Hours" value="0">
+      <Help>
+        This parameter sets the amount of time the LED Indicator blinks after the trap is tripped.
+        0 LED Blinks Until Trap is Reset.
+        1 to 255 in Hours.
+      </Help>
+    </Value>
+  </CommandClass>
+  <!-- Association Groups -->
+  <CommandClass id="133">
+    <Associations num_groups="4">
+      <Group index="1" label="Lifeline" max_associations="5"/>
+      <Group index="2" label="Basic Set" max_associations="5"/>
+      <Group index="3" label="Notification Report" max_associations="5"/>
+      <Group index="4" label="Sensor Binary Report" max_associations="5"/>
+    </Associations>
+  </CommandClass>
+</Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -531,6 +531,7 @@
     <Product config="dome/0087.xml" id="0087" name="On/Off Plug-In Switch" type="0003"/>
     <Product config="dome/0088.xml" id="0088" name="Siren" type="0003"/>
     <Product config="dome/0101.xml" id="0101" name="Door/Window Sensor" type="0003"/>
+    <Product config="dome/0104.xml" id="0104" name="Mouser" type="0003"/>
     <Product config="dome/dmex1.xml" id="0108" name="DMEX1 Range Extender" type="0003"/>
     <Product config="dome/0201.xml" id="0201" name="Door/Window Sensor Pro" type="0003"/>
   </Manufacturer>


### PR DESCRIPTION
There's a new hardware variant of the Dome Mouser z-wave pest trap out there. The device is functionally the same as the old 0086 id device but is now id 0104.