### PR TITLE
Add length of message to duplicate message detection (addresses #2587)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,11 @@ ozw_config
 gtest-main
 cpp/src/command_classes/\.DS_Store
 .DS_Store
+cpp/build/windows/vs2010/GIT-VS-VERSION-FILE
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/.suo
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/Browse.VC.db
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/Browse.VC.db-shm
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/Browse.VC.db-wal
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/Browse.VC.opendb
+cpp/build/windows/vs2010/.vs/OpenZWave/v16/ipch/AutoPCH/3d8d75d01e4a3926/NODE.ipch
+cpp/build/windows/vs2010/OpenZWave.vcxproj.user

--- a/cpp/src/Driver.h
+++ b/cpp/src/Driver.h
@@ -399,7 +399,7 @@ namespace OpenZWave
 			void HandleRemoveFailedNodeRequest(uint8* _data);
 			void HandleReplaceFailedNodeRequest(uint8* _data);
 			void HandleRemoveNodeFromNetworkRequest(uint8* _data);
-			void HandleApplicationCommandHandlerRequest(uint8* _data, bool encrypted);
+			void HandleApplicationCommandHandlerRequest(uint8* _data, uint8 _length, bool encrypted);
 			void HandlePromiscuousApplicationCommandHandlerRequest(uint8* _data);
 			void HandleAssignReturnRouteRequest(uint8* _data);
 			void HandleDeleteReturnRouteRequest(uint8* _data);

--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -99,11 +99,23 @@ static char const* c_queryStageNames[] =
 // Constructor
 //-----------------------------------------------------------------------------
 Node::Node(uint32 const _homeId, uint8 const _nodeId) :
-		m_queryStage(QueryStage_None), m_queryPending(false), m_queryConfiguration(false), m_queryRetries(0), m_protocolInfoReceived(false), m_basicprotocolInfoReceived(false), m_nodeInfoReceived(false), m_nodePlusInfoReceived(false), m_manufacturerSpecificClassReceived(false), m_nodeInfoSupported(true), m_refreshonNodeInfoFrame(true), m_nodeAlive(true),	// assome live node
+		m_queryStage(QueryStage_None), m_queryPending(false), m_queryConfiguration(false), m_queryRetries(0),
+		m_protocolInfoReceived(false), m_basicprotocolInfoReceived(false), m_nodeInfoReceived(false),
+		m_nodePlusInfoReceived(false), m_manufacturerSpecificClassReceived(false), m_nodeInfoSupported(true),
+		m_refreshonNodeInfoFrame(true), m_nodeAlive(true),	// assume live node
 		m_listening(true),	// assume we start out listening
-		m_frequentListening(false), m_beaming(false), m_routing(false), m_maxBaudRate(0), m_version(0), m_security(false), m_homeId(_homeId), m_nodeId(_nodeId), m_basic(0), m_generic(0), m_specific(0), m_type(""), m_addingNode(false), m_manufacturerName(""), m_productName(""), m_nodeName(""), m_location(""), m_manufacturerId(0), m_productType(0), m_productId(0), m_deviceType(0), m_role(0), m_nodeType(0), m_secured(false), m_nodeCache( NULL), m_Product( NULL), m_fileConfigRevision(0), m_loadedConfigRevision(
-				0), m_latestConfigRevision(0), m_values(new Internal::VC::ValueStore()), m_sentCnt(0), m_sentFailed(0), m_retries(0), m_receivedCnt(0), m_receivedDups(0), m_receivedUnsolicited(0), m_lastRequestRTT(0), m_lastResponseRTT(0), m_averageRequestRTT(0), m_averageResponseRTT(0), m_quality(0), m_lastReceivedMessage(), m_errors(0), m_txStatusReportSupported(false), m_txTime(0), m_hops(0), m_ackChannel(0), m_lastTxChannel(0), m_routeScheme((TXSTATUS_ROUTING_SCHEME) 0), m_routeUsed
-		{ }, m_routeSpeed((TXSTATUS_ROUTE_SPEED) 0), m_routeTries(0), m_lastFailedLinkFrom(0), m_lastFailedLinkTo(0), m_lastnonce(0)
+		m_frequentListening(false), m_beaming(false), m_routing(false), m_maxBaudRate(0), m_version(0), m_security(false),
+		m_homeId(_homeId), m_nodeId(_nodeId), m_basic(0), m_generic(0), m_specific(0), m_type(""),
+		m_addingNode(false), m_manufacturerName(""), m_productName(""), m_nodeName(""), m_location(""),
+		m_manufacturerId(0), m_productType(0), m_productId(0), m_deviceType(0), m_role(0), m_nodeType(0),
+		m_secured(false), m_nodeCache( NULL), m_Product( NULL), m_fileConfigRevision(0), m_loadedConfigRevision(0),
+		m_latestConfigRevision(0), m_values(new Internal::VC::ValueStore()), m_sentCnt(0), m_sentFailed(0),
+		m_retries(0), m_receivedCnt(0), m_receivedDups(0), m_receivedUnsolicited(0), m_lastRequestRTT(0),
+		m_lastResponseRTT(0), m_averageRequestRTT(0), m_averageResponseRTT(0), m_quality(0), m_lastReceivedMessage(),
+		m_lastReceivedMessageLength(0), m_errors(0), m_txStatusReportSupported(false), m_txTime(0), m_hops(0),
+		m_ackChannel(0), m_lastTxChannel(0), m_routeScheme((TXSTATUS_ROUTING_SCHEME) 0), m_routeUsed{ },
+		m_routeSpeed((TXSTATUS_ROUTE_SPEED) 0), m_routeTries(0), m_lastFailedLinkFrom(0), m_lastFailedLinkTo(0),
+		m_lastnonce(0)
 {
 	memset(m_neighbors, 0, sizeof(m_neighbors));
 	memset(m_nonces, 0, sizeof(m_nonces));

--- a/cpp/src/Node.h
+++ b/cpp/src/Node.h
@@ -798,6 +798,7 @@ namespace OpenZWave
 					uint32 m_averageResponseRTT;
 					uint8 m_quality;					// Node quality measure
 					uint8 m_lastReceivedMessage[254];
+					uint8 m_lastReceivedMessageLength;
 					list<CommandClassData> m_ccData;
 					bool m_txStatusReportSupported;
 					uint16 m_txTime;
@@ -834,6 +835,7 @@ namespace OpenZWave
 			uint32 m_averageResponseRTT;		// Average Response round trip time.
 			uint8 m_quality;					// Node quality measure
 			uint8 m_lastReceivedMessage[254];	// Place to hold last received message
+			uint8 m_lastReceivedMessageLength;	// Length of the last received message
 			uint8 m_errors;
 			bool m_txStatusReportSupported;		// if Extended Status Reports are available
 			uint16 m_txTime;					// Time Taken to Transmit the last frame


### PR DESCRIPTION
As described in issue #2587 a duplicate message may fail to be detected because additional bytes from previous messages are included in the comparison. This PR tries to address this by adding the length of a previously received message in the nod structure and use it in the comparison for a new incoming message. Also added setting the remainder of the buffer to 0x00 to make it more clear which data was actually in the buffer.