### PR TITLE
Add Zooz ZST10 700 series USB controller

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="162" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="163" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -2039,6 +2039,9 @@
     <Product config="zipato/ne-nas-ab02z.xml" id="1083" name="Indoor Siren" type="0003"/>
   </Manufacturer>
   <Manufacturer id="0120" name="Zonoff"></Manufacturer>
+  <Manufacturer id="0000" name="Zooz">
+    <Product id="0004" name="ZST10 700 S2 Z-Wave Plus USB Stick" type="0004" />
+  </Manufacturer>
   <Manufacturer id="027a" name="Zooz">
     <Product id="0002" name="ZST10 S2 Z-Wave Plus USB Stick" type="0401"/>
     <Product config="zooz/zen06.xml" id="000a" name="ZEN06 Smart Plug" type="0101"/>


### PR DESCRIPTION
The new Zooz stick with 700 series chip is reporting with manufacturer 0000, type 0004 and id 0004. That manufacturer ID is in the list already for Sigma Designs but they don't have anything with id/type 0004 so I created a new Zooz entry with that manufacturer ID. I don't know what is the preferred way to handle such a thing. Maybe they'll get the manufacturer ID corrected on future production runs.

2021-02-09 09:57:36.850 Info, contrlr,     Manufacturer ID:      0x0000
2021-02-09 09:57:36.851 Info, contrlr,     Product Type:         0x0004
2021-02-09 09:57:36.851 Info, contrlr,     Product ID:           0x0004