### PR TITLE
Preserve whitespace in OZW XML cache

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -621,6 +621,7 @@ bool Driver::ReadCache()
 	string filename = userPath + string(str);
 
 	TiXmlDocument doc;
+	doc.SetCondenseWhiteSpace(false);
 	if (!doc.LoadFile(filename.c_str(), TIXML_ENCODING_UTF8))
 	{
 		return false;
@@ -7089,6 +7090,7 @@ void Driver::ReloadNode(uint8 const _nodeId)
 	string filename = userPath + string(str);
 
 	TiXmlDocument doc;
+	doc.SetCondenseWhiteSpace(false);
 	if (doc.LoadFile(filename.c_str(), TIXML_ENCODING_UTF8))
 	{
 		doc.SetUserData((void *) filename.c_str());


### PR DESCRIPTION
The `ozwcache_*.xml` file does not preserve white space. Config XML might contain useable formatting, so don't condense white space into a single space.

E.g., a configuration XML might contain:
```xml
 <Help>This parameter allows to enable different additional functions of the device.
                1) Enable open window detector (normal)
                2) Enable open window detector (rapid)
                4) Increase receiver sensitivity (shortens battery life)
                8) Enable LED indications when controlling remotely</Help>
```

Currently this is stored in the OZW XML cache as:
```xml
 <Help>This parameter allows to enable different additional functions of the device. 1) Enable open window detector (normal) 2) Enable open window detector (rapid) 4) Increase receiver sensitivity (shortens battery life) 8) Enable LED indications when controlling remotely</Help>
```

This makes it quiet hard to read.