### PR TITLE
Use supervision to set thermostat setpoint

### DIFF
--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -33,6 +33,7 @@
 #include "ZWSecurity.h"
 #include "platform/Log.h"
 #include "command_classes/MultiInstance.h"
+#include "command_classes/Supervision.h"
 #include "command_classes/Security.h"
 #include "aes/aescpp.h"
 
@@ -229,6 +230,33 @@ namespace OpenZWave
 
 			return str;
 		}
+
+//-----------------------------------------------------------------------------
+// <Msg::SupervisionEncap>
+// Encapsulate the data inside a Supervision message
+//-----------------------------------------------------------------------------
+		void Msg::SupervisionEncap(uint8 session_id)
+        {
+			char str[256];
+			if (m_buffer[3] != FUNC_ID_ZW_SEND_DATA)
+			{
+				return;
+			}
+
+            for (uint32 i = m_length - 1; i >= 6; --i)
+            {
+                m_buffer[i + 4] = m_buffer[i];
+            }
+            m_buffer[6] = Internal::CC::Supervision::StaticGetCommandClassId();
+            m_buffer[7] = Internal::CC::Supervision::SupervisionCmd_Get;
+            m_buffer[8] = Internal::CC::Supervision::SupervisionMoreStatusUpdates_MoreReports | session_id;
+            m_buffer[9] = m_buffer[5];
+            m_buffer[5] += 4;
+            m_length += 4;
+
+            snprintf(str, sizeof(str), "Supervisioned: %s", m_logText.c_str());
+            m_logText = str;
+        }
 
 //-----------------------------------------------------------------------------
 // <Msg::MultiEncap>

--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -51,7 +51,7 @@ namespace OpenZWave
 //-----------------------------------------------------------------------------
 		Msg::Msg(string const& _logText, uint8 _targetNodeId, uint8 const _msgType, uint8 const _function, bool const _bCallbackRequired, bool const _bReplyRequired,			// = true
 				uint8 const _expectedReply,			// = 0
-				uint8 const _expectedCommandClassId	// = 0
+				uint8 const _expectedCommandClassId // = 0
 				) :
 				m_logText(_logText), m_bFinal(false), m_bCallbackRequired(_bCallbackRequired), m_callbackId(0), m_expectedReply(0), m_expectedCommandClassId(_expectedCommandClassId), m_length(4), m_targetNodeId(_targetNodeId), m_sendAttempts(0), m_maxSendAttempts( MAX_TRIES), m_instance(1), m_endPoint(0), m_flags(0), m_encrypted(false), m_noncerecvd(false), m_homeId(0), m_resendDuetoCANorNAK(false)
 		{
@@ -108,13 +108,13 @@ namespace OpenZWave
 // Encapsulate the data inside a Supervision message
 //-----------------------------------------------------------------------------
 		void Msg::SetSupervision(uint8 _supervision_session_id)
-        {
-            if (_supervision_session_id != Internal::CC::Supervision::StaticNoSessionId())
-            {
-                m_supervision_session_id = _supervision_session_id;
-                m_flags |= m_Supervision;
-            }
-        }
+		{
+			if (_supervision_session_id != Internal::CC::Supervision::StaticNoSessionId())
+			{
+				m_supervision_session_id = _supervision_session_id;
+				m_flags |= m_Supervision;
+			}
+		}
 
 //-----------------------------------------------------------------------------
 // <Msg::Append>
@@ -305,27 +305,27 @@ namespace OpenZWave
 // Encapsulate the data inside a Supervision message
 //-----------------------------------------------------------------------------
 		void Msg::SupervisionEncap()
-        {
+		{
 			char str[256];
 			if (m_buffer[3] != FUNC_ID_ZW_SEND_DATA)
 			{
 				return;
 			}
 
-            for (uint32 i = m_length - 1; i >= 6; --i)
-            {
-                m_buffer[i + 4] = m_buffer[i];
-            }
-            m_buffer[6] = Internal::CC::Supervision::StaticGetCommandClassId();
-            m_buffer[7] = Internal::CC::Supervision::SupervisionCmd_Get;
-            m_buffer[8] = Internal::CC::Supervision::SupervisionMoreStatusUpdates_MoreReports | m_supervision_session_id;
-            m_buffer[9] = m_buffer[5];
-            m_buffer[5] += 4;
-            m_length += 4;
+			for (uint32 i = m_length - 1; i >= 6; --i)
+			{
+				m_buffer[i + 4] = m_buffer[i];
+			}
+			m_buffer[6] = Internal::CC::Supervision::StaticGetCommandClassId();
+			m_buffer[7] = Internal::CC::Supervision::SupervisionCmd_Get;
+			m_buffer[8] = Internal::CC::Supervision::SupervisionMoreStatusUpdates_MoreReports | m_supervision_session_id;
+			m_buffer[9] = m_buffer[5];
+			m_buffer[5] += 4;
+			m_length += 4;
 
-            snprintf(str, sizeof(str), "Supervisioned: %s", m_logText.c_str());
-            m_logText = str;
-        }
+			snprintf(str, sizeof(str), "Supervisioned: %s", m_logText.c_str());
+			m_logText = str;
+		}
 
 //-----------------------------------------------------------------------------
 // <Node::GetDriver>

--- a/cpp/src/Msg.cpp
+++ b/cpp/src/Msg.cpp
@@ -323,7 +323,7 @@ namespace OpenZWave
 			m_buffer[5] += 4;
 			m_length += 4;
 
-			snprintf(str, sizeof(str), "Supervisioned: %s", m_logText.c_str());
+			snprintf(str, sizeof(str), "Supervisioned (session=%d): %s", m_supervision_session_id, m_logText.c_str());
 			m_logText = str;
 		}
 

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -65,6 +65,7 @@ namespace OpenZWave
 
 				void Append(uint8 const _data);
 				void AppendArray(const uint8* const _data, const uint8 _length);
+				void SupervisionEncap(uint8 session_id);
 				void Finalize();
 				void UpdateCallbackId();
 
@@ -215,7 +216,7 @@ namespace OpenZWave
 				{
 					m_homeId = homeId;
 				}
-				void setResendDuetoCANorNAK() 
+				void setResendDuetoCANorNAK()
 				{
 					m_resendDuetoCANorNAK = true;
 				}

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -54,6 +54,7 @@ namespace OpenZWave
 				{
 					m_MultiChannel = 0x01,		// Indicate MultiChannel encapsulation
 					m_MultiInstance = 0x02,		// Indicate MultiInstance encapsulation
+					m_Supervision = 0x03,       // Indicate Supervision encapsulation
 				};
 
 				Msg(string const& _logtext, uint8 _targetNodeId, uint8 const _msgType, uint8 const _function, bool const _bCallbackRequired, bool const _bReplyRequired = true, uint8 const _expectedReply = 0, uint8 const _expectedCommandClassId = 0);
@@ -62,10 +63,10 @@ namespace OpenZWave
 				}
 
 				void SetInstance(OpenZWave::Internal::CC::CommandClass * _cc, uint8 const _instance);	// Used to enable wrapping with MultiInstance/MultiChannel during finalize.
