### PR TITLE
Fix the typo of 2GIG manufacturer id (009B) in manufacturer_specific.xml

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ManufacturerSpecificData Revision="172" xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
-  <Manufacturer id="0098" name="2GIG Technologies">
+  <Manufacturer id="009B" name="2GIG Technologies">
     <Product config="2gig/ct50e.xml" id="015e" name="CT50e Thermostat" type="3200"/>
     <Product config="2gig/ct30.xml" id="0158" name="CT30 Thermostat" type="1e10"/>
     <Product config="2gig/ct30.xml" id="015c" name="CT30 Thermostat" type="1e12"/>


### PR DESCRIPTION
Fix the typo of 2GIG manufacturer id (009B) in config/manufacturer_specific.xml. Reference link https://opensmarthouse.org/zwavedatabase/1426