### PR TITLE
Supervision CC support for SwitchMultiLevel

### DIFF
--- a/cpp/src/command_classes/SwitchMultilevel.h
+++ b/cpp/src/command_classes/SwitchMultilevel.h
@@ -79,6 +79,7 @@ namespace OpenZWave
 					{
 						return 4;
 					}
+					virtual void SupervisionSessionSuccess(uint8 _session_id, uint32 const _instance);
 
 				protected:
 					virtual void CreateVars(uint8 const _instance) override;

--- a/cpp/src/value_classes/ValueByte.cpp
+++ b/cpp/src/value_classes/ValueByte.cpp
@@ -120,6 +120,9 @@ namespace OpenZWave
 				ValueByte* tempValue = new ValueByte(*this);
 				tempValue->m_value = _value;
 
+				// Save the new value to be stored when the device confirms the value was set successfully, 
+				m_newValue = _value;
+
 				// Set the value in the device.
 				bool ret = ((Value*) tempValue)->Set();
 

--- a/cpp/src/value_classes/ValueByte.h
+++ b/cpp/src/value_classes/ValueByte.h
@@ -55,6 +55,10 @@ namespace OpenZWave
 
 					bool Set(uint8 const _value);
 					void OnValueRefreshed(uint8 const _value);
+					void ConfirmNewValue()
+					{
+						OnValueRefreshed(m_newValue);
+					};
 					void SetTargetValue(uint8 const _target, uint32 _duration = 0);
 
 					// From Value
@@ -72,6 +76,7 @@ namespace OpenZWave
 					uint8 m_value;				// the current value
 					uint8 m_valueCheck;			// the previous value (used for double-checking spurious value reads)
 					uint8 m_targetValue; 		// the Target Value, if the CC support it
+					uint8 m_newValue;			// a new value to be set on the device (used by Supervision CC)
 			};
 		} // namespace VC
 	} // namespace Internal


### PR DESCRIPTION
Following up on pull request #2584.
Made additions to support the supervision CC for the switch multilevel CC.

This one is especially useful for dimmers and window blinds (if the node supports it). The supervision CC is more reliable than the standard set/get method, which is often faster than the transition and things get messed up.