+				void SetSupervision(uint8 _session_id);
 
 				void Append(uint8 const _data);
 				void AppendArray(const uint8* const _data, const uint8 _length);
-				void SupervisionEncap(uint8 session_id);
 				void Finalize();
 				void UpdateCallbackId();
 
@@ -232,6 +233,7 @@ namespace OpenZWave
 			private:
 
 				void MultiEncap();						// Encapsulate the data inside a MultiInstance/Multicommand message
+				void SupervisionEncap();				// Encapsulate the data inside a Supervision message
 				string m_logText;
 				bool m_bFinal;
 				bool m_bCallbackRequired;
@@ -250,6 +252,7 @@ namespace OpenZWave
 				uint8 m_instance;
 				uint8 m_endPoint;				// Endpoint to use if the message must be wrapped in a multiInstance or multiChannel command class
 				uint8 m_flags;
+                uint8 m_supervision_session_id;
 
 				bool m_encrypted;
 				bool m_noncerecvd;

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -54,7 +54,7 @@ namespace OpenZWave
 				{
 					m_MultiChannel = 0x01,		// Indicate MultiChannel encapsulation
 					m_MultiInstance = 0x02,		// Indicate MultiInstance encapsulation
-					m_Supervision = 0x03,       // Indicate Supervision encapsulation
+					m_Supervision = 0x04,       // Indicate Supervision encapsulation
 				};
 
 				Msg(string const& _logtext, uint8 _targetNodeId, uint8 const _msgType, uint8 const _function, bool const _bCallbackRequired, bool const _bReplyRequired = true, uint8 const _expectedReply = 0, uint8 const _expectedCommandClassId = 0);

--- a/cpp/src/Msg.h
+++ b/cpp/src/Msg.h
@@ -54,7 +54,7 @@ namespace OpenZWave
 				{
 					m_MultiChannel = 0x01,		// Indicate MultiChannel encapsulation
 					m_MultiInstance = 0x02,		// Indicate MultiInstance encapsulation
-					m_Supervision = 0x04,       // Indicate Supervision encapsulation
+					m_Supervision = 0x04,		// Indicate Supervision encapsulation
 				};
 
 				Msg(string const& _logtext, uint8 _targetNodeId, uint8 const _msgType, uint8 const _function, bool const _bCallbackRequired, bool const _bReplyRequired = true, uint8 const _expectedReply = 0, uint8 const _expectedCommandClassId = 0);
@@ -252,7 +252,7 @@ namespace OpenZWave
 				uint8 m_instance;
 				uint8 m_endPoint;				// Endpoint to use if the message must be wrapped in a multiInstance or multiChannel command class
 				uint8 m_flags;
-                uint8 m_supervision_session_id;
+				uint8 m_supervision_session_id;
 
 				bool m_encrypted;
 				bool m_noncerecvd;

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -58,6 +58,7 @@
 #include "command_classes/NodeNaming.h"
 #include "command_classes/NoOperation.h"
 #include "command_classes/Version.h"
+#include "command_classes/Supervision.h"
 #include "command_classes/SwitchAll.h"
 #include "command_classes/ZWavePlusInfo.h"
 #include "command_classes/DeviceResetLocally.h"
@@ -4048,4 +4049,20 @@ void Node::WriteMetaDataXML(TiXmlElement *mdElement)
 		}
 		mdElement->LinkEndChild(cl);
 	}
+}
+
+//-----------------------------------------------------------------------------
+// <Node::GetSupervisionSessionId>
+// Generate a new session id for Supervision encapsulation, if supported
+//-----------------------------------------------------------------------------
+uint Node::GetSupervisionSessionId(uint8 _command_class_id)
+{
+    if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
+    {
+        return cc->GetSession(_command_class_id);
+    }
+    else
+    {
+        return Internal::CC::Supervision::StaticNoSessionId();
+    }
 }

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -4055,7 +4055,7 @@ void Node::WriteMetaDataXML(TiXmlElement *mdElement)
 // <Node::GetSupervisionSessionId>
 // Generate a new session id for Supervision encapsulation, if supported
 //-----------------------------------------------------------------------------
-uint Node::GetSupervisionSessionId(uint8 _command_class_id)
+uint8 Node::GetSupervisionSessionId(uint8 _command_class_id)
 {
     if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
     {

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -4057,12 +4057,12 @@ void Node::WriteMetaDataXML(TiXmlElement *mdElement)
 //-----------------------------------------------------------------------------
 uint8 Node::GetSupervisionSessionId(uint8 _command_class_id)
 {
-    if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
-    {
-        return cc->GetSession(_command_class_id);
-    }
-    else
-    {
-        return Internal::CC::Supervision::StaticNoSessionId();
-    }
+	if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
+	{
+        	return cc->GetSession(_command_class_id);
+	}
+	else
+	{
+		return Internal::CC::Supervision::StaticNoSessionId();
+	}
 }

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -4052,17 +4052,33 @@ void Node::WriteMetaDataXML(TiXmlElement *mdElement)
 }
 
 //-----------------------------------------------------------------------------
-// <Node::GetSupervisionSessionId>
+// <Node::CreateSupervisionSession>
 // Generate a new session id for Supervision encapsulation, if supported
 //-----------------------------------------------------------------------------
-uint8 Node::GetSupervisionSessionId(uint8 _command_class_id)
+uint8 Node::CreateSupervisionSession(uint8 _command_class_id, uint8 _index)
 {
 	if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
 	{
-        	return cc->GetSession(_command_class_id);
+		return cc->CreateSupervisionSession(_command_class_id, _index);
 	}
 	else
 	{
 		return Internal::CC::Supervision::StaticNoSessionId();
+	}
+}
+
+//-----------------------------------------------------------------------------
+// <Node::GetSupervisionIndex>
+// Get the index used by a session
+//-----------------------------------------------------------------------------
+uint32 Node::GetSupervisionIndex(uint8 _session_id)
+{
+	if (Internal::CC::CommandClass* cc = GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
+	{
+		return cc->GetSupervisionIndex(_session_id);
+	}
+	else
+	{
+		return Internal::CC::Supervision::StaticNoIndex();
 	}
 }

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -911,6 +911,9 @@ namespace OpenZWave
 			void WriteMetaDataXML(TiXmlElement*);
 			map<MetaDataFields, string> m_metadata;
 			map<uint32_t, ChangeLogEntry> m_changeLog;
+
+		public:
+            uint GetSupervisionSessionId(uint8 _command_class_id);
 	};
 
 } //namespace OpenZWave

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -913,7 +913,8 @@ namespace OpenZWave
 			map<uint32_t, ChangeLogEntry> m_changeLog;
 
 		public:
-			uint8 GetSupervisionSessionId(uint8 _command_class_id);
+			uint8 CreateSupervisionSession(uint8 _command_class_id, uint8 _index);
+			uint32 GetSupervisionIndex(uint8 _session_id);
 	};
 
 } //namespace OpenZWave

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -913,7 +913,7 @@ namespace OpenZWave
 			map<uint32_t, ChangeLogEntry> m_changeLog;
 
 		public:
