### PR TITLE
group pointer shouldn't be null to be dereferenced

### DIFF
--- a/cpp/src/command_classes/AssociationCommandConfiguration.cpp
+++ b/cpp/src/command_classes/AssociationCommandConfiguration.cpp
@@ -182,8 +182,7 @@ namespace OpenZWave
 
 					if (Node* node = GetNodeUnsafe())
 					{
-						Group* group = node->GetGroup(groupIdx);
-						if ( NULL == group)
+						if (Group* group = node->GetGroup(groupIdx))
 						{
 							if (firstReports)
 							{


### PR DESCRIPTION
This patch fixes #2613 according to the issue discussions.