### PR TITLE
Darwin also needs O_NONBLOCK on the serial device

### DIFF
--- a/cpp/src/platform/unix/SerialControllerImpl.cpp
+++ b/cpp/src/platform/unix/SerialControllerImpl.cpp
@@ -34,6 +34,10 @@
 #include "SerialControllerImpl.h"
 #include "platform/Log.h"
 
+#if defined __APPLE__ && !defined DARWIN
+#define DARWIN
+#endif
+
 #ifdef __ANDROID__
 #include "android.h"
 #endif
@@ -179,7 +183,7 @@ namespace OpenZWave
 
 				Log::Write(LogLevel_Info, "Trying to open serial port %s (attempt %d)", device.c_str(), _attempts);
 
-#ifdef __NetBSD__
+#if defined __NetBSD__ || defined DARWIN
 				m_hSerialController = open( device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
 #else
 				m_hSerialController = open(device.c_str(), O_RDWR | O_NOCTTY, 0);


### PR DESCRIPTION
...without this, the serial controller just hangs under Mac OS. 
If this wasn't needed with older versions of the operating system, we should find out at which version this has changed.