-            uint GetSupervisionSessionId(uint8 _command_class_id);
+            uint8 GetSupervisionSessionId(uint8 _command_class_id);
 	};
 
 } //namespace OpenZWave

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -913,7 +913,7 @@ namespace OpenZWave
 			map<uint32_t, ChangeLogEntry> m_changeLog;
 
 		public:
-            uint8 GetSupervisionSessionId(uint8 _command_class_id);
+			uint8 GetSupervisionSessionId(uint8 _command_class_id);
 	};
 
 } //namespace OpenZWave

--- a/cpp/src/command_classes/CommandClass.h
+++ b/cpp/src/command_classes/CommandClass.h
@@ -149,6 +149,11 @@ namespace OpenZWave
 					virtual bool supportsMultiInstance() {
 						return true;
 					}
+					virtual uint8 GetSession(uint8 _command_class_id) {
+						return 0;
+					}
+					virtual void SessionSuccess(uint8 _session_id, uint32 const _instance) {
+					}
 
 					void SetInstances(uint8 const _instances);
 					void SetInstance(uint8 const _endPoint);

--- a/cpp/src/command_classes/CommandClass.h
+++ b/cpp/src/command_classes/CommandClass.h
@@ -152,8 +152,7 @@ namespace OpenZWave
 					virtual uint8 GetSession(uint8 _command_class_id) {
 						return 0;
 					}
-					virtual void SessionSuccess(uint8 _session_id, uint32 const _instance) {
-					}
+					virtual void SupervisionSessionSuccess(uint8 _session_id, uint32 const _instance) {};
 
 					void SetInstances(uint8 const _instances);
 					void SetInstance(uint8 const _endPoint);

--- a/cpp/src/command_classes/CommandClass.h
+++ b/cpp/src/command_classes/CommandClass.h
@@ -149,7 +149,10 @@ namespace OpenZWave
 					virtual bool supportsMultiInstance() {
 						return true;
 					}
-					virtual uint8 GetSession(uint8 _command_class_id) {
+					virtual uint8 CreateSupervisionSession(uint8 _command_class_id, uint8 _index) {
+						return 0;
+					}
+					virtual uint32 GetSupervisionIndex(uint8 _session_id) {
 						return 0;
 					}
 					virtual void SupervisionSessionSuccess(uint8 _session_id, uint32 const _instance) {};

--- a/cpp/src/command_classes/CommandClasses.cpp
+++ b/cpp/src/command_classes/CommandClasses.cpp
@@ -70,6 +70,7 @@
 #include "command_classes/SensorBinary.h"
 #include "command_classes/SensorMultilevel.h"
 #include "command_classes/SoundSwitch.h"
+#include "command_classes/Supervision.h"
 #include "command_classes/SwitchAll.h"
 #include "command_classes/SwitchBinary.h"
 #include "command_classes/SwitchMultilevel.h"
@@ -226,6 +227,7 @@ namespace OpenZWave
 				cc.Register(SensorBinary::StaticGetCommandClassId(), SensorBinary::StaticGetCommandClassName(), SensorBinary::Create);
 				cc.Register(SensorMultilevel::StaticGetCommandClassId(), SensorMultilevel::StaticGetCommandClassName(), SensorMultilevel::Create);
 				cc.Register(SoundSwitch::StaticGetCommandClassId(), SoundSwitch::StaticGetCommandClassName(), SoundSwitch::Create);
+				cc.Register(Supervision::StaticGetCommandClassId(), Supervision::StaticGetCommandClassName(), Supervision::Create);
 				cc.Register(SwitchAll::StaticGetCommandClassId(), SwitchAll::StaticGetCommandClassName(), SwitchAll::Create);
 				cc.Register(SwitchBinary::StaticGetCommandClassId(), SwitchBinary::StaticGetCommandClassName(), SwitchBinary::Create);
 				cc.Register(SwitchMultilevel::StaticGetCommandClassId(), SwitchMultilevel::StaticGetCommandClassName(), SwitchMultilevel::Create);

--- a/cpp/src/command_classes/Supervision.cpp
+++ b/cpp/src/command_classes/Supervision.cpp
@@ -53,10 +53,9 @@ namespace OpenZWave
                 return Supervision::m_session_id;
             }
 
-
 //-----------------------------------------------------------------------------
 // <Supervision::HandleSupervisionReport>
-// Handle a message from the Z-Wave network
+// Handle a supervision report message from the Z-Wave network
 //-----------------------------------------------------------------------------
 			void Supervision::HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance)
 			{
@@ -77,7 +76,7 @@ namespace OpenZWave
                             {
                                 if (CommandClass* pCommandClass = node->GetCommandClass(Supervision::m_command_class_id))
                                 {
-                                    pCommandClass->SessionSuccess(session_id, _instance);
+                                    pCommandClass->SupervisionSessionSuccess(session_id, _instance);
                                 }
                             }
                         }
@@ -90,10 +89,8 @@ namespace OpenZWave
 				}
 			}
 
-
 			bool Supervision::HandleIncomingMsg(uint8 const* _data, uint32 const _length, uint32 const _instance)
 			{
-
 				return HandleMsg(_data, _length, _instance);
 			}
 

