### PR TITLE
Another id for MH9 CO2

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1256,6 +1256,7 @@
     <Product config="mcohome/mh8fceu0803.xml" id="5102" name="MH8-FC-EU Thermostat" type="0803"/>
     <Product config="mcohome/mh9co2.xml" id="0201" name="MH9-CO2-WD CO2 Monitor" type="0905"/>
     <Product config="mcohome/mh9co2.xml" id="3102" name="MH9-CO2-WD CO2 Monitor" type="0901"/>
+    <Product config="mcohome/mh9co2.xml" id="5102" name="MH9-CO2-WD CO2 Monitor" type="0901"/>
     <Product config="mcohome/mh9co2.xml" id="5102" name="MH9-CO2-WD CO2 Monitor" type="0902"/>
     <Product config="mcohome/mh10pm25wd.xml" id="5102" name="MH10-PM2.5-WD PM 2.5 Monitor" type="0a02"/>
     <Product config="mcohome/a8-9.xml" id="1352" name="A8-9 Multi-sensor" type="a800"/>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="164" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="165" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1948,8 +1948,8 @@
                                                    'md5' => '4d34aeaaea917c229bedbb737e4de1550b2d7db5f9e61566a1c0a39966b6442d381d01f93714e12aae1404797d36854274cc4063dd7424b00d27da238b17a36a'
                                                  },
                'config/manufacturer_specific.xml' => {
-                                                       'Revision' => 164,
-                                                       'md5' => '3ce2918880efc9ed125f9737eac4b0ccb71ea547bb326019f693dc597d079515a123b11e694b1df70eb9ecad46240dee00cb9db8a98225410d2c59035480fa25'
+                                                       'Revision' => 165,
+                                                       'md5' => '054b7122d3f1194e306f1f514306f4e95d11cf46e461d3d5c77bb3c0d246eb98e5456874868351bbbc3be3efe9aa3b653133bfd1631aa8cab322fd774f3b7a87'
                                                      },
                'config/mcohome/a8-9.xml' => {
                                               'Revision' => 1,


### PR DESCRIPTION
I have two versions of MH9 CO2 at my place.
One version with id=3102 and type=0901.
Second one with id=5102 and type=0901.