### PR TITLE
Removed Invalid RF9501 Group

### DIFF
--- a/config/cooper/RF9501.xml
+++ b/config/cooper/RF9501.xml
@@ -54,7 +54,6 @@
   <CommandClass id="133">
     <Associations num_groups="2">
       <Group index="1" label="Group #1" max_associations="5"/>
-      <Group index="255" label="Group #255" max_associations="1"/>
     </Associations>
   </CommandClass>
 </Product>

--- a/config/cooper/RF9501.xml
+++ b/config/cooper/RF9501.xml
@@ -52,7 +52,7 @@
   </CommandClass>
   <!-- Association Groups -->
   <CommandClass id="133">
-    <Associations num_groups="2">
+    <Associations num_groups="1">
       <Group index="1" label="Group #1" max_associations="5"/>
     </Associations>
   </CommandClass>


### PR DESCRIPTION
RF9501 has an invalid group in the config that causes the ZWave controller to go into an endless loop. I've removed the invalid group.