--- a/cpp/src/command_classes/Supervision.cpp
+++ b/cpp/src/command_classes/Supervision.cpp
@@ -1,0 +1,139 @@
+//-----------------------------------------------------------------------------
+//
+//	Supervision.h
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_SUPERVISION
+//
+//	Copyright (c) 2020 Mark Ruys <mark@paracas.nl>
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#include "command_classes/CommandClasses.h"
+#include "command_classes/Supervision.h"
+#include "Defs.h"
+#include "Msg.h"
+#include "Node.h"
+#include "Driver.h"
+#include "platform/Log.h"
+
+#include "value_classes/Value.h"
+
+namespace OpenZWave
+{
+	namespace Internal
+	{
+		namespace CC
+		{
+            uint Supervision::m_session_id = 0;
+
+            uint8 Supervision::GetSession(uint8 _command_class_id)
+            {
+                Supervision::m_session_id++;
+                Supervision::m_session_id &= 0x3f;
+
+                Supervision::m_command_class_id = _command_class_id;
+
+                return Supervision::m_session_id;
+            }
+
+
+//-----------------------------------------------------------------------------
+// <Supervision::HandleSupervisionReport>
+// Handle a message from the Z-Wave network
+//-----------------------------------------------------------------------------
+			void Supervision::HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance)
+			{
+                if (Node* node = GetNodeUnsafe())
+				{
+				    if ( _length >= 4 ) {
+				        uint8 more_status_updates = _data[1] >> 7;
+                        uint8 session_id = _data[1] & 0x3f;
+                        uint8 status = _data[2];
+                        int duration = _data[3];
+
+                        Log::Write(LogLevel_Info, GetNodeId(), "Received SupervisionReport: session id %d, status 0x%02x, duration %d sec, more status updates %d",
+                            session_id, status, decodeDuration(duration), more_status_updates);
+
+                        if ( status == Supervision::SupervisionStatus::SupervisionStatus_Success )
+                        {
+                            if ( Supervision::m_session_id == session_id )
+                            {
+                                if (CommandClass* pCommandClass = node->GetCommandClass(Supervision::m_command_class_id))
+                                {
+                                    pCommandClass->SessionSuccess(session_id, _instance);
+                                }
+                            }
+                        }
+
+                        if ( more_status_updates == 0 )
+                        {
+                            // Clean up session
+                        }
+					}
+				}
+			}
+
+
+			bool Supervision::HandleIncomingMsg(uint8 const* _data, uint32 const _length, uint32 const _instance)
+			{
+
+				return HandleMsg(_data, _length, _instance);
+			}
+
+//-----------------------------------------------------------------------------
+// <Supervision::HandleMsg>
+// Handle a message from the Z-Wave network
+//-----------------------------------------------------------------------------
+			bool Supervision::HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance	// = 1
+					)
+			{
+				bool handled = false;
+				Node* node = GetNodeUnsafe();
+				if (node != NULL)
+				{
+					handled = true;
+					switch ((SupervisionCmd) _data[0])
+					{
+// 						case SupervisionCmd_Get:
+// 						{
+// 							HandleSupervisionEncap(_data, _length);
+// 							break;
+// 						}
+						case SupervisionCmd_Report:
+						{
+							HandleSupervisionReport(_data, _length, _instance);
+							break;
+						}
+						default:
+						{
+							handled = false;
+							break;
+						}
+					}
+				}
+
+				return handled;
+
+
+			}
+		} // namespace CC
+	} // namespace Internal
+} // namespace OpenZWave
+

--- a/cpp/src/command_classes/Supervision.cpp
+++ b/cpp/src/command_classes/Supervision.cpp
@@ -41,17 +41,17 @@ namespace OpenZWave
 	{
 		namespace CC
 		{
-            uint8 Supervision::m_session_id = 0;
+			uint8 Supervision::m_session_id = 0;
 
-            uint8 Supervision::GetSession(uint8 _command_class_id)
-            {
-                Supervision::m_session_id++;
-                Supervision::m_session_id &= 0x3f;
+			uint8 Supervision::GetSession(uint8 _command_class_id)
+			{
+				Supervision::m_session_id++;
+				Supervision::m_session_id &= 0x3f;
 
-                Supervision::m_command_class_id = _command_class_id;
+				Supervision::m_command_class_id = _command_class_id;
 
-                return Supervision::m_session_id;
-            }
+				return Supervision::m_session_id;
+			}
 
 //-----------------------------------------------------------------------------
 // <Supervision::HandleSupervisionReport>
@@ -59,32 +59,32 @@ namespace OpenZWave
 //-----------------------------------------------------------------------------
 			void Supervision::HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance)
 			{
-                if (Node* node = GetNodeUnsafe())
+				if (Node* node = GetNodeUnsafe())
 				{
-				    if ( _length >= 4 ) {
-				        uint8 more_status_updates = _data[1] >> 7;
-                        uint8 session_id = _data[1] & 0x3f;
-                        uint8 status = _data[2];
-                        int duration = _data[3];
+					if ( _length >= 4 ) {
+						uint8 more_status_updates = _data[1] >> 7;
+						uint8 session_id = _data[1] & 0x3f;
+						uint8 status = _data[2];
+						int duration = _data[3];
 
-                        Log::Write(LogLevel_Info, GetNodeId(), "Received SupervisionReport: session id %d, status 0x%02x, duration %d sec, more status updates %d",
-                            session_id, status, decodeDuration(duration), more_status_updates);
+						Log::Write(LogLevel_Info, GetNodeId(), "Received SupervisionReport: session id %d, status 0x%02x, duration %d sec, more status updates %d",
+							session_id, status, decodeDuration(duration), more_status_updates);
 
-                        if ( status == Supervision::SupervisionStatus::SupervisionStatus_Success )
-                        {
-                            if ( Supervision::m_session_id == session_id )
-                            {
-                                if (CommandClass* pCommandClass = node->GetCommandClass(Supervision::m_command_class_id))
-                                {
-                                    pCommandClass->SupervisionSessionSuccess(session_id, _instance);
-                                }
-                            }
-                        }
+						if ( status == Supervision::SupervisionStatus::SupervisionStatus_Success )
+						{
+							if ( Supervision::m_session_id == session_id )
+							{
+								if (CommandClass* pCommandClass = node->GetCommandClass(Supervision::m_command_class_id))
+								{
+									pCommandClass->SupervisionSessionSuccess(session_id, _instance);
+								}
+							}
+						}
 
-                        if ( more_status_updates == 0 )
-                        {
-                            // Clean up session
-                        }
+						if ( more_status_updates == 0 )
+						{
+							// Clean up session
+						}
 					}
 				}
 			}
@@ -98,8 +98,7 @@ namespace OpenZWave
 // <Supervision::HandleMsg>
 // Handle a message from the Z-Wave network
 //-----------------------------------------------------------------------------
-			bool Supervision::HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance	// = 1
-					)
+			bool Supervision::HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance)	// = 1
 			{
 				bool handled = false;
 				Node* node = GetNodeUnsafe();
@@ -108,11 +107,6 @@ namespace OpenZWave
 					handled = true;
 					switch ((SupervisionCmd) _data[0])
 					{
-// 						case SupervisionCmd_Get:
-// 						{
-// 							HandleSupervisionEncap(_data, _length);
-// 							break;
-// 						}
 						case SupervisionCmd_Report:
 						{
 							HandleSupervisionReport(_data, _length, _instance);
@@ -127,8 +121,6 @@ namespace OpenZWave
 				}
 
 				return handled;
-
-
 			}
 		} // namespace CC
 	} // namespace Internal

--- a/cpp/src/command_classes/Supervision.cpp
+++ b/cpp/src/command_classes/Supervision.cpp
@@ -41,7 +41,7 @@ namespace OpenZWave
 	{
 		namespace CC
 		{
-            uint Supervision::m_session_id = 0;
+            uint8 Supervision::m_session_id = 0;
 
             uint8 Supervision::GetSession(uint8 _command_class_id)
             {

--- a/cpp/src/command_classes/Supervision.cpp
+++ b/cpp/src/command_classes/Supervision.cpp
@@ -114,14 +114,18 @@ namespace OpenZWave
 										pCommandClass->SupervisionSessionSuccess(session_id, _instance);
 									}
 								}
-							}
+								else
+								{
+									Log::Write(LogLevel_Warning, GetNodeId(), "Received SupervisionReport for unknown CC %d", it->command_class_id);
+								}
 
-							if (more_status_updates == 0)
-							{
-								m_sessions.erase(it);
-							}
+								if (more_status_updates == 0)
+								{
+									m_sessions.erase(it);
+								}
 							
