### PR TITLE
Added entry in manufacturers.xml for Fibaro Smart Module FGS-214 in EU

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -691,6 +691,7 @@
     <Product config="fibaro/fgs213.xml" id="2000" name="FGS213 Switch" type="0403"/>
     <Product config="fibaro/fgs213.xml" id="3000" name="FGS213 Switch" type="0403"/>
     <Product config="fibaro/fgs213.xml" id="4000" name="FGS213 Switch" type="0403"/>
+    <Product config="fibaro/fgs214.xml" id="1000" name="FGS214 Single Relay Switch" type="0404"/>
     <Product config="fibaro/fgs214.xml" id="4000" name="FGS214 Single Relay Switch" type="0404"/>
     <Product config="fibaro/fgs221.xml" id="0104" name="FGS221 Double Relay Switch 2x1.5kW" type="0200"/>
     <Product config="fibaro/fgs221.xml" id="0105" name="FGS221 Double Relay Switch 2x1.5kW" type="0200"/>


### PR DESCRIPTION
This was required to correctly map our newly purchased FGS-214 switch with OpenZWave.  

Thanks!

Monica