### PR TITLE
Update manufacturer_specific.xml

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="167" xmlns="https://github.com/OpenZWave/open-zwave">
+<ManufacturerSpecificData Revision="168" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>
@@ -2041,9 +2041,6 @@
     <Product config="zipato/ne-nas-ab02z.xml" id="1083" name="Indoor Siren" type="0003"/>
   </Manufacturer>
   <Manufacturer id="0120" name="Zonoff"></Manufacturer>
-  <Manufacturer id="0000" name="Zooz">
-    <Product id="0004" name="ZST10 700 S2 Z-Wave Plus USB Stick" type="0004" />
-  </Manufacturer>
   <Manufacturer id="027a" name="Zooz">
     <Product id="0002" name="ZST10 S2 Z-Wave Plus USB Stick" type="0401"/>
     <Product config="zooz/zen06.xml" id="000a" name="ZEN06 Smart Plug" type="0101"/>


### PR DESCRIPTION
Remove Zooz 700 series USB controller stick
This uses the bridge firmware which is not supported in 1.6, do not give impression this device will work by included in list