-							return;
+								return;
+							}
 						}
 
 						Log::Write(LogLevel_Warning, GetNodeId(), "Received SupervisionReport: unknown session %d, status %s, duration %d sec, more status updates %d",

--- a/cpp/src/command_classes/Supervision.h
+++ b/cpp/src/command_classes/Supervision.h
@@ -1,0 +1,119 @@
+//-----------------------------------------------------------------------------
+//
+//	Supervision.h
+//
+//	Implementation of the Z-Wave COMMAND_CLASS_SUPERVISION
+//
+//	Copyright (c) 2020 Mark Ruys <mark@paracas.nl>
+//
+//	SOFTWARE NOTICE AND LICENSE
+//
+//	This file is part of OpenZWave.
+//
+//	OpenZWave is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU Lesser General Public License as published
+//	by the Free Software Foundation, either version 3 of the License,
+//	or (at your option) any later version.
+//
+//	OpenZWave is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU Lesser General Public License for more details.
+//
+//	You should have received a copy of the GNU Lesser General Public License
+//	along with OpenZWave.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#ifndef _Supervision_H
+#define _Supervision_H
+
+#include "command_classes/CommandClass.h"
+
+namespace OpenZWave
+{
+	namespace Internal
+	{
+		namespace CC
+		{
+			/** \brief Implements COMMAND_CLASS_SUPERVISION (0x6c), a Z-Wave device command class.
+			 * \ingroup CommandClass
+			 */
+			class Supervision: public CommandClass
+			{
+				public:
+                    enum SupervisionCmd
+                    {
+                        SupervisionCmd_Get = 0x01,
+                        SupervisionCmd_Report = 0x02,
+                    };
+                    enum SupervisionMoreStatusUpdates
+                    {
+                        SupervisionMoreStatusUpdates_LastReport = 0x00,
+                        SupervisionMoreStatusUpdates_MoreReports = 0x80,
+                    };
+                    enum SupervisionStatus
+                    {
+                        SupervisionStatus_NoSupport = 0x00,
+                        SupervisionStatus_Working = 0x01,
+                        SupervisionStatus_Fail = 0x02,
+                        SupervisionStatus_Success = 0xff
+                    };
+
+					static CommandClass* Create(uint32 const _homeId, uint8 const _nodeId)
+					{
+						return new Supervision(_homeId, _nodeId);
+					}
+					virtual ~Supervision()
+					{
+					}
+
+					static uint8 const StaticGetCommandClassId()
+					{
+						return 0x6c;
+					}
+					static string const StaticGetCommandClassName()
+					{
+						return "COMMAND_CLASS_SUPERVISION";
+					}
+
+// 					virtual uint8 GetMaxVersion() override
+// 					{
+// 						return 2;   // TODO support v2 too
+// 					}
+
+					uint8 GetSession(uint8 _command_class_id) ;
+					static uint8 const StaticNoSessionId()
+					{
+						return 0xff; // As sessions are only 5 bits, this value will never match
+					}
+
+					// From CommandClass
+					virtual uint8 const GetCommandClassId() const override
+					{
+						return StaticGetCommandClassId();
+					}
+					virtual string const GetCommandClassName() const override
+					{
+						return StaticGetCommandClassName();
+					}
+					virtual bool HandleIncomingMsg(uint8 const* _data, uint32 const _length, uint32 const _instance = 1) override;
+					virtual bool HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance = 1) override;
+
+				private:
+					Supervision(uint32 const _homeId, uint8 const _nodeId) :
+							CommandClass(_homeId, _nodeId)
+					{
+					}
+
+                    static uint m_session_id;
+                    uint m_command_class_id;    // TODO as implemented now we support only a single concurrent supervision call per CC
+
+					void HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance);
+			};
+		} // namespace CC
+	} // namespace Internal
+} // namespace OpenZWave
+
+#endif
+

--- a/cpp/src/command_classes/Supervision.h
+++ b/cpp/src/command_classes/Supervision.h
@@ -28,6 +28,8 @@
 #ifndef _Supervision_H
 #define _Supervision_H
 
+#include <deque>
+
 #include "command_classes/CommandClass.h"
 
 namespace OpenZWave
@@ -102,13 +104,18 @@ namespace OpenZWave
 
 				private:
 					Supervision(uint32 const _homeId, uint8 const _nodeId) :
-							CommandClass(_homeId, _nodeId), m_session_id{StaticNoSessionId()}
+						CommandClass(_homeId, _nodeId), 
+						m_last_session_id{StaticNoSessionId()}
 					{
 					}
 
-					uint8 m_session_id;
-					uint8 m_index;
-					uint8 m_command_class_id;
+					struct s_Session {
+						uint8 session_id;
+						uint8 command_class_id;
+						uint8 index;
+					};
+					std::deque<s_Session> m_sessions;
+					uint8 m_last_session_id;
 
 					void HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance);
 			};

--- a/cpp/src/command_classes/Supervision.h
+++ b/cpp/src/command_classes/Supervision.h
@@ -106,8 +106,8 @@ namespace OpenZWave
 					{
 					}
 
-                    static uint m_session_id;
-                    uint m_command_class_id;    // TODO as implemented now we support only a single concurrent supervision call per CC
+                    static uint8 m_session_id;
+                    uint8 m_command_class_id;    // TODO as implemented now we support only a single concurrent supervision call per CC
 
 					void HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance);
 			};

--- a/cpp/src/command_classes/Supervision.h
+++ b/cpp/src/command_classes/Supervision.h
@@ -77,10 +77,15 @@ namespace OpenZWave
 						return "COMMAND_CLASS_SUPERVISION";
 					}
 
-					uint8 GetSession(uint8 _command_class_id) ;
+					uint8 CreateSupervisionSession(uint8 _command_class_id, uint8 _index);
 					static uint8 const StaticNoSessionId()
 					{
 						return 0xff; // As sessions are only 5 bits, this value will never match
+					}
+					uint32 GetSupervisionIndex(uint8 _session_id);
+					static uint32 const StaticNoIndex()
+					{
+						return 0xffff; // As indices are max 16 bits, this value will never match
 					}
 
 					// From CommandClass
@@ -97,11 +102,12 @@ namespace OpenZWave
 
 				private:
 					Supervision(uint32 const _homeId, uint8 const _nodeId) :
-							CommandClass(_homeId, _nodeId)
+							CommandClass(_homeId, _nodeId), m_session_id{StaticNoSessionId()}
 					{
 					}
 
-					static uint8 m_session_id;
+					uint8 m_session_id;
+					uint8 m_index;
 					uint8 m_command_class_id;
 
 					void HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance);

