### PR TITLE
Fix incorrect null pointer check

### DIFF
--- a/cpp/src/command_classes/AssociationCommandConfiguration.cpp
+++ b/cpp/src/command_classes/AssociationCommandConfiguration.cpp
@@ -183,7 +183,7 @@ namespace OpenZWave
 					if (Node* node = GetNodeUnsafe())
 					{
 						Group* group = node->GetGroup(groupIdx);
-						if ( NULL == group)
+						if ( NULL != group)
 						{
 							if (firstReports)
 							{


### PR DESCRIPTION
After calling `node->GetGroup()`, the current version checks if `group` is null, and if true, proceeds to derefecence the null pointer.

This amends the code to perform as intended, only dereferencing the pointer if `group` is **not** null.