--- a/cpp/src/command_classes/Supervision.h
+++ b/cpp/src/command_classes/Supervision.h
@@ -42,23 +42,23 @@ namespace OpenZWave
 			class Supervision: public CommandClass
 			{
 				public:
-                    enum SupervisionCmd
-                    {
-                        SupervisionCmd_Get = 0x01,
-                        SupervisionCmd_Report = 0x02,
-                    };
-                    enum SupervisionMoreStatusUpdates
-                    {
-                        SupervisionMoreStatusUpdates_LastReport = 0x00,
-                        SupervisionMoreStatusUpdates_MoreReports = 0x80,
-                    };
-                    enum SupervisionStatus
-                    {
-                        SupervisionStatus_NoSupport = 0x00,
-                        SupervisionStatus_Working = 0x01,
-                        SupervisionStatus_Fail = 0x02,
-                        SupervisionStatus_Success = 0xff
-                    };
+					enum SupervisionCmd
+					{
+						SupervisionCmd_Get = 0x01,
+						SupervisionCmd_Report = 0x02,
+					};
+					enum SupervisionMoreStatusUpdates
+					{
+						SupervisionMoreStatusUpdates_LastReport = 0x00,
+						SupervisionMoreStatusUpdates_MoreReports = 0x80,
+					};
+					enum SupervisionStatus
+					{
+						SupervisionStatus_NoSupport = 0x00,
+						SupervisionStatus_Working = 0x01,
+						SupervisionStatus_Fail = 0x02,
+						SupervisionStatus_Success = 0xff
+					};
 
 					static CommandClass* Create(uint32 const _homeId, uint8 const _nodeId)
 					{
@@ -76,11 +76,6 @@ namespace OpenZWave
 					{
 						return "COMMAND_CLASS_SUPERVISION";
 					}
-
-// 					virtual uint8 GetMaxVersion() override
-// 					{
-// 						return 2;   // TODO support v2 too
-// 					}
 
 					uint8 GetSession(uint8 _command_class_id) ;
 					static uint8 const StaticNoSessionId()
@@ -106,8 +101,8 @@ namespace OpenZWave
 					{
 					}
 
-                    static uint8 m_session_id;
-                    uint8 m_command_class_id;    // TODO as implemented now we support only a single concurrent supervision call per CC
+					static uint8 m_session_id;
+					uint8 m_command_class_id;
 
 					void HandleSupervisionReport(uint8 const* _data, uint32 const _length, uint32 const _instance);
 			};

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -297,6 +297,11 @@ namespace OpenZWave
                         m_value = static_cast<Internal::VC::ValueDecimal const*>(&_value);
                         m_supervision_session_id = node->GetSupervisionSessionId(StaticGetCommandClassId());
 
+						if (m_supervision_session_id == Internal::CC::Supervision::StaticNoSessionId())
+						{
+							Log::Write(LogLevel_Debug, GetNodeId(), "Supervision not supported, fall back to setpoint set/get");
+						}
+
                         uint8 scale = strcmp("C", m_value->GetUnits().c_str()) ? 1 : 0;
 
                         Msg* msg = new Msg("ThermostatSetpointCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true);

--- a/cpp/src/command_classes/ThermostatSetpoint.cpp
+++ b/cpp/src/command_classes/ThermostatSetpoint.cpp
@@ -144,7 +144,7 @@ namespace OpenZWave
 // <ThermostatSetpoint::HandleMsg>
 // Handle a message from the Z-Wave network
 //-----------------------------------------------------------------------------
-			bool ThermostatSetpoint::HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance	// = 1
+			bool ThermostatSetpoint::HandleMsg(uint8 const* _data, uint32 const _length, uint32 const _instance // = 1
 					)
 			{
 				if (ThermostatSetpointCmd_Report == (ThermostatSetpointCmd) _data[0])
@@ -264,20 +264,20 @@ namespace OpenZWave
 
 			void ThermostatSetpoint::SupervisionSessionSuccess(uint8 _session_id, uint32 const _instance)
 			{
-			    if ( m_supervision_session_id == _session_id )
-			    {
+				if ( m_supervision_session_id == _session_id )
+				{
 					if (Internal::VC::ValueDecimal* value = static_cast<Internal::VC::ValueDecimal*>(GetValue(_instance, m_supervision_index)))
 					{
 						value->ConfirmNewValue();
 
-                        Log::Write(LogLevel_Info, GetNodeId(), "Confirmed thermostat setpoint to %s%s",
-                            value->GetValue().c_str(), value->GetUnits().c_str());
-                    }
-                }
-                else
-                {
-                    Log::Write(LogLevel_Info, GetNodeId(), "Ignore unknown supervision session %d", _session_id);
-                }
+						Log::Write(LogLevel_Info, GetNodeId(), "Confirmed thermostat setpoint to %s%s",
+							value->GetValue().c_str(), value->GetUnits().c_str());
+					}
+				}
+				else
+				{
+					Log::Write(LogLevel_Info, GetNodeId(), "Ignore unknown supervision session %d", _session_id);
+				}
 			}
 
 //-----------------------------------------------------------------------------
@@ -286,36 +286,36 @@ namespace OpenZWave
 //-----------------------------------------------------------------------------
 			bool ThermostatSetpoint::SetValue(Internal::VC::Value const& _value)
 			{
-                if (Node* node = GetNodeUnsafe())
-                {
-                    if (ValueID::ValueType_Decimal == _value.GetID().GetType())
-                    {
-                        Internal::VC::ValueDecimal const* value = static_cast<Internal::VC::ValueDecimal const*>(&_value);
-                        m_supervision_session_id = node->GetSupervisionSessionId(StaticGetCommandClassId());
-                        m_supervision_index = value->GetID().GetIndex() & 0xFF;
+				if (Node* node = GetNodeUnsafe())
+				{
+					if (ValueID::ValueType_Decimal == _value.GetID().GetType())
+					{
+						Internal::VC::ValueDecimal const* value = static_cast<Internal::VC::ValueDecimal const*>(&_value);
+						m_supervision_session_id = node->GetSupervisionSessionId(StaticGetCommandClassId());
+						m_supervision_index = value->GetID().GetIndex() & 0xFF;
 
 						if (m_supervision_session_id == Internal::CC::Supervision::StaticNoSessionId())
 						{
 							Log::Write(LogLevel_Debug, GetNodeId(), "Supervision not supported, fall back to setpoint set/get");
 						}
 
-                        uint8 scale = strcmp("C", value->GetUnits().c_str()) ? 1 : 0;
+						uint8 scale = strcmp("C", value->GetUnits().c_str()) ? 1 : 0;
 
-                        Msg* msg = new Msg("ThermostatSetpointCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true);
-                        msg->SetInstance(this, _value.GetID().GetInstance());
-                        msg->SetSupervision(m_supervision_session_id);
-                        msg->Append(GetNodeId());
-                        msg->Append(4 + GetAppendValueSize(value->GetValue()));
-                        msg->Append(GetCommandClassId());
-                        msg->Append(ThermostatSetpointCmd_Set);
-                        msg->Append(m_supervision_index);
-                        AppendValue(msg, value->GetValue(), scale);
+						Msg* msg = new Msg("ThermostatSetpointCmd_Set", GetNodeId(), REQUEST, FUNC_ID_ZW_SEND_DATA, true);
+						msg->SetInstance(this, _value.GetID().GetInstance());
+						msg->SetSupervision(m_supervision_session_id);
+						msg->Append(GetNodeId());
+						msg->Append(4 + GetAppendValueSize(value->GetValue()));
+						msg->Append(GetCommandClassId());
+						msg->Append(ThermostatSetpointCmd_Set);
+						msg->Append(m_supervision_index);
+						AppendValue(msg, value->GetValue(), scale);
 
-                        msg->Append(GetDriver()->GetTransmitOptions());
-                        GetDriver()->SendMsg(msg, Driver::MsgQueue_Send);
-                        return true;
-                    }
-                }
+						msg->Append(GetDriver()->GetTransmitOptions());
+						GetDriver()->SendMsg(msg, Driver::MsgQueue_Send);
+						return true;
+					}
+				}
 
 				return false;
 			}

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -80,7 +80,7 @@ namespace OpenZWave
 					{
 						return 3;
 					}
-					virtual void SessionSuccess(uint8 _session_id, uint32 const _instance);
+					virtual void SupervisionSessionSuccess(uint8 _session_id, uint32 const _instance);
 
 				protected:
 					virtual void CreateVars(uint8 const _instance) override;

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <string>
 #include "command_classes/CommandClass.h"
+#include "value_classes/ValueDecimal.h"
 
 namespace OpenZWave
 {
@@ -79,12 +80,16 @@ namespace OpenZWave
 					{
 						return 3;
 					}
+					virtual void SessionSuccess(uint8 _session_id, uint32 const _instance);
 
 				protected:
 					virtual void CreateVars(uint8 const _instance) override;
 
 				private:
 					ThermostatSetpoint(uint32 const _homeId, uint8 const _nodeId);
+
+                    uint m_supervision_session_id;
+					Internal::VC::ValueDecimal const* m_value;
 			};
 		} // namespace CC
 	} // namespace Internal

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -89,7 +89,7 @@ namespace OpenZWave
 					ThermostatSetpoint(uint32 const _homeId, uint8 const _nodeId);
 
                     uint8 m_supervision_session_id;
-					Internal::VC::ValueDecimal const* m_value;
+					uint8 m_supervision_index;
 			};
 		} // namespace CC
 	} // namespace Internal

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -87,9 +87,6 @@ namespace OpenZWave
 
 				private:
 					ThermostatSetpoint(uint32 const _homeId, uint8 const _nodeId);
-
-					uint8 m_supervision_session_id;
-					uint8 m_supervision_index;
 			};
 		} // namespace CC
 	} // namespace Internal

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -88,7 +88,7 @@ namespace OpenZWave
 				private:
 					ThermostatSetpoint(uint32 const _homeId, uint8 const _nodeId);
 
-                    uint m_supervision_session_id;
+                    uint8 m_supervision_session_id;
 					Internal::VC::ValueDecimal const* m_value;
 			};
 		} // namespace CC

--- a/cpp/src/command_classes/ThermostatSetpoint.h
+++ b/cpp/src/command_classes/ThermostatSetpoint.h
@@ -88,7 +88,7 @@ namespace OpenZWave
 				private:
 					ThermostatSetpoint(uint32 const _homeId, uint8 const _nodeId);
 
-                    uint8 m_supervision_session_id;
+					uint8 m_supervision_session_id;
 					uint8 m_supervision_index;
 			};
 		} // namespace CC

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -36,6 +36,7 @@
 #include "value_classes/Value.h"
 #include "platform/Log.h"
 #include "command_classes/CommandClass.h"
+#include "command_classes/Supervision.h"
 #include <ctime>
 #include "Options.h"
 
@@ -312,9 +313,13 @@ namespace OpenZWave
 							{
 								if (!IsWriteOnly())
 								{
-									// queue a "RequestValue" message to update the value
-									if (m_refreshAfterSet) {
-										cc->RequestValue( 0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send );
+									if (m_refreshAfterSet)
+									{
+									    if (!node->GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
+									    {
+        									// queue a "RequestValue" message to update the value
+									    	cc->RequestValue( 0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send );
+									    }
 									}
 								}
 								else
@@ -483,11 +488,11 @@ namespace OpenZWave
 // Check a refreshed value
 //-----------------------------------------------------------------------------
 			int Value::VerifyRefreshedValue(
-					void* _originalValue, 
-					void* _checkValue, 
-					void* _newValue, 
+					void* _originalValue,
+					void* _checkValue,
+					void* _newValue,
 					void* _targetValue,
-					ValueID::ValueType _type, 
+					ValueID::ValueType _type,
 					int _originalValueLength, // = 0,
 					int _checkValueLength, // = 0,
 					int _newValueLength, // = 0,
@@ -788,19 +793,19 @@ namespace OpenZWave
 				 * - Caveat here is that if the outgoing queue is large, then this will be additionally delayed
 				 */
 				int32 timeout;
-				if (m_duration <= 2) 
+				if (m_duration <= 2)
 				{
 					timeout = 250;
 				}
-				else if (m_duration <= 5) 
+				else if (m_duration <= 5)
 				{
 					/* for Durations less than 5 seconds, lets refresh every 1/2 seconds
 					 */
 					timeout = 500;
-				} 
-				else 
+				}
+				else
 				{
-					/* Everything else is 1 second 
+					/* Everything else is 1 second
 					 */
 					timeout = 1000;
 				}
@@ -813,7 +818,7 @@ namespace OpenZWave
 
 //-----------------------------------------------------------------------------
 // <Value::sendValueRefresh>
-// Callback from the Timer to send a Get value to refresh a value from the 
+// Callback from the Timer to send a Get value to refresh a value from the
 // CheckTargetValue function
 //-----------------------------------------------------------------------------
 			void Value::sendValueRefresh(uint32 _unused)

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -499,10 +499,10 @@ namespace OpenZWave
 					int _targetValueLength // = 0,
 					)
 			{
-				// TODO: this is pretty rough code, but it's reused by each value type.	 It would be
+				// TODO: this is pretty rough code, but it's reused by each value type.  It would be
 				// better if the actions were taken (m_value = _value, etc.) in this code rather than
-				// in the calling routine as a result of the return value.	In particular, it's messy
-				// to be setting these values after the refesh or notification is sent.	 With some
+				// in the calling routine as a result of the return value.  In particular, it's messy
+				// to be setting these values after the refesh or notification is sent.  With some
 				// focus on the actual variable storage, we should be able to accomplish this with
 				// memory functions.  It's really the strings that make things complicated(?).
 				// if this is the first read of a value, assume it is valid (and notify as a change)

--- a/cpp/src/value_classes/Value.cpp
+++ b/cpp/src/value_classes/Value.cpp
@@ -315,11 +315,11 @@ namespace OpenZWave
 								{
 									if (m_refreshAfterSet)
 									{
-									    if (!node->GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
-									    {
-        									// queue a "RequestValue" message to update the value
-									    	cc->RequestValue( 0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send );
-									    }
+										if (!node->GetCommandClass(Internal::CC::Supervision::StaticGetCommandClassId()))
+										{
+											// queue a "RequestValue" message to update the value
+											cc->RequestValue( 0, m_id.GetIndex(), m_id.GetInstance(), Driver::MsgQueue_Send );
+										}
 									}
 								}
 								else
@@ -499,10 +499,10 @@ namespace OpenZWave
 					int _targetValueLength // = 0,
 					)
 			{
-				// TODO: this is pretty rough code, but it's reused by each value type.  It would be
+				// TODO: this is pretty rough code, but it's reused by each value type.	 It would be
 				// better if the actions were taken (m_value = _value, etc.) in this code rather than
-				// in the calling routine as a result of the return value.  In particular, it's messy
-				// to be setting these values after the refesh or notification is sent.  With some
+				// in the calling routine as a result of the return value.	In particular, it's messy
+				// to be setting these values after the refesh or notification is sent.	 With some
 				// focus on the actual variable storage, we should be able to accomplish this with
 				// memory functions.  It's really the strings that make things complicated(?).
 				// if this is the first read of a value, assume it is valid (and notify as a change)
@@ -612,9 +612,9 @@ namespace OpenZWave
 						bOriginalEqual = (*((bool*) _originalValue) == *((bool*) _newValue));
 						break;
 					case ValueID::ValueType_Raw:			// raw
-						bOriginalEqual = (_originalValueLength == _newValueLength);	// first check length of arrays
+						bOriginalEqual = (_originalValueLength == _newValueLength); // first check length of arrays
 						if (bOriginalEqual)
-							bOriginalEqual = (memcmp(_originalValue, _newValue, _newValueLength) == 0);	// if length is the same, then check content
+							bOriginalEqual = (memcmp(_originalValue, _newValue, _newValueLength) == 0); // if length is the same, then check content
 						break;
 					case ValueID::ValueType_Schedule:		// Schedule
 						/* Should not get here */

--- a/cpp/src/value_classes/ValueDecimal.cpp
+++ b/cpp/src/value_classes/ValueDecimal.cpp
@@ -87,6 +87,9 @@ namespace OpenZWave
 				ValueDecimal* tempValue = new ValueDecimal(*this);
 				tempValue->m_value = _value;
 
+				// Save the new value to be stored when the device confirms the value was set successfully, 
+				m_newValue = _value;
+
 				// Set the value in the device.
 				bool ret = ((Value*) tempValue)->Set();
 

--- a/cpp/src/value_classes/ValueDecimal.h
+++ b/cpp/src/value_classes/ValueDecimal.h
@@ -59,6 +59,10 @@ namespace OpenZWave
 
 					bool Set(string const& _value);
 					void OnValueRefreshed(string const& _value);
+					void ConfirmNewValue()
+					{
+						OnValueRefreshed(m_newValue);
+					};
 					void SetTargetValue(string const _target, uint32 _duration = 0);
 
 					// From Value


### PR DESCRIPTION
[ I messed up #2525, so I created a new PR ]

Some devices like the Fibaro FGT001 Heat Controller won't accept a `ThermostatSetpointCmd_Get` right immediate after a `ThermostatSetpointCmd_Set`. The device returns instead:

0x22 = COMMAND_CLASS_APPLICATION_STATUS (See 4.2.2 Application Busy Command in SDS13782 Z-Wave Management Command Class Specification.pdf)
0x01 = APPLICATION_BUSY
0x01 = "Try again in Wait Time seconds"
0x02 = two seconds...

One solution would be to retry the `ThermostatSetpointCmd_Get` after 2 seconds. A more efficient approach is to encapsulate the `ThermostatSetpointCmd_Set` with a supervision CC. This was proposed in issue #1971 and is implemented in this PR. It works like this:

```
2021-02-13 16:46:12.338 Info, Node019, Value::Set - COMMAND_CLASS_THERMOSTAT_SETPOINT - Heating 1 - 1 - 1 - 20
2021-02-13 16:46:12.338 Detail, Node019, Queuing (Send) MultiChannel Encapsulated (instance=1): Supervisioned: ThermostatSetpointCmd_Set (Node=19): 0x01, 0x14, 0x00, 0x13, 0x13, 0x0d, 0x60, 0x0d, 0x01, 0x01, 0x6c, 0x01, 0x83, 0x05, 0x43, 0x01, 0x01, 0x01, 0x14, 0x25, 0x8b, 0x98
2021-02-13 16:46:12.338 Info, Node019, Sending (Send) message (Callback ID=0x8b, Expected Reply=0x13) - MultiChannel Encapsulated (instance=1): Supervisioned: ThermostatSetpointCmd_Set (Node=19): 0x01, 0x14, 0x00, 0x13, 0x13, 0x0d, 0x60, 0x0d, 0x01, 0x01, 0x6c, 0x01, 0x83, 0x05, 0x43, 0x01, 0x01, 0x01, 0x14, 0x25, 0x8b, 0x98
2021-02-13 16:46:12.338 Info, Node019, Encrypted Flag is 0
2021-02-13 16:46:12.353 Detail, Node019,   Received: 0x01, 0x04, 0x01, 0x13, 0x01, 0xe8
2021-02-13 16:46:12.353 Detail, Node019,   ZW_SEND_DATA delivered to Z-Wave stack
2021-02-13 16:46:13.654 Detail, Node019,   Received: 0x01, 0x07, 0x00, 0x13, 0x8b, 0x00, 0x00, 0x83, 0xe3
2021-02-13 16:46:13.654 Detail, Node019,   ZW_SEND_DATA Request with callback ID 0x8b received (expected 0x8b)
2021-02-13 16:46:13.654 Info, Node019, Request RTT 1316 Average Request RTT 991
2021-02-13 16:46:13.654 Detail, Node019,   Expected callbackId was received
2021-02-13 16:46:13.654 Detail, Node019,   Expected reply was received
2021-02-13 16:46:13.655 Detail, Node019,   Message transaction complete
2021-02-13 16:46:13.655 Detail, Node019, Removing current message
2021-02-13 16:46:13.777 Detail, Node019,   Received: 0x01, 0x0f, 0x00, 0x04, 0x00, 0x13, 0x09, 0x60, 0x0d, 0x01, 0x01, 0x6c, 0x02, 0x03, 0xff, 0x00, 0x11
2021-02-13 16:46:13.777 Info, Node019, Received a MultiChannelEncap from node 19, endpoint 1 for Command Class COMMAND_CLASS_SUPERVISION
2021-02-13 16:46:13.777 Info, Node019, Received SupervisionReport: session 3, COMMAND_CLASS_THERMOSTAT_SETPOINT index 1, status SUCCESS, duration 0 sec, more status updates 0
2021-02-13 16:46:13.777 Detail, Node019, Value Updated: old value=22, new value=20, type=decimal
2021-02-13 16:46:13.778 Detail, Node019, Changes to this value are not verified
2021-02-13 16:46:13.778 Info, Node019, Confirmed thermostat setpoint index 1 to 20C
2021-02-13 16:46:13.778 Detail, Node019, Notification: ValueChanged CC: COMMAND_CLASS_THERMOSTAT_SETPOINT Instance: 1 Index: 1
```

The implementation supports up to 6 concurrent supervision sessions per node.
